### PR TITLE
feat(mobile): compact menu & onboarding layout for small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3991,16 +3991,116 @@ body {
 
 @media (max-width: 640px) {
   .main-menu-onboarding {
-    padding: 0 1rem 2rem;
+    padding: 0 0.75rem 1.5rem;
   }
 
+  /* Compact the header shell */
+  .main-menu-onboarding .menu-shell {
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Hide logo column — saves ~180px of vertical space */
+  .main-menu-onboarding .menu-brand-column {
+    display: none;
+  }
+
+  /* Compact hero panel */
+  .main-menu-onboarding .menu-hero-main,
+  .main-menu-onboarding .menu-hero-compact .menu-hero-main,
+  .main-menu-onboarding .menu-hero-minimal .menu-hero-main {
+    padding: 0.85rem 1rem;
+  }
+
+  .main-menu-onboarding .menu-step-line {
+    margin-bottom: 0.5rem;
+  }
+
+  /* Reduce h1 to a compact size that still reads well */
+  .main-menu-onboarding .menu-hero h1,
+  .main-menu-onboarding .menu-hero-compact h1,
+  .main-menu-onboarding .menu-hero-minimal h1,
+  .main-menu-onboarding .menu-shell-hero .menu-hero-main h1,
+  .main-menu-onboarding .menu-shell-hero[data-step="02"] .menu-hero-main h1 {
+    font-size: clamp(1.45rem, 6.5vw, 2rem);
+    margin: 0 0 0.35rem;
+    max-width: none;
+    line-height: 1;
+  }
+
+  .main-menu-onboarding .menu-hero-description,
+  .main-menu-onboarding .menu-hero-minimal .menu-hero-description,
+  .main-menu-onboarding .menu-shell-hero .menu-hero-description {
+    font-size: 0.74rem;
+    line-height: 1.4;
+    max-width: none;
+  }
+
+  /* Compact status panel */
+  .main-menu-onboarding .menu-status-panel {
+    padding: 0.65rem 0.9rem;
+  }
+
+  .main-menu-onboarding .menu-status-header {
+    margin-bottom: 0.45rem;
+  }
+
+  /* Hide the explanatory subtitle in status header — wastes space */
+  .main-menu-onboarding .menu-status-header p {
+    display: none;
+  }
+
+  /* Status grid: 2 columns compact chips */
   .main-menu-onboarding .menu-status-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.4rem;
   }
 
+  .main-menu-onboarding .menu-status-panel-compact .menu-status-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .main-menu-onboarding .menu-status-item {
+    padding: 0.4rem 0.6rem;
+    gap: 0.12rem;
+  }
+
+  /* Options grid: 2 columns so 4 cards = 2×2, fits without scroll */
+  .main-menu-onboarding .options-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Remove tall min-height from all card variants */
   .main-menu-onboarding .option-card,
   .main-menu-onboarding .option-card.compact,
   .main-menu-onboarding .menu-option-card.featured {
     min-height: auto;
+    padding: 0.8rem 0.85rem;
+  }
+
+  .main-menu-onboarding .menu-option-top {
+    margin-bottom: 0.3rem;
+  }
+
+  /* Card title: readable but compact */
+  .main-menu-onboarding .menu-option-card .option-title {
+    font-size: clamp(1.15rem, 4.8vw, 1.55rem);
+  }
+
+  .main-menu-onboarding .menu-option-card.compact .option-title {
+    font-size: 0.95rem;
+  }
+
+  /* Hide long description and conjugation example — title + subtitle suffice on mobile */
+  .main-menu-onboarding .menu-option-description {
+    display: none;
+  }
+
+  .main-menu-onboarding .menu-option-detail {
+    display: none;
+    min-height: 0;
+    margin-top: 0;
   }
 }

--- a/src/components/learning/LearnTenseFlow.css
+++ b/src/components/learning/LearnTenseFlow.css
@@ -379,3 +379,89 @@
     font-size: 1.3rem;
   }
 }
+
+/* Mobile: fit menus on-screen without scroll */
+@media (max-width: 640px) {
+  .learning-menu-layout {
+    padding: 0 0.75rem 1.5rem;
+  }
+
+  .learning-menu-shell {
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Hide logo — recovers the full-width header column */
+  .learning-menu-brand {
+    display: none;
+  }
+
+  /* Single-column header with compact padding */
+  .learning-menu-header {
+    grid-template-columns: 1fr;
+  }
+
+  .learning-menu-copy {
+    padding: 0.85rem 1rem;
+  }
+
+  .learning-menu-meta {
+    margin-bottom: 0.45rem;
+  }
+
+  .learning-menu-layout .learning-menu-copy h1 {
+    font-size: clamp(1.4rem, 6.5vw, 1.9rem);
+    margin-bottom: 0.3rem;
+    line-height: 1;
+  }
+
+  .learning-menu-description {
+    font-size: 0.74rem;
+    line-height: 1.4;
+  }
+
+  .learning-menu-body {
+    gap: 0.75rem;
+  }
+
+  /* Options grid: 2 columns */
+  .learn-flow .options-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+  }
+
+  /* Compact learning option cards */
+  .learn-flow .learning-option-card {
+    min-height: auto;
+    padding: 0.8rem 0.85rem;
+  }
+
+  .learn-flow .learning-option-card .menu-option-top {
+    margin-bottom: 0.3rem;
+  }
+
+  /* Hide verbose content — title + subtitle are sufficient */
+  .learn-flow .learning-option-card .menu-option-description {
+    display: none;
+  }
+
+  .learn-flow .learning-option-card .menu-option-detail {
+    display: none;
+    min-height: 0;
+    margin: 0;
+  }
+
+  /* Tense sections more compact */
+  .tense-section {
+    margin-bottom: 1.25rem;
+  }
+
+  .tense-section h2 {
+    font-size: 1rem;
+    margin-bottom: 0.6rem;
+  }
+
+  .learn-flow .back-btn {
+    margin: 1.25rem auto 0;
+  }
+}


### PR DESCRIPTION
On viewports ≤640px the new brutalist menu shell occupied more vertical
space than most phones have, requiring scroll to reach the option cards.

Changes:
- Hide logo/brand column on mobile (saves ~180px)
- Compress hero h1 with clamp(1.45rem, 6.5vw, 2rem)
- Reduce hero/status panel padding and gaps
- Status grid: 2 columns of compact chips instead of 1-column tall list
- Hide status header subtitle and option card descriptions/examples
  (title + subtitle are sufficient to make a choice on small screens)
- Options grid: repeat(2, 1fr) so 4 cards → 2×2, not a scrolling column
- Remove 280px/250px min-height from all menu option card variants
- Same treatment applied to LearningMenuLayout (TenseSelectionStep,
  TypeSelectionStep, DurationSelectionStep) via LearnTenseFlow.css

https://claude.ai/code/session_01KL7Z4FpjsCV4LpzJj7rkPr