### PR TITLE
Fix drill item ID generation and add uniqueness test

### DIFF
--- a/src/features/drill/useProgressTracking.test.js
+++ b/src/features/drill/useProgressTracking.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useProgressTracking } from './useProgressTracking.js'
+import { generateDrillItem } from '../../hooks/modules/DrillItemGenerator.js'
+import { trackAttemptStarted } from './tracking.js'
+
+vi.mock('./tracking.js', () => ({
+  trackAttemptStarted: vi.fn(() => 'attempt-1'),
+  trackAttemptSubmitted: vi.fn(),
+  trackHintShown: vi.fn(),
+  trackStreakIncremented: vi.fn(),
+  trackTenseDrillStarted: vi.fn(),
+  trackTenseDrillEnded: vi.fn()
+}))
+
+vi.mock('../../lib/progress/userManager.js', () => ({
+  incrementSessionCount: vi.fn(),
+  getCurrentUserId: vi.fn(() => 'user-test')
+}))
+
+vi.mock('../../lib/progress/index.js', () => ({
+  isProgressSystemInitialized: vi.fn(() => true),
+  onProgressSystemReady: vi.fn((callback) => {
+    callback(true)
+    return vi.fn()
+  })
+}))
+
+vi.mock('../../lib/utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }))
+}))
+
+describe('useProgressTracking', () => {
+  const settings = {
+    useVoseo: false,
+    useTuteo: false,
+    useVosotros: false
+  }
+
+  const formsPool = [
+    {
+      lemma: 'hablar',
+      mood: 'indicative',
+      tense: 'pres',
+      person: '1s',
+      value: 'hablo'
+    },
+    {
+      lemma: 'hablar',
+      mood: 'indicative',
+      tense: 'pres',
+      person: '2s_tu',
+      value: 'hablas'
+    }
+  ]
+
+  beforeEach(() => {
+    trackAttemptStarted.mockClear()
+  })
+
+  it('receives distinct IDs for consecutive drill items', async () => {
+    const firstItem = generateDrillItem(formsPool[0], settings, formsPool)
+    const secondItem = generateDrillItem(formsPool[1], settings, formsPool)
+
+    expect(firstItem?.id).toBeTruthy()
+    expect(secondItem?.id).toBeTruthy()
+    expect(firstItem.id).not.toBe(secondItem.id)
+
+    const { rerender } = renderHook(
+      ({ item }) => useProgressTracking(item, () => {}),
+      { initialProps: { item: firstItem } }
+    )
+
+    await waitFor(() => {
+      expect(trackAttemptStarted).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ item: secondItem })
+
+    await waitFor(() => {
+      expect(trackAttemptStarted).toHaveBeenCalledTimes(2)
+    })
+
+    const firstCallItem = trackAttemptStarted.mock.calls[0][0]
+    const secondCallItem = trackAttemptStarted.mock.calls[1][0]
+
+    expect(firstCallItem.id).toBe(firstItem.id)
+    expect(secondCallItem.id).toBe(secondItem.id)
+    expect(firstCallItem.id).not.toBe(secondCallItem.id)
+  })
+})

--- a/src/hooks/modules/DrillItemGenerator.js
+++ b/src/hooks/modules/DrillItemGenerator.js
@@ -14,6 +14,20 @@ import { createLogger } from '../../lib/utils/logger.js'
 
 const logger = createLogger('DrillItemGenerator')
 
+let drillItemIdCounter = 0
+
+const createDrillItemId = () => {
+  if (typeof globalThis !== 'undefined') {
+    const cryptoObject = globalThis.crypto
+    if (cryptoObject && typeof cryptoObject.randomUUID === 'function') {
+      return cryptoObject.randomUUID()
+    }
+  }
+
+  drillItemIdCounter += 1
+  return `drill-item-${drillItemIdCounter}`
+}
+
 /**
  * Find canonical form from the available forms pool
  * @param {string} lemma - Verb lemma
@@ -126,7 +140,7 @@ export const generateDrillItem = (selectedForm, settings, formsPool = []) => {
   
   // Create complete drill item
   const drillItem = {
-    id: Date.now(), // Unique identifier to force re-render
+    id: createDrillItemId(),
     lemma: selectedForm.lemma,
     mood: selectedForm.mood,
     tense: selectedForm.tense,
@@ -302,9 +316,9 @@ export const validateDrillItemStructure = (item) => {
  */
 export const createFallbackDrillItem = (fallbackData, settings) => {
   logger.warn('createFallbackDrillItem', 'Creating fallback drill item')
-  
+
   return {
-    id: Date.now(),
+    id: createDrillItemId(),
     lemma: fallbackData.lemma || 'ser',
     mood: fallbackData.mood || 'ind',
     tense: fallbackData.tense || 'pres',


### PR DESCRIPTION
## Summary
- replace the Date.now-based drill item identifiers with a UUID-aware generator that falls back to a scoped counter
- reuse the new identifier generator for fallback drill items to ensure consistent uniqueness handling
- add a useProgressTracking test that asserts consecutive drill items provide distinct IDs to the tracking hook

## Testing
- npx vitest run src/features/drill/useProgressTracking.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d99fd995d48328be78614921ecf1b8