### PR TITLE
feat: refresh SRS dashboard panel automatically

### DIFF
--- a/README_PROGRESS_SYSTEM.md
+++ b/README_PROGRESS_SYSTEM.md
@@ -111,6 +111,11 @@ Componentes React para:
 - Mapa de calor interactivo
 - Radar de competencias visual
 
+#### Panel de Repaso Inteligente (dashboard)
+- `SRSPanel.jsx` escucha el evento global `progress:srs-updated` para disparar `reload()` del hook `useSRSQueue()` y volver a calcular los totales agregados vía `loadSRSData()`.
+- Los cambios en `queueStats` y `lastUpdated` rehidratan automáticamente los contadores de "listos", "urgentes" y "vencidos" sin interacción del usuario.
+- La vista permanece sincronizada aun cuando otros módulos actualizan la cola SRS (p. ej. al registrar intentos en Drill o tras una sincronización).
+
 ### 9. Integración con Drill (`src/features/drill/`)
 Hooks y wrappers para:
 - Tracking automático de intentos

--- a/src/features/progress/SRSPanel.test.jsx
+++ b/src/features/progress/SRSPanel.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+
+const { reloadMock, getSRSStatsMock, getCurrentUserIdMock } = vi.hoisted(() => ({
+  reloadMock: vi.fn(),
+  getSRSStatsMock: vi.fn(),
+  getCurrentUserIdMock: vi.fn()
+}))
+
+vi.mock('../../state/settings.js', () => ({
+  useSettings: () => ({
+    set: vi.fn()
+  })
+}))
+
+vi.mock('../../components/gamification/GamificationDisplay.jsx', () => ({
+  default: () => <div data-testid="gamification-display" />
+}))
+
+vi.mock('../../components/srs/SRSAnalytics.jsx', () => ({
+  default: () => <div data-testid="srs-analytics" />
+}))
+
+vi.mock('../../components/progress/ProgressJourney.jsx', () => ({
+  default: () => <div data-testid="progress-journey" />
+}))
+
+vi.mock('../../components/mobile/TouchHints.jsx', () => ({
+  SRSHints: ({ children }) => <div data-testid="srs-hints">{children}</div>,
+  GamificationHints: ({ children }) => <div data-testid="gamification-hints">{children}</div>,
+  JourneyHints: ({ children }) => <div data-testid="journey-hints">{children}</div>
+}))
+
+vi.mock('../../components/notifications/NotificationSettings.jsx', () => ({
+  default: () => <div data-testid="notification-settings" />
+}))
+
+vi.mock('../../hooks/useSRSQueue.js', () => ({
+  useSRSQueue: () => ({
+    queue: [],
+    loading: false,
+    error: '',
+    stats: { total: 0, urgent: 0, overdue: 0, scheduled: 0 },
+    lastUpdated: null,
+    reload: reloadMock
+  })
+}))
+
+vi.mock('../../lib/progress/analytics.js', () => ({
+  getSRSStats: getSRSStatsMock
+}))
+
+vi.mock('../../lib/progress/userManager.js', () => ({
+  getCurrentUserId: getCurrentUserIdMock
+}))
+
+import SRSPanel from './SRSPanel.jsx'
+
+describe('SRSPanel', () => {
+  beforeEach(() => {
+    reloadMock.mockClear()
+    getSRSStatsMock.mockReset()
+    getCurrentUserIdMock.mockReset()
+    getCurrentUserIdMock.mockReturnValue('user-123')
+    getSRSStatsMock.mockResolvedValue({ dueNow: 3, dueToday: 7 })
+  })
+
+  it('recarga la cola y las estadísticas cuando se emite progress:srs-updated', async () => {
+    render(<SRSPanel />)
+
+    await waitFor(() => {
+      expect(getSRSStatsMock).toHaveBeenCalledTimes(1)
+    })
+
+    window.dispatchEvent(new CustomEvent('progress:srs-updated'))
+
+    await waitFor(() => {
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      expect(getSRSStatsMock).toHaveBeenCalledTimes(2)
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- trigger SRS panel reloads when the `progress:srs-updated` event fires and when queue stats change
- document the new auto-refresh behavior in the dashboard SRS section
- cover the listener with a dedicated Vitest that simulates the browser event

## Testing
- npx vitest run src/features/progress/SRSPanel.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68d9acfb3f408328a647ab24132bd9d6