### PR TITLE
fix: align LearnTenseFlow with MeaningfulPractice API

### DIFF
--- a/src/components/learning/LearnTenseFlow.jsx
+++ b/src/components/learning/LearnTenseFlow.jsx
@@ -718,12 +718,11 @@ function LearnTenseFlowContainer({ onHome, onGoToProgress }) {
     return (
       <ErrorBoundary>
         <MeaningfulPractice
-          tense={selectedTense}
-          verbType={verbType}
-          selectedFamilies={selectedFamilies}
+          tense={selectedTense?.tense}
+          mood={selectedTense?.mood}
           eligibleForms={eligibleForms}
           onBack={() => setCurrentStep('practice')}
-          onPhaseComplete={handleMeaningfulPhaseComplete}
+          onComplete={handleMeaningfulPhaseComplete}
         />
       </ErrorBoundary>
     );

--- a/src/components/learning/MeaningfulPractice.integration.test.jsx
+++ b/src/components/learning/MeaningfulPractice.integration.test.jsx
@@ -40,7 +40,7 @@ describe('MeaningfulPractice SRS Integration', () => {
   const mockUserId = 'test-user-123';
 
   const mockOnBack = vi.fn();
-  const mockOnPhaseComplete = vi.fn();
+  const mockOnComplete = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,10 +69,11 @@ describe('MeaningfulPractice SRS Integration', () => {
   it('should update SRS schedule when correct verbs are found in meaningful practice', async () => {
     render(
       <MeaningfulPractice
-        tense={mockTense}
+        tense={mockTense.tense}
+        mood={mockTense.mood}
         eligibleForms={mockEligibleForms}
         onBack={mockOnBack}
-        onPhaseComplete={mockOnPhaseComplete}
+        onComplete={mockOnComplete}
       />
     );
 
@@ -104,10 +105,11 @@ describe('MeaningfulPractice SRS Integration', () => {
   it('should not update SRS schedule when eligibleForms is not provided', async () => {
     render(
       <MeaningfulPractice
-        tense={mockTense}
+        tense={mockTense.tense}
+        mood={mockTense.mood}
         eligibleForms={undefined} // No eligible forms provided
         onBack={mockOnBack}
-        onPhaseComplete={mockOnPhaseComplete}
+        onComplete={mockOnComplete}
       />
     );
 
@@ -134,10 +136,11 @@ describe('MeaningfulPractice SRS Integration', () => {
 
     render(
       <MeaningfulPractice
-        tense={mockTense}
+        tense={mockTense.tense}
+        mood={mockTense.mood}
         eligibleForms={limitedEligibleForms}
         onBack={mockOnBack}
-        onPhaseComplete={mockOnPhaseComplete}
+        onComplete={mockOnComplete}
       />
     );
 
@@ -167,10 +170,11 @@ describe('MeaningfulPractice SRS Integration', () => {
 
     render(
       <MeaningfulPractice
-        tense={mockTense}
+        tense={mockTense.tense}
+        mood={mockTense.mood}
         eligibleForms={mockEligibleForms}
         onBack={mockOnBack}
-        onPhaseComplete={mockOnPhaseComplete}
+        onComplete={mockOnComplete}
       />
     );
 


### PR DESCRIPTION
## Summary
- update LearnTenseFlow to pass tense and mood primitives to MeaningfulPractice and use the onComplete callback
- remove unused verbType and selectedFamilies props from the MeaningfulPractice integration and adjust tests to use the new API signature

## Testing
- npx vitest run src/components/learning/MeaningfulPractice.integration.test.jsx (fails: existing expectations around SRS schedule updates)


------
https://chatgpt.com/codex/tasks/task_e_68d9214a4a9483289a0136444a25e0e3