### PR TITLE
fix(progress): use createdAt when calculating practice frequency

### DIFF
--- a/src/lib/progress/dataExport.js
+++ b/src/lib/progress/dataExport.js
@@ -175,14 +175,24 @@ function calculateMasteryDistribution(masteryData) {
   return distribution
 }
 
-function calculatePracticeFrequency(attempts) {
-  const daysWithPractice = new Set(
-    attempts.map(a => new Date(a.timestamp).toDateString())
-  ).size
-  
+export function calculatePracticeFrequency(attempts) {
+  const practiceDays = attempts
+    .map(attempt => {
+      const dateValue = attempt?.createdAt ?? attempt?.timestamp
+      if (!dateValue) return null
+
+      const practiceDate = new Date(dateValue)
+      if (Number.isNaN(practiceDate.getTime())) return null
+
+      return practiceDate.toDateString()
+    })
+    .filter(Boolean)
+
+  const daysWithPractice = new Set(practiceDays).size
+
   return {
     totalDays: daysWithPractice,
-    averageAttemptsPerDay: daysWithPractice ? (attempts.length / daysWithPractice).toFixed(1) : 0
+    averageAttemptsPerDay: daysWithPractice ? (practiceDays.length / daysWithPractice).toFixed(1) : 0
   }
 }
 

--- a/src/lib/progress/dataExport.test.js
+++ b/src/lib/progress/dataExport.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculatePracticeFrequency } from './dataExport.js'
+
+describe('calculatePracticeFrequency', () => {
+  it('counts practice days using createdAt when available and ignores invalid dates', () => {
+    const attempts = [
+      {
+        createdAt: '2024-06-01T08:00:00.000Z',
+        timestamp: '2024-05-29T12:00:00.000Z'
+      },
+      {
+        createdAt: '2024-06-01T18:00:00.000Z',
+        timestamp: '2024-05-29T14:00:00.000Z'
+      },
+      {
+        timestamp: '2024-06-02T10:00:00.000Z'
+      },
+      {
+        createdAt: 'not-a-real-date',
+        timestamp: '2024-06-03T09:00:00.000Z'
+      }
+    ]
+    const originalAttempts = attempts.map(attempt => ({ ...attempt }))
+
+    const result = calculatePracticeFrequency(attempts)
+
+    expect(result.totalDays).toBe(2)
+    expect(result.averageAttemptsPerDay).toBe('1.5')
+    expect(attempts).toEqual(originalAttempts)
+  })
+})


### PR DESCRIPTION
## Summary
- update practice frequency calculation to prioritize createdAt timestamps and ignore invalid dates
- expose calculatePracticeFrequency for testing and add a unit test that covers createdAt usage

## Testing
- npx vitest run src/lib/progress/dataExport.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9ace823f88328aeae41737867447b