### PR TITLE
feat: add pronunciation practice panel to drill mode

### DIFF
--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -1,13 +1,15 @@
 import React from 'react'
 
-function DrillHeader({ 
-  onToggleQuickSwitch, 
-  onToggleAccentKeys, 
-  onToggleGames, 
+function DrillHeader({
+  onToggleQuickSwitch,
+  onToggleAccentKeys,
+  onToggleGames,
+  onTogglePronunciation,
   onNavigateToProgress,
   onHome,
   showQuickSwitch,
-  showGames
+  showGames,
+  showPronunciation
 }) {
 
   return (
@@ -34,7 +36,7 @@ function DrillHeader({
         >
           <img src="/enie.png" alt="Tildes" className="menu-icon" />
         </button>
-        
+
         <button
           onClick={() => {
             if (showGames) {
@@ -48,7 +50,21 @@ function DrillHeader({
         >
           <img src="/dice.png" alt="Juegos" className="menu-icon" />
         </button>
-        
+
+        <button
+          onClick={() => {
+            if (showPronunciation) {
+              onTogglePronunciation(false)
+            } else {
+              onTogglePronunciation(true)
+            }
+          }}
+          className="icon-btn"
+          title="Pronunciación"
+        >
+          <img src="/megaf-imperat.png" alt="Pronunciación" className="menu-icon" />
+        </button>
+
         <button
           onClick={() => onNavigateToProgress()}
           className="icon-btn"

--- a/src/components/drill/DrillMode.jsx
+++ b/src/components/drill/DrillMode.jsx
@@ -64,6 +64,7 @@ import React, { useState, useEffect, Suspense, lazy, useCallback } from 'react'
 import DrillHeader from './DrillHeader.jsx'
 const QuickSwitchPanel = lazy(() => import('./QuickSwitchPanel.jsx'))
 const GamesPanel = lazy(() => import('./GamesPanel.jsx'))
+const PronunciationPanel = lazy(() => import('./PronunciationPanel.jsx'))
 import Drill from '../../features/drill/Drill.jsx'
 
 /**
@@ -89,10 +90,12 @@ function DrillMode({
   const [showQuickSwitch, setShowQuickSwitch] = useState(false)
   const [showAccentKeys, setShowAccentKeys] = useState(false)
   const [showGames, setShowGames] = useState(false)
+  const [showPronunciation, setShowPronunciation] = useState(false)
 
   const closeAllPanels = () => {
     setShowQuickSwitch(false)
     setShowGames(false)
+    setShowPronunciation(false)
   }
 
   const handleToggleQuickSwitch = useCallback((show = null) => {
@@ -114,6 +117,16 @@ function DrillMode({
       setShowGames(false)
     }
   }, [showGames])
+
+  const handleTogglePronunciation = useCallback((show = null) => {
+    const newShow = show !== null ? show : !showPronunciation
+    if (newShow) {
+      closeAllPanels()
+      setShowPronunciation(true)
+    } else {
+      setShowPronunciation(false)
+    }
+  }, [showPronunciation])
 
   const handleToggleAccentKeys = () => {
     setShowAccentKeys(prev => !prev)
@@ -188,10 +201,12 @@ function DrillMode({
         onToggleQuickSwitch={handleToggleQuickSwitch}
         onToggleAccentKeys={handleToggleAccentKeys}
         onToggleGames={handleToggleGames}
+        onTogglePronunciation={handleTogglePronunciation}
         onNavigateToProgress={onNavigateToProgress}
         onHome={onHome}
         showQuickSwitch={showQuickSwitch}
         showGames={showGames}
+        showPronunciation={showPronunciation}
       />
 
       {showQuickSwitch && (
@@ -213,6 +228,16 @@ function DrillMode({
             settings={settings}
             onClose={() => handleToggleGames(false)}
             onRegenerateItem={onRegenerateItem}
+          />
+        </Suspense>
+      )}
+
+      {showPronunciation && (
+        <Suspense fallback={<div className="loading">Cargando práctica de pronunciación...</div>}>
+          <PronunciationPanel
+            currentItem={currentItem}
+            onClose={() => handleTogglePronunciation(false)}
+            onContinue={() => handleTogglePronunciation(false)}
           />
         </Suspense>
       )}

--- a/src/components/drill/PronunciationPanel.jsx
+++ b/src/components/drill/PronunciationPanel.jsx
@@ -1,0 +1,53 @@
+import React, { useMemo } from 'react'
+import PronunciationPractice from '../learning/PronunciationPractice.jsx'
+
+function PronunciationPanel({ currentItem, onClose, onContinue }) {
+  const tense = useMemo(() => {
+    if (!currentItem) return null
+    return {
+      mood: currentItem.mood || null,
+      tense: currentItem.tense || null
+    }
+  }, [currentItem])
+
+  const eligibleForms = useMemo(() => {
+    if (!currentItem) return []
+    const value = currentItem.form?.value || currentItem.value
+    if (!value) return []
+
+    return [
+      {
+        verb: currentItem.lemma,
+        lemma: currentItem.lemma,
+        form: value,
+        value,
+        person: currentItem.person,
+        mood: currentItem.mood,
+        tense: currentItem.tense,
+        type: currentItem.type
+      }
+    ]
+  }, [currentItem])
+
+  const handleContinue = () => {
+    if (typeof onContinue === 'function') {
+      onContinue()
+    } else if (typeof onClose === 'function') {
+      onClose()
+    }
+  }
+
+  return (
+    <div className="quick-switch-panel pronunciation-panel">
+      <PronunciationPractice
+        tense={tense}
+        eligibleForms={eligibleForms}
+        trackingItem={currentItem}
+        onBack={onClose}
+        onContinue={handleContinue}
+      />
+    </div>
+  )
+}
+
+export default PronunciationPanel

--- a/src/features/drill/tracking.js
+++ b/src/features/drill/tracking.js
@@ -1,6 +1,6 @@
 // Funciones de tracking para el sistema de progreso
 
-import { 
+import {
   trackAttemptStarted as internalTrackAttemptStarted,
   trackAttemptSubmitted as internalTrackAttemptSubmitted,
   trackSessionEnded as internalTrackSessionEnded,
@@ -8,6 +8,7 @@ import {
   trackStreakIncremented as internalTrackStreakIncremented,
   trackTenseDrillStarted as internalTrackTenseDrillStarted,
   trackTenseDrillEnded as internalTrackTenseDrillEnded,
+  trackPronunciationAttempt as internalTrackPronunciationAttempt,
   getUserStats as internalGetUserStats
 } from '../../lib/progress/tracking.js'
 import { classifyError as internalClassifyError } from '../../lib/progress/errorClassification.js'
@@ -109,6 +110,20 @@ export async function trackTenseDrillEnded(tense) {
     console.log(`✅ Drill de tiempo ${tense} finalizado`)
   } catch (error) {
     console.error('❌ Error al finalizar drill de tiempo:', error)
+  }
+}
+
+/**
+ * Registra un intento de práctica de pronunciación
+ * @param {Object} context - Datos del intento de pronunciación
+ * @returns {Promise<void>}
+ */
+export async function trackPronunciationAttempt(context = {}) {
+  try {
+    await internalTrackPronunciationAttempt(context)
+    console.log('🎙️ Intento de pronunciación registrado')
+  } catch (error) {
+    console.error('❌ Error al registrar intento de pronunciación:', error)
   }
 }
 

--- a/src/lib/progress/tracking.js
+++ b/src/lib/progress/tracking.js
@@ -411,6 +411,43 @@ export async function trackTenseDrillEnded(tense, results = {}) {
 }
 
 /**
+ * Registra un intento de práctica de pronunciación
+ * @param {Object} context - Datos del intento de pronunciación
+ * @returns {Promise<void>}
+ */
+export async function trackPronunciationAttempt(context = {}) {
+  if (!currentSession) {
+    throw new Error('Sistema de tracking no inicializado')
+  }
+
+  try {
+    const pronunciationEvent = {
+      id: `pronunciation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      type: 'pronunciation_attempt',
+      userId: currentSession.userId,
+      sessionId: currentSession.id,
+      verbId: context.verbId || null,
+      lemma: context.lemma || null,
+      mood: context.mood || null,
+      tense: context.tense || null,
+      person: context.person || null,
+      target: context.target || null,
+      recognized: context.recognized || null,
+      accuracy: typeof context.accuracy === 'number' ? context.accuracy : null,
+      error: context.error || null,
+      metadata: context.metadata || null,
+      createdAt: new Date()
+    }
+
+    await saveEvent(pronunciationEvent)
+    console.log(`🎙️ Intento de pronunciación registrado: ${pronunciationEvent.id}`)
+  } catch (error) {
+    console.error('❌ Error al registrar intento de pronunciación:', error)
+    throw error
+  }
+}
+
+/**
  * Obtiene las estadísticas actuales del usuario
  * @returns {Promise<Object>} Estadísticas del usuario
  */

--- a/src/lib/progress/tracking.test.js
+++ b/src/lib/progress/tracking.test.js
@@ -9,7 +9,8 @@ import {
   trackHintShown,
   trackStreakIncremented,
   trackTenseDrillStarted,
-  trackTenseDrillEnded
+  trackTenseDrillEnded,
+  trackPronunciationAttempt
 } from './tracking.js'
 
 // Mock de IndexedDB para pruebas
@@ -293,6 +294,31 @@ describe('Sistema de Tracking', () => {
           correctAttempts: 12,
           accuracy: 80,
           completed: true
+        })
+      )
+    })
+
+    it('debería registrar eventos de práctica de pronunciación', async () => {
+      const { saveEvent } = await import('./database.js')
+
+      await trackPronunciationAttempt({
+        verbId: 'hablar',
+        lemma: 'hablar',
+        mood: 'indicativo',
+        tense: 'presente',
+        person: '1s',
+        target: 'hablo',
+        recognized: 'ablo',
+        accuracy: 78
+      })
+
+      expect(saveEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'pronunciation_attempt',
+          userId: testUserId,
+          verbId: 'hablar',
+          target: 'hablo',
+          accuracy: 78
         })
       )
     })


### PR DESCRIPTION
## Summary
- add a lazy-loaded pronunciation practice panel to drill mode with a header toggle
- reuse the PronunciationPractice flow for the current drill item from a dedicated panel
- extend progress tracking to record pronunciation attempts and add unit coverage

## Testing
- npm test -- --run src/features/drill/useProgressTracking.test.js
- npm test -- --run src/lib/progress/tracking.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b84194348328a0f66c7d31d0d847