### PR TITLE
Refactor onboarding routing to use router navigation

### DIFF
--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -123,7 +123,7 @@ function AppRouter() {
 
     if (route.mode === 'onboarding' && route.step) {
       cleanupStateForStep(route.step)
-      onboardingFlowRef.current.setOnboardingStep(route.step)
+      onboardingFlowRef.current.setOnboardingStep(route.step, { syncRouter: false })
     }
     
     // Regenerate drill item if navigating to drill without current item
@@ -147,13 +147,13 @@ function AppRouter() {
     if (initialRoute.mode === 'onboarding') {
       // If dialect not selected yet, force onboarding to start at step 1
       if (!useSettings.getState().region) {
-        onboardingFlowRef.current.setOnboardingStep(1)
+        onboardingFlowRef.current.setOnboardingStep(1, { syncRouter: false })
         try { router.navigate({ mode: 'onboarding', step: 1 }) } catch { /* Navigation error ignored */ }
       } else if (initialRoute.step) {
-        onboardingFlowRef.current.setOnboardingStep(initialRoute.step)
+        onboardingFlowRef.current.setOnboardingStep(initialRoute.step, { syncRouter: false })
       }
     } else if (initialRoute.step) {
-      onboardingFlowRef.current.setOnboardingStep(initialRoute.step)
+      onboardingFlowRef.current.setOnboardingStep(initialRoute.step, { syncRouter: false })
     }
 
     // Subscribe to route changes

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,7 +17,6 @@ export default defineConfig({
       '**/*.e2e.{js,jsx,ts,tsx}',
       // Temporarily exclude problematic tests with clipboard issues
       'src/utils/swUpdateHandler.test.js',
-      'src/components/onboarding/navigationBack.test.jsx',
       'src/components/learning/LearningDrill.test.jsx'
     ],
 


### PR DESCRIPTION
## Summary
- refactor useOnboardingFlow to drive step changes through the router and a reducer-backed state machine
- update AppRouter integration and onboarding tests to align with router-driven navigation
- enable onboarding navigation integration tests and extend coverage for back button and popstate behavior

## Testing
- `npx vitest run src/components/onboarding/navigationBack.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68d99fcc232c8328a6344acda2b2a06e