### PR TITLE
Remove CSV data transfer utilities

### DIFF
--- a/src/features/progress/DataManagementPanel.jsx
+++ b/src/features/progress/DataManagementPanel.jsx
@@ -2,7 +2,7 @@
 // Funcionalidades avanzadas de Fase 5
 
 import { useState, useEffect } from 'react'
-import { exportProgressData, exportToCSV, downloadExportedData, generateProgressReport } from '../../lib/progress/dataExport.js'
+import { exportProgressData, downloadExportedData, generateProgressReport } from '../../lib/progress/dataExport.js'
 import { importFromFile, createBackup } from '../../lib/progress/dataRestore.js'
 import {
   setSyncEndpoint,
@@ -82,22 +82,6 @@ export default function DataManagementPanel({ onClose }) {
       setStatus('✅ Datos exportados exitosamente')
     } catch (err) {
       setError(`Error al exportar: ${err.message}`)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleExportCSV = async (dataType) => {
-    setLoading(true)
-    setError('')
-    try {
-      setStatus(`Exportando ${dataType} en formato CSV...`)
-      const csvData = await exportToCSV(null, dataType)
-      const filename = `${dataType}_export_${new Date().toISOString().split('T')[0]}.csv`
-      downloadExportedData(csvData, filename, 'text/csv')
-      setStatus(`✅ ${dataType} exportado exitosamente`)
-    } catch (err) {
-      setError(`Error al exportar CSV: ${err.message}`)
     } finally {
       setLoading(false)
     }
@@ -278,15 +262,6 @@ export default function DataManagementPanel({ onClose }) {
             <div className="export-options">
               <button onClick={handleExportJSON} disabled={loading}>
                 📄 Exportar Todo (JSON)
-              </button>
-              <button onClick={() => handleExportCSV('attempts')} disabled={loading}>
-                📊 Exportar Intentos (CSV)
-              </button>
-              <button onClick={() => handleExportCSV('mastery')} disabled={loading}>
-                🎯 Exportar Dominio (CSV)
-              </button>
-              <button onClick={() => handleExportCSV('schedules')} disabled={loading}>
-                ⏰ Exportar Horarios (CSV)
               </button>
               <button onClick={handleGenerateReport} disabled={loading}>
                 📈 Generar Reporte Completo

--- a/src/lib/progress/README.md
+++ b/src/lib/progress/README.md
@@ -401,14 +401,13 @@ Si usa pista: no sube de nivel en esa pasada.
 
 #### Funcionalidades
 
-- **Exportar** a CSV o PDF
+- **Generar reportes** descargables
 - **Filtrar** por lista de verbos de clase
 - **Código breve** de sesión para compartir
 
 #### Funciones Principales
 
 - `generateStudentReport(userId)` - Genera informe para docente
-- `exportToCSV(data, filename)` - Exporta datos a CSV
 - `generateSessionCode()` - Genera código de sesión
 - `getClassStats(userIds)` - Obtiene estadísticas de clase
 
@@ -569,7 +568,6 @@ Práctica sin logging si el usuario quiere solo "calentar".
 
 ##### Modo Docente
 - `generateStudentReport(userId)` - Genera informe para docente
-- `exportToCSV(data, filename)` - Exporta datos a CSV
 - `generateSessionCode()` - Genera código de sesión
 - `getClassStats(userIds)` - Obtiene estadísticas de clase
 

--- a/src/lib/progress/all.js
+++ b/src/lib/progress/all.js
@@ -211,7 +211,6 @@ export {
 // Teacher Mode
 export {
   generateStudentReport,
-  exportToCSV,
   generateSessionCode,
   getClassStats
 } from './teacherMode.js'

--- a/src/lib/progress/dataExport.js
+++ b/src/lib/progress/dataExport.js
@@ -50,54 +50,6 @@ export async function exportProgressData(userId = null) {
   }
 }
 
-/**
- * Exporta los datos en formato CSV
- * @param {string} userId - ID del usuario
- * @param {string} dataType - Tipo de datos a exportar ('attempts', 'mastery', 'schedules')
- * @returns {Promise<string>} Datos en formato CSV
- */
-export async function exportToCSV(userId = null, dataType = 'attempts') {
-  try {
-    const actualUserId = userId || getCurrentUserId()
-    if (!actualUserId) {
-      throw new Error('No se encontró ID de usuario para exportar CSV')
-    }
-
-    console.log(`📊 Exportando ${dataType} en formato CSV...`)
-    
-    const data = await getUserDataForExport(dataType, actualUserId)
-    
-    if (!data.length) {
-      return `No hay datos de ${dataType} para exportar`
-    }
-
-    // Generar headers del CSV basado en el primer registro
-    const headers = Object.keys(data[0])
-    
-    // Convertir datos a CSV
-    const csvLines = [
-      headers.join(','),
-      ...data.map(row => 
-        headers.map(header => {
-          const value = row[header]
-          // Escapar comillas y envolver en comillas si contiene comas
-          if (typeof value === 'string' && (value.includes(',') || value.includes('"'))) {
-            return `"${value.replace(/"/g, '""')}"`
-          }
-          return value || ''
-        }).join(',')
-      )
-    ]
-
-    const csvContent = csvLines.join('\n')
-    console.log(`✅ CSV generado con ${data.length} registros`)
-    return csvContent
-  } catch (error) {
-    console.error(`❌ Error al exportar CSV de ${dataType}:`, error)
-    throw error
-  }
-}
-
 async function getUserDataForExport(dataType, userId) {
   switch (dataType) {
     case 'attempts':

--- a/src/lib/progress/teacherMode.js
+++ b/src/lib/progress/teacherMode.js
@@ -78,38 +78,6 @@ export async function generateStudentReport(userId = null) {
 }
 
 /**
- * Exporta datos como CSV
- * @param {Array} data - Datos a exportar
- * @param {string} filename - Nombre del archivo
- * @returns {string} Datos en formato CSV
- */
-export function exportToCSV(data) {
-  if (!data || data.length === 0) return ''
-  
-  try {
-    // Crear encabezados
-    const headers = Object.keys(data[0]).join(',')
-    
-    // Crear filas
-    const rows = data.map(row => 
-      Object.values(row).map(value => 
-        `"${String(value).replace(/"/g, '""')}"`
-      ).join(',')
-    )
-    
-    // Combinar todo
-    const csv = [headers, ...rows].join('\n')
-    
-    // En una implementación completa, esto crearía un archivo descargable
-    // Por ahora, solo devolvemos el contenido CSV
-    return csv
-  } catch (error) {
-    console.error('Error al exportar datos a CSV:', error)
-    throw error
-  }
-}
-
-/**
  * Genera un código de sesión para compartir con docentes
  * @returns {string} Código de sesión
  */

--- a/tests/dataExport.test.js
+++ b/tests/dataExport.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import 'fake-indexeddb/auto'
 
-import { exportProgressData, exportToCSV } from '../src/lib/progress/dataExport.js'
+import { exportProgressData } from '../src/lib/progress/dataExport.js'
 import {
   saveAttempt,
   saveMastery,
@@ -157,21 +157,4 @@ describe('exportación de datos filtrada por usuario', () => {
     expect(result.data.schedules.some(record => record.userId === USER_B)).toBe(false)
   })
 
-  it('exportToCSV reutiliza el filtrado para intentos y schedules', async () => {
-    await seedTestData()
-
-    const attemptsCsv = await exportToCSV(USER_A, 'attempts')
-    const attemptLines = attemptsCsv.split('\n').filter(line => line.trim().length > 0)
-
-    expect(attemptLines.length).toBe(3) // header + 2 filas de USER_A
-    expect(attemptLines.slice(1).every(line => line.includes(USER_A))).toBe(true)
-    expect(attemptLines.slice(1).some(line => line.includes(USER_B))).toBe(false)
-
-    const schedulesCsv = await exportToCSV(USER_A, 'schedules')
-    const scheduleLines = schedulesCsv.split('\n').filter(line => line.trim().length > 0)
-
-    expect(scheduleLines.length).toBe(3)
-    expect(scheduleLines.slice(1).every(line => line.includes(USER_A))).toBe(true)
-    expect(scheduleLines.slice(1).some(line => line.includes(USER_B))).toBe(false)
-  })
 })


### PR DESCRIPTION
## Summary
- remove the legacy CSV export helpers from the progress library and teacher tooling
- simplify the data management panel to only offer JSON exports and reports
- refresh the progress README and tests to match the JSON-only flows

## Testing
- npx vitest run tests/dataExport.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b2f939748328a0df0af110eb7a41