### PR TITLE
fix: correct oír family classification

### DIFF
--- a/per-tense-analysis-results.json
+++ b/per-tense-analysis-results.json
@@ -7832,8 +7832,8 @@
     },
     "familyClassification": [
       "G_VERBS",
-      "PRET_J",
-      "IRREG_GERUNDS"
+      "IRREG_GERUNDS",
+      "HIATUS_Y"
     ],
     "expectedAffectedTenses": [
       "pres",

--- a/src/lib/data/irregularFamilies.js
+++ b/src/lib/data/irregularFamilies.js
@@ -428,7 +428,7 @@ export function categorizeVerb(lemma, _verbData) {
     'hacer': ['G_VERBS', 'PRET_I', 'IMPERATIVE_IRREG', 'IRREG_CONDITIONAL', 'IRREG_PARTICIPLES'],
     'venir': ['G_VERBS', 'DIPHT_E_IE', 'PRET_I', 'IMPERATIVE_IRREG', 'IRREG_CONDITIONAL', 'IRREG_GERUNDS'],
     'decir': ['G_VERBS', 'E_I_IR', 'PRET_J', 'IRREG_GERUNDS', 'IRREG_CONDITIONAL', 'IMPERATIVE_IRREG', 'IRREG_PARTICIPLES'],
-    'oír': ['G_VERBS', 'PRET_J', 'IRREG_GERUNDS', 'HIATUS_Y'],
+    'oír': ['G_VERBS', 'IRREG_GERUNDS', 'HIATUS_Y'],
     'traer': ['G_VERBS', 'PRET_J', 'IRREG_GERUNDS'],
     'caer': ['G_VERBS', 'PRET_J', 'IRREG_GERUNDS', 'HIATUS_Y'],
     'valer': ['G_VERBS'],

--- a/src/lib/data/irregularFamilies.test.js
+++ b/src/lib/data/irregularFamilies.test.js
@@ -44,5 +44,12 @@ describe('irregularFamilies data helpers', () => {
     // -uir verbs (non -guir)
     expect(categorizeVerb('construir')).toContain('UIR_Y')
   })
+
+  it('categorizeVerb classifies oír in hiato and gerund families without PRET_J', () => {
+    const families = categorizeVerb('oír')
+    expect(families).toContain('HIATUS_Y')
+    expect(families).toContain('IRREG_GERUNDS')
+    expect(families).not.toContain('PRET_J')
+  })
 })
 


### PR DESCRIPTION
## Summary
- remove the PRET_J tag from the known families for **oír** while keeping its hiatus and gerund irregularities
- update the oír fixture entry to reflect the revised family set
- add a unit test ensuring oír is classified into HIATUS_Y/IRREG_GERUNDS and excluded from PRET_J

## Testing
- npm test -- --run src/lib/data/irregularFamilies.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d99fd3aab48328adb7c89e22ce4fa7