### PR TITLE
feat: redesign communicative practice flow

### DIFF
--- a/src/components/learning/CommunicativePractice.evaluation.test.jsx
+++ b/src/components/learning/CommunicativePractice.evaluation.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateCommunicativeTurn, detectTenseUsage } from './CommunicativePractice.jsx';
+import { ERROR_TAGS } from '../../lib/progress/dataModels.js';
+
+describe('evaluateCommunicativeTurn', () => {
+  it('returns full matches for multiple eligible forms', () => {
+    const step = {
+      resolvedTargetForms: [
+        {
+          resolvedValue: 'trabajo',
+          form: { lemma: 'trabajar', value: 'trabajo', mood: 'indicativo', tense: 'pres', person: '1s' },
+          optional: false,
+          acceptedPhrases: [],
+          synonyms: [],
+        },
+        {
+          resolvedValue: 'como',
+          form: { lemma: 'comer', value: 'como', mood: 'indicativo', tense: 'pres', person: '1s' },
+          optional: false,
+          acceptedPhrases: [],
+          synonyms: [],
+        },
+      ],
+    };
+
+    const evaluation = evaluateCommunicativeTurn({
+      userText: 'Trabajo y como en casa cada día.',
+      step,
+      eligibleForms: step.resolvedTargetForms.map(target => target.form),
+    });
+
+    expect(evaluation.fullMatches).toHaveLength(2);
+    expect(evaluation.partialMatches).toHaveLength(0);
+    expect(evaluation.missingTargets).toHaveLength(0);
+    expect(evaluation.score).toBe(1);
+  });
+
+  it('detects partial matches when the learner switches tense', () => {
+    const form = { lemma: 'trabajar', value: 'trabajo', mood: 'indicativo', tense: 'pres', person: '1s' };
+    const step = {
+      resolvedTargetForms: [
+        {
+          resolvedValue: 'trabajo',
+          form,
+          optional: false,
+          acceptedPhrases: [],
+          synonyms: [],
+        },
+      ],
+    };
+
+    const evaluation = evaluateCommunicativeTurn({
+      userText: 'Cuando era joven trabajaba mucho.',
+      step,
+      eligibleForms: [form],
+    });
+
+    expect(evaluation.fullMatches).toHaveLength(0);
+    expect(evaluation.partialMatches.length).toBeGreaterThan(0);
+    expect(evaluation.aggregateErrorTags).toEqual(
+      expect.arrayContaining([ERROR_TAGS.WRONG_PERSON])
+    );
+    expect(evaluation.score).toBeLessThan(1);
+  });
+
+  it('flags accent differences as partial matches', () => {
+    const form = { lemma: 'estar', value: 'está', mood: 'indicativo', tense: 'pres', person: '3s' };
+    const step = {
+      resolvedTargetForms: [
+        {
+          resolvedValue: 'está',
+          form,
+          optional: false,
+          acceptedPhrases: [],
+          synonyms: [],
+        },
+      ],
+    };
+
+    const evaluation = evaluateCommunicativeTurn({
+      userText: 'Mi amigo esta contento.',
+      step,
+      eligibleForms: [form],
+    });
+
+    expect(evaluation.fullMatches).toHaveLength(1);
+    expect(evaluation.score).toBe(1);
+  });
+});
+
+describe('detectTenseUsage', () => {
+  it('recognises future perfect constructions', () => {
+    const analysis = detectTenseUsage('Para entonces habré terminado el proyecto.', 'futPerf');
+    expect(analysis.hasExpectedTense).toBe(true);
+  });
+
+  it('identifies subjunctive pluscuamperfecto forms', () => {
+    const analysis = detectTenseUsage('Ojalá que hubieran llegado a tiempo.', 'subjPlusc');
+    expect(analysis.hasExpectedTense).toBe(true);
+  });
+
+  it('reports wrong tense usage when user switches tense', () => {
+    const analysis = detectTenseUsage('Ayer trabajé demasiado.', 'pres');
+    expect(analysis.wrongTenses.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/learning/CommunicativePractice.jsx
+++ b/src/components/learning/CommunicativePractice.jsx
@@ -1,422 +1,581 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { formatMoodTense } from '../../lib/utils/verbLabels.js';
 import { updateSchedule } from '../../lib/progress/srs.js';
 import { getCurrentUserId } from '../../lib/progress/userManager.js';
 import { useProgressTracking } from '../../features/drill/useProgressTracking.js';
 import { ERROR_TAGS } from '../../lib/progress/dataModels.js';
-// import { grade } from '../../lib/core/grader.js';
-// import { classifyError } from '../../features/drill/tracking.js';
+import { grade } from '../../lib/core/grader.js';
+import { classifyError } from '../../lib/progress/tracking.js';
+import { communicativeScenarios } from '../../data/communicativeScenarios.js';
+import { normalizeFormValue, normalizeTextForComparison } from '../../lib/utils/normalizeFormValue.js';
 import './CommunicativePractice.css';
 
-// Helper function to detect tense usage patterns in conversational text
-function detectTenseUsage(userText, expectedTense) {
-  const text = userText.toLowerCase();
+const PHASES = {
+  PRE: 'pre',
+  INTERACTION: 'interaction',
+  REFLECTION: 'reflection',
+};
 
-  const tensePatterns = {
-    'pres': /\b\w+[oaeáéí]\b|\b(soy|eres|es|somos|sois|son|estoy|estás|está|estamos|estáis|están|voy|vas|va|vamos|vais|van)\b/g,
-    'pretIndef': /\b\w+[óé]\b|\b\w+(aste|aron|ieron|amos|asteis)\b|\b(fui|fuiste|fue|fuimos|fuisteis|fueron|tuve|tuviste|tuvo|tuvimos|tuvisteis|tuvieron)\b/g,
-    'impf': /\b\w+(aba|ías|ía|íamos|íais|aban)\b|\b(era|eras|éramos|erais|eran|estaba|estabas|estábamos|estabais|estaban)\b/g,
-    'fut': /\b\w+(ré|rás|rá|remos|réis|rán)\b|\b(seré|serás|será|seremos|seréis|serán|estaré|estarás|estará|estaremos|estaréis|estarán)\b/g,
-    'pretPerf': /\b(he|has|ha|hemos|habéis|han)\s+\w+ado\b|\b(he|has|ha|hemos|habéis|han)\s+\w+ido\b/g
-  };
+const tenseRegexBuilders = {
+  pres: () => /\b(?:soy|eres|es|somos|sois|son|estoy|estás|está|estamos|estáis|están|voy|vas|va|vamos|vais|van|\w+(?:o|as|es|amos|emos|imos|an|en))\b/gi,
+  pretIndef: () => /\b(?:fui|fuiste|fue|fuimos|fuisteis|fueron|tuve|tuviste|tuvo|tuvimos|tuvisteis|tuvieron|\w+(?:é|aste|ó|amos|asteis|aron|í|iste|ió|imos|isteis|ieron))\b/gi,
+  impf: () => /\b(?:era|eras|éramos|erais|eran|estaba|estabas|estábamos|estabais|estaban|\w+(?:aba|abas|ábamos|abais|aban|ía|ías|íamos|íais|ían))\b/gi,
+  fut: () => /\b(?:seré|serás|será|seremos|seréis|serán|estaré|estarás|estará|estaremos|estaréis|estarán|\w+(?:ré|rás|rá|remos|réis|rán))\b/gi,
+  pretPerf: () => /\b(?:he|has|ha|hemos|habéis|han)\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+  cond: () => /\b(?:sería|serías|sería|seríamos|seríais|serían|\w+(?:ría|rías|ríamos|ríais|rían))\b/gi,
+  plusc: () => /\b(?:hab(?:i|í)a|hab(?:i|í)as|hab(?:i|í)amos|hab(?:i|í)ais|hab(?:i|í)an)\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+  futPerf: () => /\b(?:habr(?:e|é)|habr(?:as|ás)|habr(?:a|á)|habr(?:emos|émos)|habr(?:eis|éis)|habr(?:an|án))\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+  subjPres: () => /\b(?:sea|seas|seamos|seáis|sean|esté|estés|estemos|estéis|estén|\w+(?:e|es|emos|éis|en|a|as|amos|áis|an))\b/gi,
+  subjImpf: () => /\b(?:fuera|fueras|fuéramos|fuerais|fueran|fuese|fueses|fuésemos|fueseis|fuesen|\w+(?:ra|ras|ramos|rais|ran|se|ses|semos|seis|sen))\b/gi,
+  subjPerf: () => /\b(?:haya|hayas|hayamos|hayáis|hayan)\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+  subjPlusc: () => /\b(?:hubier(?:a|á)|hubier(?:as|ás)|hubier(?:amos|ámos)|hubier(?:ais|áis)|hubier(?:an|án)|hubies(?:e|é)|hubies(?:es|és)|hubies(?:emos|émos)|hubies(?:eis|éis)|hubies(?:en|én))\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+  condPerf: () => /\b(?:habr(?:i|í)a|habr(?:i|í)as|habr(?:i|í)amos|habr(?:i|í)ais|habr(?:i|í)an)\s+(?:\w+(?:ado|ido|cho|to|so))\b/gi,
+};
 
-  const expectedPattern = tensePatterns[expectedTense];
-  const wrongTenseUsed = [];
+const tenseHints = {
+  pres: 'Volvé al presente: "trabajo", "estudio", "salgo".',
+  pretIndef: 'Usá acciones puntuales: "fui", "hice", "comí".',
+  impf: 'Descrí el contexto con imperfecto: "vivía", "jugaba", "tenía".',
+  fut: 'Proyectá en futuro: "estudiaré", "viajaré", "ahorraré".',
+  pretPerf: 'Conectá con el presente usando "he + participio".',
+  cond: 'Habla de hipótesis con "-ría": "viajaría", "cambiaría".',
+  plusc: 'Marcá el pasado anterior con "había + participio".',
+  futPerf: 'Imaginá logros futuros con "habré + participio".',
+  subjPres: 'Usá expresiones como "quiero que" + subjuntivo.',
+  subjImpf: 'Combiná "si" con formas en "-ra" o "-se".',
+  subjPerf: 'Expresá deseos recientes con "haya + participio".',
+  subjPlusc: 'Para lamentar el pasado, usá "hubiera/hubiese + participio".',
+  condPerf: 'Mostrá alternativas con "habría + participio".',
+};
 
-  // Check if user used expected tense
-  const hasExpectedTense = expectedPattern && expectedPattern.test(text);
+const defaultGradeSettings = {
+  accentTolerance: 'warn',
+  strict: false,
+};
 
-  // Check for wrong tenses
-  for (const [tense, pattern] of Object.entries(tensePatterns)) {
-    if (tense !== expectedTense && pattern.test(text)) {
-      wrongTenseUsed.push(tense);
-    }
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function detectTenseUsage(userText, expectedTense) {
+  const normalized = normalizeTextForComparison(userText);
+  if (!normalized) {
+    return { hasExpectedTense: false, wrongTenses: [] };
   }
+
+  const wrongTenses = [];
+  let hasExpectedTense = false;
+
+  Object.entries(tenseRegexBuilders).forEach(([tense, builder]) => {
+    const regex = builder();
+    if (regex.test(normalized)) {
+      if (tense === expectedTense) {
+        hasExpectedTense = true;
+      } else {
+        wrongTenses.push(tense);
+      }
+    }
+  });
 
   return {
     hasExpectedTense,
-    wrongTenseUsed: wrongTenseUsed.length > 0,
-    wrongTenses: wrongTenseUsed
+    wrongTenses,
   };
 }
 
-const chatData = {
-  pres: {
-    title: 'Rutina diaria',
-    initialMessage: '¡Hola! Me gusta conocer la rutina de las personas. ¿Qué haces normalmente durante la semana?',
-    script: [
-      {
-        userKeywords: ['trabajo', 'estudio', 'voy', 'como', 'duermo', 'hago', 'veo', 'hablo', 'vivo', 'tengo', 'soy', 'estoy'],
-        botResponse: '¡Qué interesante! ¿Y en tu tiempo libre? ¿Cómo te gusta relajarte?',
-      },
-      {
-        userKeywords: ['leo', 'escucho', 'veo', 'juego', 'salgo', 'camino', 'cocino', 'escribo', 'practico', 'visito'],
-        botResponse: '¡Me parece genial! Es importante tener actividades que nos gusten. ¡Tienes una rutina muy equilibrada!',
-      },
-    ],
-  },
-  pretIndef: {
-    title: 'Charla sobre el finde',
-    initialMessage: '¡Hola! ¿Qué tal tu fin de semana? ¿Hiciste algo interesante?',
-    script: [
-      {
-        userKeywords: ['fui', 'visité', 'comí', 'vi', 'jugué', 'tuve', 'vimos', 'caminé', 'leí', 'cociné', 'hice', 'salí', 'llegué'], // Verbs in preterite
-        botResponse: '¡Suena genial! ¿Y con quién fuiste?',
-      },
-      {
-        userKeywords: ['amigos', 'familia', 'novia', 'novio', 'solo'],
-        botResponse: '¡Qué bueno! A mí también me gusta salir con gente. La próxima vez podríamos hacer algo.',
-      },
-    ],
-  },
-  subjPres: {
-    title: 'Planeando una fiesta',
-    initialMessage: '¡Hola! Estoy organizando una fiesta el sábado. Para que todo salga bien, necesito que me ayudes.',
-    script: [
-      {
-        userKeywords: ['quieres que', 'necesitas que', 'dime qué'],
-        botResponse: 'Perfecto. Sugiero que tú __traigas__ las bebidas. ¿Te parece?',
-      },
-      {
-        userKeywords: ['traiga', 'compre', 'lleve', 'de acuerdo', 'claro'],
-        botResponse: '¡Genial! Y ojalá que tus amigos __vengan__ también. ¡Será divertido!',
-      },
-    ],
-  },
-  impf: {
-    title: 'Recordando la infancia',
-    initialMessage: '¡Qué nostalgia! ¿Cómo era tu vida cuando eras pequeño? Me encanta escuchar historias de la infancia.',
-    script: [
-      {
-        userKeywords: ['vivía', 'tenía', 'era', 'estaba', 'jugaba', 'iba', 'hacía', 'estudiaba'],
-        botResponse: '¡Qué interesante! ¿Y qué era lo que más te gustaba hacer en esa época?',
-      },
-      {
-        userKeywords: ['gustaba', 'encantaba', 'divertía', 'jugaba', 'veía', 'leía'],
-        botResponse: '¡Qué bonitos recuerdos! La infancia siempre deja memorias especiales.',
-      },
-    ],
-  },
-  fut: {
-    title: 'Hablando del futuro',
-    initialMessage: '¡Hola! Me gusta planificar el futuro. ¿Qué planes tienes para el próximo año?',
-    script: [
-      {
-        userKeywords: ['viajaré', 'estudiaré', 'trabajaré', 'haré', 'seré', 'tendré', 'iré'],
-        botResponse: '¡Suena genial! ¿Y cómo crees que lograrás esos objetivos?',
-      },
-      {
-        userKeywords: ['estudiaré', 'prepararé', 'practicaré', 'esforzaré', 'dedicaré'],
-        botResponse: 'Me parece un plan excelente. ¡Seguro que lo conseguirás!',
-      },
-    ],
-  },
-  pretPerf: {
-    title: 'Lo que has hecho hoy',
-    initialMessage: '¡Hola! ¿Qué tal ha ido tu día? ¿Has hecho algo especial hoy?',
-    script: [
-      {
-        userKeywords: ['he hecho', 'he trabajado', 'he estudiado', 'he quedado', 'he ido', 'he visto'],
-        botResponse: '¡Qué productivo! ¿Y has tenido tiempo para relajarte un poco?',
-      },
-      {
-        userKeywords: ['he descansado', 'he visto', 'he leído', 'he escuchado', 'he salido'],
-        botResponse: 'Perfecto, es importante encontrar el equilibrio entre trabajo y descanso.',
-      },
-    ],
-  },
-  cond: {
-    title: 'Situaciones hipotéticas',
-    initialMessage: 'Me encantan las preguntas hipotéticas. Si fueras millonario, ¿qué harías?',
-    script: [
-      {
-        userKeywords: ['compraría', 'viajaría', 'haría', 'ayudaría', 'donaría', 'invertiría'],
-        botResponse: '¡Qué interesante! ¿Y si pudieras vivir en cualquier época de la historia?',
-      },
-      {
-        userKeywords: ['viviría', 'sería', 'estaría', 'conocería', 'aprendería', 'experimentaría'],
-        botResponse: '¡Qué respuesta tan reflexiva! Me gusta cómo piensas.',
-      },
-    ],
-  },
-  plusc: {
-    title: 'Hablando del pasado',
-    initialMessage: '¡Hola! Me encanta escuchar historias del pasado. ¿Te acuerdas de alguna vez que llegaste tarde y ya había pasado algo importante?',
-    script: [
-      {
-        userKeywords: ['había terminado', 'había empezado', 'habían ido', 'había salido', 'había llegado', 'había comido', 'había visto'],
-        botResponse: '¡Qué situación! Seguro que fue frustrante. ¿Y qué hiciste después?',
-      },
-      {
-        userKeywords: ['me quedé', 'volví', 'esperé', 'pregunté', 'llamé', 'buscá'],
-        botResponse: '¡Qué bien que encontraras una solución! A veces las cosas pasan por algo.',
-      },
-    ],
-  },
-  futPerf: {
-    title: 'Planes a largo plazo',
-    initialMessage: '¡Hola! Me gusta hablar del futuro. Para el año que viene, ¿qué cosas habrás logrado?',
-    script: [
-      {
-        userKeywords: ['habré terminado', 'habré aprendido', 'habré viajado', 'habré conseguido', 'me habré mudado', 'habré ahorrado'],
-        botResponse: '¡Qué planes tan ambiciosos! ¿Y para dentro de 5 años, qué habrás logrado?',
-      },
-      {
-        userKeywords: ['habré construido', 'habré creado', 'habré fundado', 'habré escrito', 'me habré casado', 'habré tenido'],
-        botResponse: '¡Me encanta tu visión del futuro! Estoy seguro de que lo lograrás.',
-      },
-    ],
-  },
-  subjImpf: {
-    title: 'Mundo de fantasía',
-    initialMessage: '¡Hola! Me gustan las historias de fantasía. Si fueras un personaje mágico, ¿qué podrías hacer?',
-    script: [
-      {
-        userKeywords: ['volara', 'fuera', 'tuviera', 'pudiera', 'supiera', 'hiciera', 'dijera', 'viviera'],
-        botResponse: '¡Qué fantástico! Si yo fuera mágico, me gustaría poder teletransportarme. ¿Y qué harías para ayudar a los demás?',
-      },
-      {
-        userKeywords: ['ayudara', 'curara', 'salvara', 'protegiera', 'diera', 'compartiera', 'enseñara'],
-        botResponse: '¡Qué noble! El mundo sería mejor si todos pensáramos así.',
-      },
-    ],
-  },
-  condPerf: {
-    title: 'Reflexiones sobre el pasado',
-    initialMessage: '¡Hola! A veces pienso en el pasado. Si hubieras sabido lo que sabes ahora, ¿qué habrías hecho diferente?',
-    script: [
-      {
-        userKeywords: ['habría estudiado', 'habría viajado', 'habría ahorrado', 'me habría mudado', 'habría aprendido', 'habría dicho'],
-        botResponse: 'Es interesante pensar en esas posibilidades. ¿Crees que habría cambiado mucho tu vida?',
-      },
-      {
-        userKeywords: ['habría sido', 'habría tenido', 'habría estado', 'habrían sido', 'habría conocido', 'habría hecho'],
-        botResponse: 'Al final, todas nuestras experiencias nos han traído hasta donde estamos hoy.',
-      },
-    ],
-  },
-  subjPerf: {
-    title: 'Esperanzas y dudas',
-    initialMessage: '¡Hola! Estoy un poco preocupado. Espero que mi amigo haya llegado bien a su destino. ¿Tú también te preocupas por tus seres queridos cuando viajan?',
-    script: [
-      {
-        userKeywords: ['haya llegado', 'haya encontrado', 'se haya adaptado', 'haya comido', 'haya descansado', 'haya llamado'],
-        botResponse: 'Sí, es normal preocuparse. Espero que todo haya salido bien. ¿Sueles enviar mensajes para saber cómo están?',
-      },
-      {
-        userKeywords: ['haya respondido', 'haya visto', 'haya contestado', 'se haya comunicado', 'haya escrito'],
-        botResponse: 'Qué bueno que te mantengas en contacto. La comunicación es muy importante.',
-      },
-    ],
-  },
-  subjPlusc: {
-    title: 'Lamentos del pasado',
-    initialMessage: '¡Hola! Ayer me arrepentí de algo. Ojalá que hubiera estudiado más para el examen. ¿Tú también tienes cosas de las que te arrepientes?',
-    script: [
-      {
-        userKeywords: ['hubiera estudiado', 'hubiera trabajado', 'hubiera ahorrado', 'hubiera dicho', 'hubiera hecho', 'me hubiera esforzado'],
-        botResponse: 'Todos tenemos esos momentos. Lo importante es aprender de ellos. ¿Qué harías diferente la próxima vez?',
-      },
-      {
-        userKeywords: ['estudiaría', 'trabajaría', 'ahorraría', 'diría', 'haría', 'me esforzaría'],
-        botResponse: 'Excelente actitud. Los errores nos enseñan y nos hacen crecer.',
-      },
-    ],
-  },
-};
+function buildCandidatePhrases(tokens) {
+  const phrases = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    const single = tokens[i];
+    if (single) {
+      phrases.push(single);
+    }
+    if (i < tokens.length - 1) {
+      phrases.push(`${tokens[i]} ${tokens[i + 1]}`);
+    }
+    if (i < tokens.length - 2) {
+      phrases.push(`${tokens[i]} ${tokens[i + 1]} ${tokens[i + 2]}`);
+    }
+  }
+  return phrases;
+}
 
-function CommunicativePractice({ tense, eligibleForms, onBack, onFinish }) {
-  const [messages, setMessages] = useState([]);
-  const [inputValue, setInputValue] = useState('');
-  const [chatEnded, setChatEnded] = useState(false);
-  const [scriptIndex, setScriptIndex] = useState(0);
+function selectFormForTarget(target, availableForms) {
+  if (!target) return null;
+  const { match = {} } = target;
 
-  const exercise = tense ? chatData[tense.tense] : null;
-  
-  // Create a dummy currentItem for progress tracking
-  const currentItem = {
-    id: `communicative-practice-${tense?.tense}`,
-    lemma: 'communicative-practice',
-    tense: tense?.tense,
-    mood: tense?.mood
-  };
-  
-  const { handleResult } = useProgressTracking(currentItem, (result) => {
-    console.log('Communicative practice progress tracking result:', result);
+  const matchIndex = availableForms.findIndex(form => {
+    if (!form) return false;
+    if (match.person && form.person !== match.person) return false;
+    if (match.lemmas) {
+      const lemmas = Array.isArray(match.lemmas) ? match.lemmas : [match.lemmas];
+      if (!lemmas.includes(form.lemma)) return false;
+    }
+    if (match.tense && form.tense !== match.tense) return false;
+    if (match.mood && form.mood !== match.mood) return false;
+    return true;
   });
 
-  useEffect(() => {
-    if (exercise) {
-      setMessages([{ author: 'bot', text: exercise.initialMessage }]);
-      setScriptIndex(0);
-      setChatEnded(false);
-      setInputValue(''); // Reset input when exercise changes
-    } else {
-      setMessages([]);
-      setInputValue('');
-      setScriptIndex(0);
-      setChatEnded(false);
+  let selected = null;
+  if (matchIndex >= 0) {
+    selected = availableForms[matchIndex];
+  } else if (!match || Object.keys(match).length === 0) {
+    selected = availableForms[0];
+  }
+
+  if (selected && target.allowReuse !== true) {
+    const removalIndex = availableForms.findIndex(form => form === selected);
+    if (removalIndex >= 0) {
+      availableForms.splice(removalIndex, 1);
     }
-  }, [exercise]);
+  }
 
-  const handleSendMessage = async () => {
-    if (!inputValue.trim() || !exercise) return;
+  return selected || null;
+}
 
-    const currentScriptNode = exercise.script[scriptIndex];
-    const userMessage = { author: 'user', text: inputValue };
-    const newMessages = [...messages, userMessage];
+function resolveScenario(template, eligibleForms = []) {
+  if (!template) return null;
+  const available = [...eligibleForms];
 
-    const userText = inputValue.toLowerCase();
-
-    let keywordFound = null;
-    const keywordMatched = currentScriptNode.userKeywords.some(kw => {
-        // Normalize both texts to handle accents properly
-        const normalizeText = (text) => text.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
-        const normalizedUser = normalizeText(userText);
-        const normalizedKeyword = normalizeText(kw);
-        
-        const regex = new RegExp(`\\b${normalizedKeyword.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}\\b`, 'i');
-        if (regex.test(normalizedUser)) {
-            keywordFound = kw;
-            return true;
-        }
-        return false;
+  const resolvedSteps = (template.conversationSteps || []).map(step => {
+    const resolvedTargets = (step.targetForms || []).map(target => {
+      const selectedForm = selectFormForTarget(target, available);
+      const expectedValue = selectedForm?.value || target.fallbackForm || null;
+      return {
+        ...target,
+        form: selectedForm || null,
+        resolvedValue: expectedValue,
+        acceptedPhrases: target.acceptedPhrases || [],
+        synonyms: target.synonyms || [],
+      };
     });
 
-    if (keywordMatched) {
-      // Correct keyword found, move to next bot response
-      const botMessage = { author: 'bot', text: currentScriptNode.botResponse };
-      newMessages.push(botMessage);
+    return {
+      ...step,
+      resolvedTargetForms: resolvedTargets,
+    };
+  });
 
-      // Use official progress tracking system
-      await handleResult({
-        correct: true,
-        userAnswer: inputValue,
-        correctAnswer: keywordFound || 'correct usage',
-        hintsUsed: 0,
-        errorTags: [],
-        latencyMs: 0, // Not applicable for chat-based exercise
-        isIrregular: false,
-        itemId: currentItem.id
-      });
+  return {
+    ...template,
+    resolvedSteps,
+    bridgeForms: eligibleForms.slice(0, 6).map(form => form.value),
+  };
+}
 
-      // Keep SRS scheduling for specific verb forms
-      if (keywordFound) {
-        const formObject = eligibleForms?.find(f => f.value === keywordFound);
-        if (formObject) {
-          try {
-            const userId = getCurrentUserId();
-            if (userId) {
-              await updateSchedule(userId, formObject, true, 0);
-              console.log(`Analytics: Updated schedule for communicative practice: ${formObject.lemma} - ${keywordFound}`);
-            }
-          } catch (error) {
-            console.error("Failed to update SRS schedule:", error);
-          }
-        }
+function collectAcceptableStrings(target) {
+  const values = new Set();
+  if (target.form?.value) values.add(target.form.value);
+  if (Array.isArray(target.form?.alt)) {
+    target.form.alt.forEach(val => values.add(val));
+  }
+  if (target.resolvedValue) values.add(target.resolvedValue);
+  if (target.acceptedPhrases) {
+    target.acceptedPhrases.forEach(val => values.add(val));
+  }
+  if (target.synonyms) {
+    target.synonyms.forEach(val => values.add(val));
+  }
+  return [...values];
+}
+
+export function evaluateCommunicativeTurn({
+  userText,
+  step,
+  eligibleForms = [],
+  gradeSettings = defaultGradeSettings,
+}) {
+  const safeText = userText || '';
+  const normalizedFull = normalizeTextForComparison(safeText);
+  const tokenized = safeText
+    .replace(/[.,!?;:]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+  const normalizedTokens = tokenized.map(token => normalizeFormValue(token));
+  const candidatePhrases = buildCandidatePhrases(tokenized);
+
+  const expectedForms = [];
+  const fullMatches = [];
+  const partialMatches = [];
+  const missingTargets = [];
+  const aggregateErrorTags = new Set();
+
+  const gradeConfig = { ...defaultGradeSettings, ...gradeSettings };
+
+  (step?.resolvedTargetForms || []).forEach(target => {
+    const acceptableStrings = collectAcceptableStrings(target);
+    if (acceptableStrings.length > 0) {
+      expectedForms.push(acceptableStrings[0]);
+    }
+
+    let matched = false;
+    const normalizedAcceptables = acceptableStrings.map(value => ({
+      original: value,
+      normalized: normalizeTextForComparison(value),
+    }));
+
+    // Check direct inclusion in the normalized text
+    for (const acceptable of normalizedAcceptables) {
+      if (!acceptable.normalized) continue;
+      const regex = new RegExp(`\\b${escapeRegExp(acceptable.normalized)}\\b`, 'i');
+      if (regex.test(normalizedFull)) {
+        fullMatches.push({
+          target,
+          form: target.form || null,
+          expected: acceptable.original,
+        });
+        matched = true;
+        break;
       }
+    }
 
-      if (scriptIndex >= exercise.script.length - 1) {
-        setChatEnded(true);
-      } else {
-        setScriptIndex(prev => prev + 1);
+    if (matched) {
+      return;
+    }
+
+    const expectedForm = target.form || null;
+
+    // Try candidate phrases (bigrams/trigrams) using grader
+    for (const phrase of candidatePhrases) {
+      if (!expectedForm || typeof phrase !== 'string' || !phrase.trim()) continue;
+      const gradeResult = grade(phrase.trim(), expectedForm, gradeConfig);
+      if (gradeResult.correct) {
+        fullMatches.push({ target, form: expectedForm, expected: expectedForm.value });
+        matched = true;
+        break;
       }
-    } else {
-      // Enhanced error analysis for communicative practice
-      const errorTags = [ERROR_TAGS.INCORRECT_TENSE_OR_VERB];
-      const userText = inputValue.toLowerCase();
-
-      // Analyze what type of error the user made
-      const hasVerbs = /\b\w+(o|as|a|amos|áis|an|é|aste|ó|amos|asteis|aron|ía|ías|íamos|íais|ían|ré|rás|rá|remos|réis|rán)\b/g.test(userText);
-
-      if (!hasVerbs) {
-        errorTags.push(ERROR_TAGS.NO_VERBS_DETECTED);
-      } else {
-        // Check if user used verbs but in wrong tense
-        const expectedTense = tense?.tense;
-        if (expectedTense) {
-          const tenseAnalysis = detectTenseUsage(userText, expectedTense);
-          if (tenseAnalysis.wrongTenseUsed) {
-            errorTags.push(ERROR_TAGS.WRONG_TENSE_USED);
-            errorTags.push(`expected_${expectedTense}`);
-          }
-        }
+      if (gradeResult.isAccentError) {
+        partialMatches.push({
+          target,
+          form: expectedForm,
+          token: phrase.trim(),
+          errors: [ERROR_TAGS.ACCENT],
+        });
+        aggregateErrorTags.add(ERROR_TAGS.ACCENT);
+        matched = true;
+        break;
       }
+    }
 
-      // Check if user provided a substantial response
-      if (userText.trim().length < 5) {
-        errorTags.push(ERROR_TAGS.TOO_SHORT_RESPONSE);
-      }
+    if (matched) {
+      return;
+    }
 
-      // Provide contextual hint
-      const hintText = tense.tense === 'pres'
-        ? `Cuéntame usando verbos en presente. Por ejemplo: "Yo trabajo en..." o "Normalmente voy a..."`
-        : `Intenta usar un verbo en ${formatMoodTense(tense.mood, tense.tense)} para contarme qué pasó.`;
-      const hint = { author: 'bot', text: hintText };
-      newMessages.push(hint);
+    if (expectedForm) {
+      // Explore word-level attempts for partial credit
+      for (let index = 0; index < normalizedTokens.length; index += 1) {
+        const token = tokenized[index];
+        const normalizedToken = normalizedTokens[index];
+        if (!token || !normalizedToken) continue;
 
-      // Track incorrect attempt with enhanced error classification
-      await handleResult({
-        correct: false,
-        userAnswer: inputValue,
-        correctAnswer: currentScriptNode.userKeywords.join(' o '),
-        hintsUsed: 1, // Hint was given
-        errorTags,
-        latencyMs: 0,
-        isIrregular: false,
-        itemId: currentItem.id,
-        conversationContext: {
-          scriptIndex,
-          expectedKeywords: currentScriptNode.userKeywords,
-          botResponse: currentScriptNode.botResponse
-        }
-      });
-
-      // Try to update SRS for expected verb forms if we can match them
-      if (eligibleForms && tense?.tense) {
-        try {
-          const userId = getCurrentUserId();
-          if (userId) {
-            // Mark expected verbs as needing more practice
-            const relevantForms = eligibleForms.filter(f =>
-              f.tense === tense.tense &&
-              currentScriptNode.userKeywords.some(keyword =>
-                f.value.includes(keyword) || keyword.includes(f.value)
-              )
-            );
-
-            for (const form of relevantForms.slice(0, 3)) { // Limit to avoid spam
-              await updateSchedule(userId, form, false, 1); // Mark as incorrect with hint
-              console.log(`Analytics: Marked verb form for more practice: ${form.lemma} - ${form.value}`);
-            }
-          }
-        } catch (error) {
-          console.error("Failed to update SRS for communicative practice:", error);
+        const classification = classifyError(token, expectedForm.value, expectedForm) || [];
+        if (classification.includes(ERROR_TAGS.OTHER_VALID_FORM) || classification.includes(ERROR_TAGS.WRONG_TENSE) || classification.includes(ERROR_TAGS.WRONG_PERSON) || classification.includes(ERROR_TAGS.ACCENT)) {
+          partialMatches.push({
+            target,
+            form: expectedForm,
+            token,
+            errors: classification,
+          });
+          classification.forEach(tag => aggregateErrorTags.add(tag));
+          matched = true;
+          break;
         }
       }
     }
 
-    setMessages(newMessages);
+    if (!matched && !target.optional) {
+      missingTargets.push(target);
+      aggregateErrorTags.add(ERROR_TAGS.MISSING_VERBS);
+    }
+  });
+
+  const requiredTargets = (step?.resolvedTargetForms || []).filter(target => !target.optional).length;
+  const denominator = requiredTargets > 0 ? requiredTargets : (step?.resolvedTargetForms?.length || 1);
+  const matchedCount = fullMatches.filter(match => !match.target?.optional).length;
+  const partialCount = partialMatches.filter(match => !match.target?.optional).length;
+  const score = Math.max(0, Math.min(1, (matchedCount + partialCount * 0.5) / denominator));
+
+  return {
+    expectedForms,
+    fullMatches,
+    partialMatches,
+    missingTargets,
+    aggregateErrorTags: [...aggregateErrorTags],
+    score,
+  };
+}
+
+function summarizeMissingTargets(targets) {
+  if (!targets || targets.length === 0) return '';
+  return targets
+    .map(target => target.resolvedValue || target.fallbackForm)
+    .filter(Boolean)
+    .map(value => `«${value}»`)
+    .join(', ');
+}
+
+function summarizePartialMatches(partials) {
+  if (!partials || partials.length === 0) return '';
+  return partials
+    .map(match => {
+      const base = match.form?.value || match.target?.resolvedValue || '';
+      if (!base) return null;
+      if (!match.errors || match.errors.length === 0) return `Intentaste con «${base}», revisá la forma.`;
+      return `«${base}» necesita ajuste (${match.errors.join(', ')}).`;
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
+function CommunicativePractice({ tense, eligibleForms = [], onBack, onFinish }) {
+  const [phase, setPhase] = useState(PHASES.PRE);
+  const [messages, setMessages] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [reflectionNotes, setReflectionNotes] = useState('');
+
+  const scenarioTemplate = tense?.tense ? communicativeScenarios[tense.tense] : null;
+  const scenario = useMemo(
+    () => resolveScenario(scenarioTemplate, eligibleForms || []),
+    [scenarioTemplate, eligibleForms]
+  );
+
+  useEffect(() => {
+    setPhase(PHASES.PRE);
+    setMessages([]);
     setInputValue('');
-  };
+    setCurrentStepIndex(0);
+    setReflectionNotes('');
+  }, [scenario]);
 
-  const handleKeyDown = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      if (!chatEnded) {
-        handleSendMessage();
+  const currentStep = phase === PHASES.INTERACTION ? scenario?.resolvedSteps?.[currentStepIndex] : null;
+  const nextStep = phase === PHASES.INTERACTION ? scenario?.resolvedSteps?.[currentStepIndex + 1] : null;
+
+  const bridgeForms = useMemo(() => {
+    if (scenario?.bridgeForms?.length) return scenario.bridgeForms;
+    return (eligibleForms || [])
+      .filter(form => !tense?.tense || form.tense === tense.tense)
+      .slice(0, 6)
+      .map(form => form.value);
+  }, [scenario, eligibleForms, tense?.tense]);
+
+  const currentItem = useMemo(
+    () => ({
+      id: `communicative-practice-${tense?.tense || 'unknown'}`,
+      lemma: 'communicative-practice',
+      tense: tense?.tense,
+      mood: tense?.mood,
+    }),
+    [tense]
+  );
+
+  const { handleResult } = useProgressTracking(currentItem);
+
+  const startInteraction = useCallback(() => {
+    setPhase(PHASES.INTERACTION);
+    if (scenario?.resolvedSteps?.length) {
+      setMessages([
+        {
+          author: 'bot',
+          text: scenario.resolvedSteps[0].prompt,
+          stepId: scenario.resolvedSteps[0].id,
+        },
+      ]);
+      setCurrentStepIndex(0);
+    }
+  }, [scenario]);
+
+  useEffect(() => {
+    if (phase === PHASES.INTERACTION && scenario?.resolvedSteps?.length && messages.length === 0) {
+      setMessages([
+        {
+          author: 'bot',
+          text: scenario.resolvedSteps[0].prompt,
+          stepId: scenario.resolvedSteps[0].id,
+        },
+      ]);
+    }
+  }, [phase, scenario, messages.length]);
+
+  const updateSchedulesForEvaluation = useCallback(async (stepId, evaluation, isSuccess) => {
+    if (!Array.isArray(eligibleForms) || eligibleForms.length === 0) {
+      return;
+    }
+    try {
+      const userId = getCurrentUserId();
+      if (!userId) return;
+
+      const processed = new Set();
+
+      for (const match of evaluation.fullMatches) {
+        const form = match.form;
+        if (!form) continue;
+        const key = `${form.lemma}|${form.person}|${form.tense}`;
+        if (processed.has(key)) continue;
+        processed.add(key);
+        await updateSchedule(userId, form, true, 0, {
+          source: 'communicative-practice',
+          stepId,
+          evaluation: 'full',
+        });
+      }
+
+      for (const partial of evaluation.partialMatches) {
+        const form = partial.form;
+        if (!form) continue;
+        const key = `${form.lemma}|${form.person}|${form.tense}`;
+        if (processed.has(key)) continue;
+        processed.add(key);
+        await updateSchedule(userId, form, false, 0, {
+          source: 'communicative-practice',
+          stepId,
+          evaluation: 'partial',
+          errorTags: partial.errors,
+        });
+      }
+
+      for (const missing of evaluation.missingTargets) {
+        const form = missing.form;
+        if (!form) continue;
+        const key = `${form.lemma}|${form.person}|${form.tense}`;
+        if (processed.has(key)) continue;
+        processed.add(key);
+        await updateSchedule(userId, form, false, 1, {
+          source: 'communicative-practice',
+          stepId,
+          evaluation: 'missed',
+        });
+      }
+    } catch (error) {
+      console.error('Failed to update SRS schedule for communicative practice:', error);
+    }
+  }, [eligibleForms]);
+
+  const handleSendMessage = useCallback(async () => {
+    if (phase !== PHASES.INTERACTION || !currentStep || !inputValue.trim()) {
+      return;
+    }
+
+    const userMessage = { author: 'user', text: inputValue.trim(), stepId: currentStep.id };
+    const nextMessages = [...messages, userMessage];
+
+    const evaluation = evaluateCommunicativeTurn({
+      userText: inputValue,
+      step: currentStep,
+      eligibleForms,
+      gradeSettings: defaultGradeSettings,
+    });
+
+    const tenseAnalysis = tense?.tense ? detectTenseUsage(inputValue, tense.tense) : { hasExpectedTense: true, wrongTenses: [] };
+    if (!tenseAnalysis.hasExpectedTense && tenseAnalysis.wrongTenses.length > 0) {
+      evaluation.aggregateErrorTags.push(ERROR_TAGS.WRONG_TENSE_USED);
+    }
+
+    const isSuccessfulTurn = evaluation.missingTargets.length === 0 && evaluation.partialMatches.length === 0;
+
+    const summaryParts = [];
+    if (evaluation.missingTargets.length > 0) {
+      summaryParts.push(`Nos faltó usar: ${summarizeMissingTargets(evaluation.missingTargets)}.`);
+    }
+    if (evaluation.partialMatches.length > 0) {
+      summaryParts.push(summarizePartialMatches(evaluation.partialMatches));
+    }
+    if (!tenseAnalysis.hasExpectedTense && tenseAnalysis.wrongTenses.length > 0) {
+      const hint = tenseHints[tense.tense] || 'Revisá el tiempo verbal objetivo.';
+      summaryParts.push(hint);
+    }
+
+    const feedbackText = isSuccessfulTurn
+      ? currentStep.successResponse || '¡Excelente! Cumpliste el objetivo de esta parte.'
+      : [currentStep.hint || 'Probemos otra vez usando los verbos objetivo.', ...summaryParts.filter(Boolean)].join(' ');
+
+    const botResponse = { author: 'bot', text: feedbackText, stepId: currentStep.id };
+
+    const updatedMessages = [...nextMessages, botResponse];
+
+    if (isSuccessfulTurn) {
+      if (nextStep) {
+        updatedMessages.push({
+          author: 'bot',
+          text: nextStep.prompt,
+          stepId: nextStep.id,
+        });
       } else {
-        onFinish();
+        updatedMessages.push({
+          author: 'bot',
+          text: 'Excelente trabajo. Pasemos a la reflexión final.',
+          stepId: 'reflection-intro',
+        });
       }
     }
-  };
 
-  if (!exercise) {
+    setMessages(updatedMessages);
+
+    await handleResult({
+      correct: isSuccessfulTurn,
+      userAnswer: inputValue,
+      correctAnswer: evaluation.expectedForms.filter(Boolean).join(', '),
+      hintsUsed: isSuccessfulTurn ? 0 : 1,
+      errorTags: evaluation.aggregateErrorTags,
+      latencyMs: 0,
+      isIrregular: false,
+      itemId: currentItem.id,
+      partialCredit: evaluation.score,
+      conversationContext: {
+        phase,
+        stepId: currentStep.id,
+        goal: currentStep.goal,
+        expectedForms: evaluation.expectedForms,
+        evaluation,
+        tenseAnalysis,
+      },
+    });
+
+    await updateSchedulesForEvaluation(currentStep.id, evaluation, isSuccessfulTurn);
+
+    if (isSuccessfulTurn) {
+      if (nextStep) {
+        setCurrentStepIndex(currentStepIndex + 1);
+      } else {
+        setPhase(PHASES.REFLECTION);
+      }
+    }
+
+    setInputValue('');
+  }, [
+    phase,
+    currentStep,
+    inputValue,
+    messages,
+    eligibleForms,
+    tense,
+    currentItem.id,
+    handleResult,
+    updateSchedulesForEvaluation,
+    nextStep,
+    currentStepIndex,
+  ]);
+
+  const handleKeyDown = useCallback(
+    event => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        if (phase === PHASES.INTERACTION) {
+          handleSendMessage();
+        } else if (phase === PHASES.REFLECTION) {
+          onFinish();
+        }
+      }
+    },
+    [handleSendMessage, onFinish, phase]
+  );
+
+  if (!scenario) {
     return (
-        <div className="center-column">
-            <p>Ejercicio no disponible para este tiempo verbal aún.</p>
-            <button onClick={onBack} className="btn-secondary">Volver</button>
-        </div>
+      <div className="center-column">
+        <p>Estamos preparando actividades comunicativas para este tiempo verbal.</p>
+        <button onClick={onBack} className="btn-secondary">Volver</button>
+      </div>
     );
   }
 
@@ -424,37 +583,136 @@ function CommunicativePractice({ tense, eligibleForms, onBack, onFinish }) {
     <div className="App learn-flow">
       <div className="center-column">
         <div className="drill-header-learning">
-            <button onClick={onBack} className="back-btn-drill">
-                <img src="/back.png" alt="Volver" className="back-icon" />
-            </button>
-            <h2>Práctica Comunicativa: {formatMoodTense(tense.mood, tense.tense)}</h2>
+          <button onClick={onBack} className="back-btn-drill">
+            <img src="/back.png" alt="Volver" className="back-icon" />
+          </button>
+          <h2>Práctica Comunicativa: {formatMoodTense(tense?.mood, tense?.tense)}</h2>
         </div>
 
-        <div className="chat-container">
-            <div className="message-list">
-                {messages.map((msg, index) => (
-                    <div key={index} className={`message ${msg.author}`}>
-                        {msg.text}
-                    </div>
+        {phase === PHASES.PRE && (
+          <div className="pre-task-panel">
+            <h3>{scenario.title}</h3>
+            <p className="pre-task-context">{scenario.preTask?.context}</p>
+            {scenario.preTask?.objectives?.length > 0 && (
+              <div className="pre-task-section">
+                <h4>Objetivos</h4>
+                <ul>
+                  {scenario.preTask.objectives.map((objective, index) => (
+                    <li key={index}>{objective}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {scenario.preTask?.activationQuestions?.length > 0 && (
+              <div className="pre-task-section">
+                <h4>Activa tu conocimiento</h4>
+                <ul>
+                  {scenario.preTask.activationQuestions.map((question, index) => (
+                    <li key={index}>{question}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {bridgeForms.length > 0 && (
+              <div className="pre-task-section">
+                <h4>Verbos puente</h4>
+                <div className="bridge-forms">
+                  {bridgeForms.map(form => (
+                    <span key={form} className="bridge-form-chip">{form}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+            <button onClick={startInteraction} className="btn-primary">Comenzar conversación</button>
+          </div>
+        )}
+
+        {phase === PHASES.INTERACTION && (
+          <div className="communicative-layout">
+            <div className="chat-container">
+              <div className="message-list">
+                {messages.map((message, index) => (
+                  <div key={index} className={`message ${message.author}`}>
+                    {message.text}
+                  </div>
                 ))}
-            </div>
-            <div className="input-area">
-                <input 
-                    type="text"
-                    placeholder="Escribe tu respuesta..."
-                    value={inputValue}
-                    onChange={e => setInputValue(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    disabled={chatEnded}
-                    autoFocus
+              </div>
+              <div className="input-area">
+                <textarea
+                  placeholder="Escribe tu respuesta..."
+                  value={inputValue}
+                  onChange={event => setInputValue(event.target.value)}
+                  onKeyDown={handleKeyDown}
                 />
-                {chatEnded ? (
-                    <button onClick={onFinish} className="btn-primary">Finalizar</button>
-                ) : (
-                    <button onClick={handleSendMessage}>Enviar</button>
-                )}
+                <button onClick={handleSendMessage} className="btn-primary">Enviar</button>
+              </div>
             </div>
-        </div>
+            {currentStep && (
+              <aside className="interaction-support">
+                <h4>Objetivo del turno</h4>
+                <p>{currentStep.goal}</p>
+                {currentStep.supportPhrases?.length > 0 && (
+                  <div className="support-phrases">
+                    <h5>Frases de apoyo</h5>
+                    <ul>
+                      {currentStep.supportPhrases.map((phrase, index) => (
+                        <li key={index}>{phrase}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {currentStep.resolvedTargetForms?.length > 0 && (
+                  <div className="support-targets">
+                    <h5>Formas objetivo</h5>
+                    <ul>
+                      {currentStep.resolvedTargetForms.map((target, index) => (
+                        <li key={index}>{target.resolvedValue || target.fallbackForm}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </aside>
+            )}
+          </div>
+        )}
+
+        {phase === PHASES.REFLECTION && (
+          <div className="reflection-panel">
+            <h3>Cierre reflexivo</h3>
+            <p>Antes de finalizar, tomá un momento para consolidar lo que usaste.</p>
+            {scenario.postTask?.prompts?.length > 0 && (
+              <div className="reflection-section">
+                <h4>Preguntas para reflexionar</h4>
+                <ul>
+                  {scenario.postTask.prompts.map((prompt, index) => (
+                    <li key={index}>{prompt}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {scenario.postTask?.successCriteria?.length > 0 && (
+              <div className="reflection-section">
+                <h4>Rúbrica de éxito</h4>
+                <ul>
+                  {scenario.postTask.successCriteria.map((criterion, index) => (
+                    <li key={index}>{criterion}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <textarea
+              className="reflection-notes"
+              placeholder="Anotá ideas o frases que quieras recordar (opcional)"
+              value={reflectionNotes}
+              onChange={event => setReflectionNotes(event.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            {scenario.postTask?.consolidationTip && (
+              <p className="consolidation-tip">💡 {scenario.postTask.consolidationTip}</p>
+            )}
+            <button onClick={onFinish} className="btn-primary">Finalizar práctica</button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/data/communicativeScenarios.js
+++ b/src/data/communicativeScenarios.js
@@ -1,0 +1,920 @@
+export const communicativeScenarios = {
+  pres: {
+    title: 'Rutina conectada',
+    preTask: {
+      context:
+        'Conecta tu rutina diaria con los verbos que practicamos. Pensá en actividades reales y cómo se relacionan con tu contexto.',
+      objectives: [
+        'Activar vocabulario de hábitos en presente',
+        'Integrar al menos dos verbos del listado practicado',
+        'Preparar una respuesta fluida que conecte acciones y personas'
+      ],
+      activationQuestions: [
+        '¿Qué acción repetís casi todos los días?',
+        '¿Con quién compartís parte de tu rutina?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'habits',
+        prompt: 'Contame qué hacés en un día típico de semana.',
+        goal: 'Describir la actividad principal usando verbos en 1ª persona del presente.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            focus: 'actividad central',
+            fallbackForm: 'trabajo',
+            acceptedPhrases: ['trabajo', 'laburo'],
+          },
+          {
+            match: { person: '1s' },
+            focus: 'actividad secundaria',
+            fallbackForm: 'estudio',
+            optional: true,
+          },
+        ],
+        successResponse: '¡Genial! Ahora contame cómo te relajás o desconectás.',
+        hint: 'Usá al menos dos verbos en presente (trabajo, estudio, salgo, como...).',
+        supportPhrases: ['Normalmente...', 'Suelo...', 'Me levanto y...'],
+      },
+      {
+        id: 'leisure',
+        prompt: '¿Qué hacés para relajarte o disfrutar después?',
+        goal: 'Incorporar hábitos de ocio en presente y conectar con emociones.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            focus: 'tiempo libre',
+            fallbackForm: 'descanso',
+            acceptedPhrases: ['descanso', 'relajo'],
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            focus: 'actividad social',
+            fallbackForm: 'salgo',
+            optional: true,
+          },
+        ],
+        successResponse: 'Perfecto, describí con quién compartís esos momentos.',
+        hint: 'Sumá otro verbo en presente para explicar tu tiempo libre.',
+        supportPhrases: ['Cuando termino...', 'Después de trabajar...', 'Me gusta...'],
+      },
+      {
+        id: 'people',
+        prompt: '¿Con quién compartís parte de esas actividades?',
+        goal: 'Practicar 1ª persona plural o 3ª persona para hablar de otras personas.',
+        targetForms: [
+          {
+            match: { person: '1p' },
+            focus: 'actividad compartida',
+            fallbackForm: 'salimos',
+            optional: true,
+          },
+          {
+            match: { person: '3p' },
+            focus: 'hábitos de otra persona',
+            fallbackForm: 'trabajan',
+            optional: true,
+            allowReuse: true,
+          },
+        ],
+        successResponse: 'Excelente. Con eso tenemos una imagen completa de tu rutina.',
+        hint: 'Incluí otra persona verbal (salimos, compartimos, ellos vienen...).',
+        supportPhrases: ['Con mi familia...', 'Mis amigos...', 'En casa solemos...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué verbos del listado usaste con mayor seguridad?',
+        '¿Dónde podrías ampliar tu descripción para sonar más natural?',
+      ],
+      successCriteria: [
+        'Incluiste al menos dos verbos del listado practicado.',
+        'Conectaste tus acciones con otra persona o emoción.',
+        'Usaste el tiempo verbal objetivo sin cambiar a otro tiempo.',
+      ],
+      consolidationTip: 'Escribí un párrafo breve con tres verbos clave y léelo en voz alta.',
+    },
+  },
+  pretIndef: {
+    title: 'Relato reciente',
+    preTask: {
+      context:
+        'Traé a la memoria una experiencia concreta del fin de semana o de los últimos días.',
+      objectives: [
+        'Secuenciar acciones puntuales en pasado',
+        'Recuperar verbos de alta frecuencia en pretérito indefinido',
+        'Vincular acciones con personas o emociones'
+      ],
+      activationQuestions: [
+        '¿Qué fue lo más interesante que hiciste el fin de semana?',
+        '¿Qué acción marcó la diferencia?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'event',
+        prompt: '¿Qué hiciste el fin de semana pasado?',
+        goal: 'Narrar la actividad principal con pretérito indefinido.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'fui',
+            focus: 'acción principal',
+            acceptedPhrases: ['fui', 'salí', 'visité'],
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'hice',
+            optional: true,
+          },
+        ],
+        successResponse: '¡Suena genial! Contame con quién lo compartiste.',
+        hint: 'Usá verbos puntuales como fui, comí, visité, hice, compré...',
+        supportPhrases: ['El sábado...', 'Primero...', 'Después...'],
+      },
+      {
+        id: 'companions',
+        prompt: '¿Con quién estuviste o qué persona fue importante?',
+        goal: 'Practicar tercera persona en pretérito y conectar con relaciones.',
+        targetForms: [
+          {
+            match: { person: '3s' },
+            fallbackForm: 'vino',
+            optional: true,
+          },
+          {
+            match: { person: '1p' },
+            fallbackForm: 'fuimos',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por compartirlo. Así cerramos la historia.',
+        hint: 'Sumá otro verbo en pasado para describir a la otra persona.',
+        supportPhrases: ['Mi amigo...', 'Con mi familia...', 'Nos encontramos y...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué conectores usaste para ordenar la historia?',
+        '¿Hubo detalles que podrías ampliar?'
+      ],
+      successCriteria: [
+        'Narraste al menos dos acciones en pretérito indefinido.',
+        'Mencionaste a otra persona o reacción.',
+      ],
+      consolidationTip: 'Escribí la secuencia de acciones en tres frases ordenadas.',
+    },
+  },
+  impf: {
+    title: 'Recuerdos en contexto',
+    preTask: {
+      context: 'Pensá en una etapa de tu infancia o adolescencia y qué hacías habitualmente.',
+      objectives: [
+        'Describir hábitos y contextos en imperfecto',
+        'Contrastar emociones o detalles de fondo',
+        'Seleccionar vocabulario de memoria autobiográfica'
+      ],
+      activationQuestions: [
+        '¿Cómo era un día típico en tu infancia?',
+        '¿Qué cosas te encantaba hacer?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'setting',
+        prompt: '¿Cómo era tu vida cuando eras pequeño/a?',
+        goal: 'Configurar el escenario con verbos en imperfecto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'vivía',
+            focus: 'contexto general',
+            acceptedPhrases: ['vivía', 'estaba'],
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'tenía',
+            optional: true,
+          },
+        ],
+        successResponse: 'Qué lindo recuerdo. Contame una actividad que repetías.',
+        hint: 'Usá el imperfecto para describir escenarios (vivía, tenía, era, jugaba...).',
+        supportPhrases: ['Cuando era chico...', 'En mi casa...', 'Siempre...'],
+      },
+      {
+        id: 'activities',
+        prompt: '¿Qué actividades repetías o disfrutabas?',
+        goal: 'Enumerar acciones habituales y sentimientos en imperfecto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'jugaba',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'leía',
+            optional: true,
+          },
+        ],
+        successResponse: 'Excelente. Esa imagen queda clara.',
+        hint: 'Agregá otra acción en imperfecto para dar más color.',
+        supportPhrases: ['Soleía...', 'Me encantaba...', 'Todos los días...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Lograste sostener el imperfecto sin cambiar a otro tiempo?',
+        '¿Qué detalles sensoriales podrías sumar la próxima vez?'
+      ],
+      successCriteria: [
+        'Usaste al menos dos verbos en imperfecto relacionados.',
+        'Conectaste la acción con emociones o escenarios.',
+      ],
+      consolidationTip: 'Grabá una nota de voz con la misma historia para escuchar tu fluidez.',
+    },
+  },
+  fut: {
+    title: 'Proyecciones personales',
+    preTask: {
+      context: 'Imaginá tus planes para el próximo año y qué metas querés alcanzar.',
+      objectives: [
+        'Expresar planes y metas en futuro simple',
+        'Relacionar verbos con objetivos concretos',
+        'Practicar conectores de proyección'
+      ],
+      activationQuestions: [
+        '¿Qué meta te entusiasma para el año que viene?',
+        '¿Qué pasos seguirás para lograrla?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'goal',
+        prompt: '¿Qué harás el próximo año para cumplir una meta importante?',
+        goal: 'Describir metas en futuro simple con claridad.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'estudiaré',
+            focus: 'objetivo principal',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'viajaré',
+            optional: true,
+          },
+        ],
+        successResponse: 'Muy bien. ¿Cómo te vas a preparar?',
+        hint: 'Usá verbos como estudiaré, trabajaré, viajaré, ahorraré.',
+        supportPhrases: ['El año que viene...', 'Tengo pensado...', 'Voy a...'],
+      },
+      {
+        id: 'plan',
+        prompt: '¿Qué pasos seguirás para hacerlo posible?',
+        goal: 'Incluir detalles de planificación en futuro.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'ahorraré',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'practicaré',
+            optional: true,
+          },
+        ],
+        successResponse: 'Excelente proyección. Me encanta tu plan.',
+        hint: 'Sumá otro verbo en futuro para detallar el proceso.',
+        supportPhrases: ['Para lograrlo...', 'Cada mes...', 'Además...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué tan realistas fueron tus verbos y planes?',
+        '¿Qué otra meta podrías describir en futuro?'
+      ],
+      successCriteria: [
+        'Presentaste una meta y un paso concreto en futuro.',
+        'Mantuviste coherencia temporal durante la respuesta.',
+      ],
+      consolidationTip: 'Escribí tus metas en una lista y léelas en voz alta cada semana.',
+    },
+  },
+  pretPerf: {
+    title: 'Logros recientes',
+    preTask: {
+      context: 'Pensá en algo que hayas hecho esta semana y que quieras compartir.',
+      objectives: [
+        'Conectar experiencias recientes con pretérito perfecto',
+        'Usar expresiones temporales como "ya", "todavía"',
+        'Reflexionar sobre resultados inmediatos'
+      ],
+      activationQuestions: [
+        '¿Qué actividad terminaste recientemente?',
+        '¿Qué sensación te dejó?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'achievement',
+        prompt: '¿Qué has hecho esta semana que te haga sentir orgulloso/a?',
+        goal: 'Describir logros con pretérito perfecto compuesto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'he terminado',
+            focus: 'logro principal',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'he aprendido',
+            optional: true,
+          },
+        ],
+        successResponse: '¡Excelente! ¿Qué impacto ha tenido?',
+        hint: 'Usá la estructura he + participio (he terminado, he estudiado...).',
+        supportPhrases: ['Esta semana he...', 'Últimamente he...', 'Todavía no he...'],
+      },
+      {
+        id: 'impact',
+        prompt: '¿Cómo te ha cambiado o qué ha significado para vos?',
+        goal: 'Relacionar el logro con consecuencias actuales.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'he mejorado',
+            optional: true,
+          },
+          {
+            match: { person: '1p' },
+            fallbackForm: 'hemos celebrado',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por compartirlo. Cerramos la conversación.',
+        hint: 'Añadí otra oración con pretérito perfecto para conectar ideas.',
+        supportPhrases: ['Desde entonces he...', 'Gracias a eso he...', 'Nos hemos sentido...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Usaste marcadores temporales como "ya" o "todavía"?',
+        '¿Podrías resumir el impacto en una frase más?'
+      ],
+      successCriteria: [
+        'Incluiste al menos un logro en pretérito perfecto.',
+        'Relacionaste el logro con una consecuencia actual.',
+      ],
+      consolidationTip: 'Anotá tus logros de la semana en un diario para revisarlos.',
+    },
+  },
+  cond: {
+    title: 'Mundos hipotéticos',
+    preTask: {
+      context: 'Imaginá situaciones hipotéticas y cómo reaccionarías.',
+      objectives: [
+        'Expresar deseos o planes condicionados',
+        'Practicar el condicional simple con verbos de alta frecuencia',
+        'Explorar consecuencias y motivos'
+      ],
+      activationQuestions: [
+        'Si tuvieras un día libre extra, ¿qué harías?',
+        '¿Qué sueño cambiarías por completo tu vida?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'wish',
+        prompt: 'Si tuvieras recursos infinitos, ¿qué harías primero?',
+        goal: 'Formular deseos en condicional simple.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'viajaría',
+            focus: 'deseo principal',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'ayudaría',
+            optional: true,
+          },
+        ],
+        successResponse: 'Interesante. ¿Qué impacto tendría?',
+        hint: 'Usá condicionales como viajaría, cambiaría, estudiaría, ayudaría.',
+        supportPhrases: ['Si pudiera...', 'Me gustaría...', 'Sería genial si...'],
+      },
+      {
+        id: 'impact',
+        prompt: '¿Cómo cambiaría tu entorno o tu vida?',
+        goal: 'Explorar consecuencias en condicional.',
+        targetForms: [
+          {
+            match: { person: '3p' },
+            fallbackForm: 'estarían',
+            optional: true,
+          },
+          {
+            match: { person: '1p' },
+            fallbackForm: 'seríamos',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por imaginar conmigo.',
+        hint: 'Sumá al menos una consecuencia usando condicional.',
+        supportPhrases: ['La gente...', 'Mis amigos...', 'Nosotros...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué tan claras quedaron las condiciones?',
+        '¿Podrías agregar un motivo que justifique tu elección?'
+      ],
+      successCriteria: [
+        'Planteaste un deseo con condicional simple.',
+        'Mencionaste una consecuencia o impacto.',
+      ],
+      consolidationTip: 'Escribí tres frases con "Si + imperfecto" y sus respuestas en condicional.',
+    },
+  },
+  plusc: {
+    title: 'Antes de que sucediera',
+    preTask: {
+      context: 'Recordá una situación donde algo ya había ocurrido cuando llegaste.',
+      objectives: [
+        'Narrar antecedentes con pluscuamperfecto',
+        'Practicar conectores temporales (cuando, antes de)',
+        'Relacionar acciones pasadas con reacciones'
+      ],
+      activationQuestions: [
+        '¿Qué cosa había pasado cuando llegaste a un lugar?',
+        '¿Cómo reaccionaste al enterarte?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'background',
+        prompt: 'Contame un momento en el que llegaste tarde y algo ya había ocurrido.',
+        goal: 'Describir antecedentes usando pluscuamperfecto.',
+        targetForms: [
+          {
+            match: { person: '3p' },
+            fallbackForm: 'habían salido',
+            focus: 'acción que ya había pasado',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'había llegado',
+            optional: true,
+          },
+        ],
+        successResponse: 'Qué situación. ¿Qué hiciste después?',
+        hint: 'Usá había + participio (había llegado, habían empezado...).',
+        supportPhrases: ['Cuando llegué...', 'Antes de que yo...', 'Ya habían...'],
+      },
+      {
+        id: 'reaction',
+        prompt: '¿Qué hiciste o cómo reaccionaste después de darte cuenta?',
+        goal: 'Continuar con acciones posteriores.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'me quedé',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'llamé',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por compartirlo. Cerramos la escena.',
+        hint: 'Podés combinar pluscuamperfecto con pretérito para explicar la reacción.',
+        supportPhrases: ['Entonces...', 'Después...', 'Decidí...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Se entendió el orden temporal de los eventos?',
+        '¿Qué detalles podrías agregar la próxima vez?'
+      ],
+      successCriteria: [
+        'Explicaste claramente qué había sucedido antes de tu llegada.',
+        'Añadiste una reacción posterior.',
+      ],
+      consolidationTip: 'Dibuja una línea temporal con los eventos para visualizar la secuencia.',
+    },
+  },
+  futPerf: {
+    title: 'Metas cumplidas en el futuro',
+    preTask: {
+      context: 'Imaginá tu vida dentro de unos años y qué cosas ya habrás completado.',
+      objectives: [
+        'Proyectar logros con futuro perfecto',
+        'Relacionar metas con plazos concretos',
+        'Practicar expresiones temporales (para entonces, dentro de)'
+      ],
+      activationQuestions: [
+        'Dentro de cinco años, ¿qué cosas ya habrás logrado?',
+        '¿Qué proyecto te gustaría haber terminado?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'projection',
+        prompt: 'Dentro de cinco años, ¿qué cosas ya habrás conseguido?',
+        goal: 'Expresar logros futuros completados.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habré terminado',
+            focus: 'logro principal',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habré aprendido',
+            optional: true,
+          },
+        ],
+        successResponse: 'Suena inspirador. ¿Qué vendrá después?',
+        hint: 'Usá habré + participio (habré terminado, habré viajado...).',
+        supportPhrases: ['Para entonces...', 'Cuando tenga...', 'Ya habré...'],
+      },
+      {
+        id: 'nextSteps',
+        prompt: '¿Qué harás después de lograrlo?',
+        goal: 'Conectar futuro perfecto con futuro simple o condicional.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'seguiré',
+            optional: true,
+          },
+          {
+            match: { person: '1p' },
+            fallbackForm: 'habremos compartido',
+            optional: true,
+          },
+        ],
+        successResponse: '¡Gran plan! Cerramos la proyección.',
+        hint: 'Añadí una acción posterior usando futuro o condicional.',
+        supportPhrases: ['Después de eso...', 'Entonces...', 'Más tarde...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Tus objetivos tienen un plazo concreto?',
+        '¿Qué paso podrías dar hoy para acercarte a esa meta?'
+      ],
+      successCriteria: [
+        'Expresaste al menos un logro en futuro perfecto.',
+        'Conectaste el logro con una acción posterior.',
+      ],
+      consolidationTip: 'Escribí tus metas en formato "Para [fecha] habré..." y revísalas mensualmente.',
+    },
+  },
+  subjPres: {
+    title: 'Organizando juntos',
+    preTask: {
+      context: 'Pensá en una actividad grupal y qué necesitas que otras personas hagan.',
+      objectives: [
+        'Expresar pedidos y recomendaciones con subjuntivo presente',
+        'Conectar con expresiones de influencia y deseo',
+        'Practicar estructuras como "quiero que", "es importante que"'
+      ],
+      activationQuestions: [
+        '¿Qué evento estás organizando?',
+        '¿Qué necesitas que haga tu equipo?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'requests',
+        prompt: 'Estoy organizando una actividad. ¿Qué te gustaría que hagan tus amigos?',
+        goal: 'Formular peticiones con subjuntivo presente.',
+        targetForms: [
+          {
+            match: { person: '3p' },
+            fallbackForm: 'vengan',
+            focus: 'petición principal',
+          },
+          {
+            match: { person: '2s' },
+            fallbackForm: 'traigas',
+            optional: true,
+          },
+        ],
+        successResponse: 'Perfecto. ¿Qué otra cosa es importante?',
+        hint: 'Usá expresiones como quiero que, es necesario que, ojalá que + subjuntivo.',
+        supportPhrases: ['Quiero que...', 'Es importante que...', 'Prefiero que...'],
+      },
+      {
+        id: 'coordination',
+        prompt: '¿Qué condiciones tienen que cumplirse para que todo salga bien?',
+        goal: 'Dar recomendaciones y condiciones con subjuntivo.',
+        targetForms: [
+          {
+            match: { person: '1p' },
+            fallbackForm: 'preparemos',
+            optional: true,
+          },
+          {
+            match: { person: '3p' },
+            fallbackForm: 'traigan',
+            optional: true,
+            allowReuse: true,
+          },
+        ],
+        successResponse: 'Excelente. Tu plan suena sólido.',
+        hint: 'Sumá otro verbo en subjuntivo para reforzar la idea.',
+        supportPhrases: ['Necesito que...', 'Es mejor que...', 'Espero que...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Usaste expresiones de influencia correctas?',
+        '¿Podrías variar los conectores la próxima vez?'
+      ],
+      successCriteria: [
+        'Formulaste al menos una petición con subjuntivo presente.',
+        'Incluiste razones o condiciones.',
+      ],
+      consolidationTip: 'Haz una lista de frases con "Quiero que..." y completa con distintos verbos.',
+    },
+  },
+  subjImpf: {
+    title: 'Escenarios alternativos',
+    preTask: {
+      context: 'Imaginá situaciones hipotéticas en el pasado y qué habría pasado si algo fuera diferente.',
+      objectives: [
+        'Practicar el subjuntivo imperfecto en oraciones condicionales',
+        'Conectar con condicional simple y expresiones de deseo',
+        'Explorar arrepentimientos o deseos no cumplidos'
+      ],
+      activationQuestions: [
+        'Si pudieras volver a una situación, ¿qué cambiarías?',
+        '¿Qué consejo le darías a tu yo del pasado?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'hypothesis',
+        prompt: 'Si volvieras a una situación importante, ¿qué harías diferente?',
+        goal: 'Usar estructuras condicionales con subjuntivo imperfecto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'hiciera',
+            focus: 'acción alternativa',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'estudiara',
+            optional: true,
+          },
+        ],
+        successResponse: 'Interesante. ¿Qué habría pasado como resultado?',
+        hint: 'Usá si + subjuntivo imperfecto (si tuviera, si pudiera, si estudiara...).',
+        supportPhrases: ['Si pudiera...', 'Si tuviera...', 'Si supiera...'],
+      },
+      {
+        id: 'result',
+        prompt: '¿Qué habría pasado si esa acción hubiera sido distinta?',
+        goal: 'Describir consecuencias hipotéticas.',
+        targetForms: [
+          {
+            match: { person: '3p' },
+            fallbackForm: 'estarían',
+            optional: true,
+          },
+          {
+            match: { person: '1p' },
+            fallbackForm: 'seríamos',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por compartir esa reflexión.',
+        hint: 'Conectá con condicional simple para mostrar el resultado.',
+        supportPhrases: ['Entonces...', 'Probablemente...', 'Eso haría que...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Combinaste correctamente subjuntivo imperfecto con condicional?',
+        '¿Podrías dar un ejemplo adicional?'
+      ],
+      successCriteria: [
+        'Formulaste al menos una hipótesis completa.',
+        'Conectaste causa y consecuencia.',
+      ],
+      consolidationTip: 'Escribí tres oraciones tipo "Si + subjuntivo imperfecto, condicional" y léelas en voz alta.',
+    },
+  },
+  subjPerf: {
+    title: 'Esperanzas recientes',
+    preTask: {
+      context: 'Pensá en situaciones recientes donde esperabas que algo ya hubiera ocurrido.',
+      objectives: [
+        'Usar el perfecto de subjuntivo para expresar duda o emoción',
+        'Relacionar eventos recientes con expectativas',
+        'Practicar expresiones como "me alegra que", "espero que"'
+      ],
+      activationQuestions: [
+        '¿Qué noticia esperabas recibir esta semana?',
+        '¿Qué emoción sentiste al saber el resultado?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'expectation',
+        prompt: 'Estoy esperando noticias. ¿Qué esperás que haya pasado?',
+        goal: 'Expresar deseos con perfecto de subjuntivo.',
+        targetForms: [
+          {
+            match: { person: '3s' },
+            fallbackForm: 'haya llegado',
+            focus: 'resultado esperado',
+          },
+          {
+            match: { person: '3p' },
+            fallbackForm: 'hayan respondido',
+            optional: true,
+          },
+        ],
+        successResponse: 'Ojalá que sí. ¿Y si no fue así?',
+        hint: 'Usá haya + participio (haya llegado, hayan respondido...).',
+        supportPhrases: ['Espero que...', 'Me alegra que...', 'Dudo que...'],
+      },
+      {
+        id: 'backupPlan',
+        prompt: 'Si las cosas no han salido como esperabas, ¿qué harías?',
+        goal: 'Planificar respuesta combinando subjuntivo perfecto y condicional.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habría llamado',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habría buscado',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gran plan alternativo. Cerramos la conversación.',
+        hint: 'Podés mezclar con condicional para mostrar tu reacción.',
+        supportPhrases: ['En caso de que...', 'Si no...', 'Entonces...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué emoción transmitiste con el perfecto de subjuntivo?',
+        '¿Cómo podrías intensificar esa emoción?'
+      ],
+      successCriteria: [
+        'Incluiste al menos una esperanza en perfecto de subjuntivo.',
+        'Conectaste con un plan alternativo.',
+      ],
+      consolidationTip: 'Anotá tres frases con "Espero que" + haya + participio.',
+    },
+  },
+  subjPlusc: {
+    title: 'Deseos imposibles',
+    preTask: {
+      context: 'Recordá un momento en el que deseabas que algo hubiera sido distinto.',
+      objectives: [
+        'Expresar lamentos con pluscuamperfecto de subjuntivo',
+        'Conectar con condicional compuesto',
+        'Explorar sentimientos de arrepentimiento'
+      ],
+      activationQuestions: [
+        '¿Qué cosa te hubiese gustado cambiar en una situación pasada?',
+        '¿Qué aprendizaje sacaste de eso?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'regret',
+        prompt: 'Pienso en algo que no salió bien. ¿Qué ojalá que hubiera pasado?',
+        goal: 'Formular deseos imposibles con subjuntivo pluscuamperfecto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'hubiera estudiado',
+            focus: 'acción no realizada',
+          },
+          {
+            match: { person: '3p' },
+            fallbackForm: 'hubieran venido',
+            optional: true,
+          },
+        ],
+        successResponse: 'Lo entiendo. ¿Qué habrías hecho diferente después?',
+        hint: 'Usá hubiera/hubiese + participio (hubiera estudiado, hubieran llegado).',
+        supportPhrases: ['Ojalá que...', 'Si al menos...', 'Me habría gustado que...'],
+      },
+      {
+        id: 'lesson',
+        prompt: '¿Qué harías si se repitiera la situación?',
+        goal: 'Conectar el arrepentimiento con un plan futuro.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'estudiaría',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habría hablado',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gran reflexión. Lo importante es aprender.',
+        hint: 'Podés pasar del subjuntivo pluscuamperfecto al condicional para mostrar aprendizaje.',
+        supportPhrases: ['La próxima vez...', 'Ahora sé que...', 'Aprendí que...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Qué emoción dominante transmitiste?',
+        '¿Cómo podrías cerrar con un mensaje positivo?'
+      ],
+      successCriteria: [
+        'Expresaste un deseo imposible usando subjuntivo pluscuamperfecto.',
+        'Ofreciste una alternativa futura.',
+      ],
+      consolidationTip: 'Escribí dos frases con "Ojalá que" + hubiera/hubiese + participio.',
+    },
+  },
+  condPerf: {
+    title: 'Lecciones aprendidas',
+    preTask: {
+      context: 'Pensá en cómo habrías actuado de otra manera con lo que sabés hoy.',
+      objectives: [
+        'Usar el condicional compuesto para hablar de alternativas pasadas',
+        'Conectar con aprendizajes presentes',
+        'Practicar expresiones como "si hubiera", "habría"'
+      ],
+      activationQuestions: [
+        'Si hubieras tenido más información, ¿qué habrías hecho?',
+        '¿Qué decisión te habría gustado cambiar?'
+      ],
+    },
+    conversationSteps: [
+      {
+        id: 'alternative',
+        prompt: 'Si hubieras tenido más tiempo, ¿qué habrías hecho diferente?',
+        goal: 'Expresar acciones alternativas con condicional compuesto.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habría estudiado',
+            focus: 'acción alternativa',
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'habría viajado',
+            optional: true,
+          },
+        ],
+        successResponse: 'Entiendo. ¿Qué aprendizaje te deja?',
+        hint: 'Usá habría + participio (habría tomado, habría dicho, habría ido).',
+        supportPhrases: ['Si hubiera...', 'Con más tiempo habría...', 'En ese caso habría...'],
+      },
+      {
+        id: 'learning',
+        prompt: '¿Qué harías ahora si una situación parecida se repite?',
+        goal: 'Conectar condicional compuesto con planes futuros.',
+        targetForms: [
+          {
+            match: { person: '1s' },
+            fallbackForm: 'aprendería',
+            optional: true,
+          },
+          {
+            match: { person: '1s' },
+            fallbackForm: 'buscaría',
+            optional: true,
+          },
+        ],
+        successResponse: 'Gracias por compartir tu aprendizaje.',
+        hint: 'Cerrá con un plan concreto para el futuro.',
+        supportPhrases: ['La próxima vez...', 'Ahora sé que...', 'Voy a...'],
+      },
+    ],
+    postTask: {
+      prompts: [
+        '¿Expresaste claramente la alternativa pasada?',
+        '¿Sumaste un aprendizaje concreto?'
+      ],
+      successCriteria: [
+        'Usaste condicional compuesto para describir la alternativa.',
+        'Conectaste con un plan o aprendizaje actual.',
+      ],
+      consolidationTip: 'Escribí un breve diario de decisiones con "Si hubiera..., habría...".',
+    },
+  },
+};

--- a/src/lib/utils/normalizeFormValue.js
+++ b/src/lib/utils/normalizeFormValue.js
@@ -1,0 +1,18 @@
+export function normalizeFormValue(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+export function normalizeTextForComparison(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return normalizeFormValue(value.replace(/[.,!?;:]/g, ' ')).replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## Summary
- introduce structured communicative scenarios with pre-task, interaction steps, and reflection metadata
- refactor CommunicativePractice to resolve scenarios from eligible forms, evaluate turns with formative feedback, and manage phase transitions
- surface eligible form data across the learning flow, normalizing matches in MeaningfulPractice, and add targeted tests for the new evaluation logic

## Testing
- npm test -- --run src/components/learning/CommunicativePractice.integration.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d680df962c832882065e9e768e7d15