### PR TITLE
feat(onboarding): VERB/OS dark brutalist redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,200..700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
     <title>VerbOS - Conjugador de Verbos en Español</title>
   </head>
   <body>

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -1,0 +1,482 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+.verbos-onboarding {
+  position: fixed;
+  inset: 0;
+  background: #0c0c0c;
+  color: #f4f1ea;
+  font-family: 'Inter Tight', -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'ss01', 'ss02', 'cv11';
+  overflow: hidden;
+  z-index: 200;
+}
+
+.verbos-onboarding * {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+.verbos-onboarding ::selection {
+  background: #ff4d1c;
+  color: #0c0c0c;
+}
+
+/* ── Scrollbar hidden ── */
+.vo-noscroll::-webkit-scrollbar { display: none; }
+.vo-noscroll { scrollbar-width: none; }
+
+/* ── Keyframes ── */
+@keyframes voBlink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes voScanIn {
+  from { clip-path: inset(0 100% 0 0); }
+  to   { clip-path: inset(0 0% 0 0); }
+}
+
+@keyframes voLiftIn {
+  from { transform: translateY(10px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+.vo-scan-in {
+  animation: voScanIn 0.45s cubic-bezier(0.7, 0, 0.2, 1) both;
+}
+
+.vo-lift-in {
+  animation: voLiftIn 0.3s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+.vo-cursor {
+  animation: voBlink 1s steps(2) infinite;
+}
+
+/* ── Layout shell ── */
+.vo-header {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-bottom: 1px solid #1f1d18;
+  background: #0c0c0c;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #6e6a60;
+  z-index: 50;
+}
+
+.vo-footer {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-top: 1px solid #1f1d18;
+  background: #0c0c0c;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #2a2823;
+  z-index: 50;
+}
+
+.vo-footer-hints { display: flex; gap: 16px; }
+.vo-footer-hints span { white-space: nowrap; }
+.vo-footer-hints em { font-style: normal; color: #6e6a60; }
+
+.vo-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.vo-logo-dot {
+  width: 8px;
+  height: 8px;
+  background: #ff4d1c;
+  flex-shrink: 0;
+}
+
+.vo-logo-name {
+  color: #f4f1ea;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+.vo-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  max-width: 40%;
+}
+
+.vo-breadcrumb-sep { color: #2a2823; }
+.vo-breadcrumb-label { color: #6e6a60; }
+.vo-breadcrumb-val { color: #f4f1ea; margin-left: 4px; }
+
+.vo-step-counter span { color: #f4f1ea; }
+
+/* ── Background grid ── */
+.vo-grid {
+  position: fixed;
+  inset: 44px 0 32px 0;
+  background-image:
+    linear-gradient(#1f1d18 1px, transparent 1px),
+    linear-gradient(90deg, #1f1d18 1px, transparent 1px);
+  background-size: 64px 64px;
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.vo-vignette {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,0.5) 100%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.vo-crosshair {
+  position: fixed;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ── Two-panel step view ── */
+.vo-step {
+  position: absolute;
+  top: 44px; bottom: 32px; left: 0; right: 0;
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  z-index: 3;
+}
+
+.vo-left {
+  position: relative;
+  padding: 40px 40px 32px 56px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-right: 1px solid #1f1d18;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.vo-step-tag {
+  position: absolute;
+  top: 24px; right: 24px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: #2a2823;
+}
+
+.vo-watermark {
+  position: absolute;
+  top: 54px; right: 24px;
+  font-family: 'Inter Tight', sans-serif;
+  font-size: clamp(160px, 26vw, 400px);
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: -0.06em;
+  color: #2a2823;
+  line-height: 0.78;
+  pointer-events: none;
+  opacity: 0.45;
+  user-select: none;
+}
+
+.vo-left-bottom {
+  position: relative;
+  z-index: 2;
+  margin-top: auto;
+}
+
+.vo-aux {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: #6e6a60;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.vo-prompt {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 22px;
+  font-weight: 300;
+  color: #6e6a60;
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+
+.vo-focal-word {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: -0.055em;
+  line-height: 0.9;
+  text-transform: lowercase;
+  overflow-wrap: break-word;
+  word-break: normal;
+  hyphens: none;
+  max-width: 100%;
+  margin-bottom: 18px;
+}
+
+.vo-meta {
+  display: flex;
+  gap: 20px;
+  padding-top: 16px;
+  border-top: 1px dashed #2a2823;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.vo-meta-item { display: flex; flex-direction: column; gap: 4px; }
+.vo-meta-key { color: #2a2823; }
+.vo-meta-val { color: #f4f1ea; }
+.vo-meta-ex { font-style: italic; text-transform: none; letter-spacing: 0.04em; }
+
+.vo-meta-right { margin-left: auto; text-align: right; }
+
+/* ── Right panel ── */
+.vo-right {
+  position: relative;
+  padding: 40px 56px 32px 40px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0;
+}
+
+.vo-options-label {
+  position: absolute;
+  top: 24px; left: 40px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  color: #2a2823;
+}
+
+.vo-options-list { display: flex; flex-direction: column; }
+
+.vo-option {
+  position: relative;
+  border-bottom: 1px solid #1f1d18;
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  transition: padding-left 0.18s cubic-bezier(0.2, 0.9, 0.3, 1);
+}
+
+.vo-option:last-child { border-bottom: none; }
+
+.vo-option-num {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: color 0.15s;
+}
+
+.vo-option-num-box {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  border: 1px solid;
+  flex-shrink: 0;
+  transition: border-color 0.15s;
+}
+
+.vo-option-tick {
+  width: 28px;
+  height: 1px;
+  margin-left: 4px;
+}
+
+.vo-option-label {
+  font-family: 'Inter Tight', sans-serif;
+  letter-spacing: -0.025em;
+  text-transform: lowercase;
+  line-height: 1.05;
+  transition: all 0.15s;
+  flex: 1;
+  min-width: 0;
+}
+
+.vo-option-tag {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: color 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.vo-option-arrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  width: 16px;
+  transition: all 0.18s;
+  flex-shrink: 0;
+}
+
+/* ── Placement test overlay ── */
+.vo-placement-overlay {
+  position: absolute;
+  top: 44px; bottom: 32px; left: 0; right: 0;
+  z-index: 10;
+  background: #0c0c0c;
+  overflow-y: auto;
+  display: flex;
+  align-items: flex-start;
+  padding: 32px 56px;
+}
+
+/* ── Placement report modal ── */
+.placement-report-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  padding: 24px;
+}
+
+.placement-report-modal {
+  background: #141412;
+  border: 1px solid #1f1d18;
+  max-width: 560px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 40px;
+  font-family: 'JetBrains Mono', monospace;
+  color: #f4f1ea;
+}
+
+.placement-report-header { margin-bottom: 32px; }
+.placement-report-header h3 {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 28px;
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: -0.03em;
+  margin-bottom: 8px;
+}
+.placement-report-header p { font-size: 11px; letter-spacing: 0.12em; color: #6e6a60; text-transform: uppercase; }
+
+.placement-report-summary {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.summary-card {
+  border: 1px solid #1f1d18;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.summary-label { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: #6e6a60; }
+.summary-value { font-size: 28px; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-style: italic; }
+
+.placement-report-section { margin-bottom: 20px; }
+.placement-report-section h4 { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: #6e6a60; margin-bottom: 10px; }
+.placement-report-section ul { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.placement-report-section li { font-size: 12px; letter-spacing: 0.06em; padding: 8px 0; border-bottom: 1px solid #1f1d18; }
+
+.placement-report-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+
+.placement-report-button {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border: none;
+  padding: 14px 18px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.placement-report-button:hover { opacity: 0.8; }
+.placement-report-button.primary { background: #ff4d1c; color: #0c0c0c; flex: 1; }
+.placement-report-button.secondary { background: transparent; color: #f4f1ea; border: 1px solid #1f1d18; }
+.placement-report-button.ghost { background: transparent; color: #6e6a60; }
+
+/* ── Mobile ── */
+@media (max-width: 680px) {
+  .vo-step {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+    overflow-y: auto;
+  }
+
+  .vo-left {
+    border-right: none;
+    border-bottom: 1px solid #1f1d18;
+    padding: 28px 20px 24px 20px;
+    min-height: 220px;
+  }
+
+  .vo-watermark { font-size: clamp(80px, 28vw, 160px); }
+
+  .vo-right {
+    padding: 20px 20px 20px 20px;
+    justify-content: flex-start;
+    overflow-y: auto;
+  }
+
+  .vo-options-label { top: 8px; left: 20px; }
+  .vo-right { padding-top: 36px; }
+
+  .vo-breadcrumb { display: none; }
+
+  .vo-footer-hints { gap: 10px; }
+
+  .vo-left-bottom { margin-top: 20px; }
+}

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -1,381 +1,413 @@
-/**
- * OnboardingFlow.jsx - Componente principal del flujo de configuración inicial
- * 
- * Este componente orquesta el proceso de configuración inicial del usuario,
- * guiándolo a través de múltiples pasos para personalizar su experiencia de práctica.
- * 
- * @component
- * @description
- * Responsabilidades principales:
- * - Gestión del flujo multi-paso de onboarding (7 pasos máximo)
- * - Coordinación entre diferentes paneles de selección
- * - Manejo de navegación hacia atrás usando historial del navegador
- * - Integración con sistema de configuraciones globales
- * - Transición fluida hacia modo de práctica configurado
- * 
- * Flujo de pasos del onboarding:
- * 1. DialectSelection: Selección de dialecto regional (rioplatense/general/peninsular)
- * 2. LevelSelection: Modo básico de selección de nivel o navegación avanzada
- * 3. LevelSelection (detalles): Selección específica de nivel CEFR con descripción
- * 4. PracticeModeSelection: Elección entre práctica mixta o específica por tiempo
- * 5. MoodTenseSelection | VerbTypeSelection: Configuración específica según modo
- * 6. VerbTypeSelection: Tipo de verbos (regular/irregular/familia específica)
- * 7. FamilySelection: Selección de familias irregulares específicas
- * 
- * @example
- * ```jsx
- * // Uso típico desde AppRouter
- * <OnboardingFlow 
- *   onStartPractice={handleStartPractice}
- *   setCurrentMode={setCurrentMode}
- *   onboardingStep={onboardingFlow.onboardingStep}
- *   selectDialect={onboardingFlow.selectDialect}
- *   selectLevel={onboardingFlow.selectLevel}
- *   // ... otros props del hook onboardingFlow
- * />
- * ```
- * 
- * @param {Object} props - Propiedades del componente
- * @param {Function} props.onStartPractice - Callback para iniciar práctica configurada
- * @param {Function} props.setCurrentMode - Setter para cambiar modo de aplicación
- * @param {Function} props.onStartLearningNewTense - Iniciar flujo de aprendizaje estructurado
- * @param {number} props.onboardingStep - Paso actual del onboarding (1-7)
- * @param {Function} props.selectDialect - Seleccionar dialecto y avanzar
- * @param {Function} props.selectLevel - Seleccionar nivel CEFR
- * @param {Function} props.selectPracticeMode - Seleccionar modo de práctica
- * @param {Function} props.selectMood - Seleccionar modo verbal
- * @param {Function} props.selectTense - Seleccionar tiempo verbal específico
- * @param {Function} props.selectVerbType - Seleccionar tipo de verbos
- * @param {Function} props.selectFamily - Seleccionar familia irregular específica
- * @param {Function} props.goToLevelDetails - Navegar a detalles de nivel
- * @param {Function} props.handleHome - Navegar al menú principal con limpieza de estado
- * @param {Object} props.settings - Configuraciones globales de usuario (Zustand store)
- * @param {Function} props.getAvailableMoodsForLevel - Obtener modos disponibles por nivel
- * @param {Function} props.getAvailableTensesForLevelAndMood - Obtener tiempos por nivel/modo
- * @param {Function} props.getModeSamples - Obtener ejemplos para modos de práctica
- * @param {Function} props.getConjugationExample - Obtener ejemplo de conjugación
- * @param {Function} props.onGoToProgress - Navegar al dashboard de progreso
- * 
- * @requires DialectSelection - Selección de dialecto regional
- * @requires LevelSelection - Selección de nivel CEFR con opciones avanzadas
- * @requires PracticeModeSelection - Elección de modo de práctica
- * @requires MoodTenseSelection - Selección específica de tiempo verbal
- * @requires VerbTypeSelection - Selección de tipo de verbos
- * @requires FamilySelection - Selección de familias irregulares
- * @requires ClickableCard - Componente base de interfaz
- * 
- * @see {@link ./DialectSelection.jsx} - Selección de dialecto
- * @see {@link ./LevelSelection.jsx} - Selección de nivel
- * @see {@link ./MoodTenseSelection.jsx} - Selección de tiempo específico
- * @see {@link ../../hooks/useOnboardingFlow.js} - Hook de lógica del flujo
- */
-
-import React from 'react'
-import DialectSelection from './DialectSelection.jsx'
-import LevelSelection from './LevelSelection.jsx'
-import PracticeModeSelection from './PracticeModeSelection.jsx'
-import MoodTenseSelection from './MoodTenseSelection.jsx'
-import VerbTypeSelection from './VerbTypeSelection.jsx'
-import FamilySelection from './FamilySelection.jsx'
-import ClickableCard from '../shared/ClickableCard.jsx'
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import './OnboardingFlow.css'
 import PlacementTest from '../levels/PlacementTest.jsx'
-import { getStepMeta } from './menuMetadata.js'
+import { getTensesForMood, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
+import { getFamiliesForMood, getFamiliesForTense } from '../../lib/data/irregularFamilies.js'
+import {
+  getSimplifiedGroupsForMood,
+  getSimplifiedGroupsForTense,
+  shouldUseSimplifiedGroupingForMood,
+  shouldUseSimplifiedGrouping,
+} from '../../lib/data/simplifiedFamilyGroups.js'
 
-/**
- * Componente principal del flujo de configuración inicial
- * 
- * @param {Object} props - Propiedades del componente según la documentación JSDoc superior
- * @returns {JSX.Element} El componente de flujo de onboarding
- */
-function OnboardingFlow({
-  onStartPractice,
-  setCurrentMode,
-  onStartLearningNewTense,
-  // Hook functions from AppRouter
-  onboardingStep,
-  selectDialect,
-  selectLevel,
-  selectPracticeMode,
-  selectMood,
-  selectTense,
-  selectVerbType,
-  selectFamily,
-  // goBack, // Commented out - currently unused
-  goToLevelDetails,
-  handleHome,
-  settings,
-  getAvailableMoodsForLevel,
-  getAvailableTensesForLevelAndMood,
-  getModeSamples,
-  getConjugationExample,
-  onGoToProgress
-}) {
+/* ── Design tokens ── */
+const ACCENT = '#ff4d1c'
+const INK    = '#f4f1ea'
+const INK2   = '#6e6a60'
+const INK3   = '#2a2823'
+const LINE   = '#1f1d18'
 
-  const [showLevelTest, setShowLevelTest] = React.useState(false)
-  const [showPlacementSummary, setShowPlacementSummary] = React.useState(false)
-  const [lastPlacementResult, setLastPlacementResult] = React.useState(null)
-  const [reportSaved, setReportSaved] = React.useState(false)
-  const stepMeta = getStepMeta(onboardingStep, settings)
-  const shellLayout = stepMeta.layout || 'split'
+/* ── Static option datasets ── */
+const MOOD_OPTS = [
+  { id: 'indicative',  label: 'indicativo',      tag: 'FINITAS',    gloss: 'hechos · hábitos · relato',   ex: 'yo hablo' },
+  { id: 'subjunctive', label: 'subjuntivo',       tag: 'FINITAS',    gloss: 'hipótesis · deseo · matiz',   ex: 'yo hable' },
+  { id: 'imperative',  label: 'imperativo',       tag: 'MANDATO',    gloss: 'órdenes',                     ex: 'tú habla / vos hablá' },
+  { id: 'conditional', label: 'condicional',      tag: 'HIPÓTESIS',  gloss: 'consecuencia · cortesía',     ex: 'yo hablaría' },
+  { id: 'nonfinite',   label: 'no conjugadas',    tag: 'NO FINITAS', gloss: 'inf · ger · part',            ex: 'hablando · hablado' },
+]
 
-  // Wrap handlers to add toasts
-  // Wrap handlers to add toasts
-  const handleSelectDialect = (d) => {
-    try {
-      selectDialect(d)
-    } catch (error) {
-      console.error('Error selecting dialect:', error)
-    }
-  }
-  const handleSelectLevel = (lvl) => {
-    try {
-      selectLevel(lvl)
-    } catch (error) {
-      console.error('Error selecting level:', error)
-    }
-  }
-  const handleSelectPracticeMode = (mode) => {
-    try {
-      selectPracticeMode(mode, onStartPractice);
-    } catch (error) {
-      console.error('Error selecting practice mode:', error)
-    }
-  }
-  const handleSelectMood = (mood) => {
-    try {
-      selectMood(mood)
-    } catch (error) {
-      console.error('Error selecting mood:', error)
-    }
-  }
-  const handleSelectTense = (tense) => {
-    try {
-      selectTense(tense)
-    } catch (error) {
-      console.error('Error selecting tense:', error)
-    }
-  }
-  const handleSelectVerbType = (verbType, onStart) => {
-    try {
-      selectVerbType(verbType, onStart)
-    } catch (error) {
-      console.error('Error selecting verb type:', error)
-    }
-  }
-  const handleSelectFamily = (familyId, onStart) => {
-    try {
-      selectFamily(familyId, onStart)
-    } catch (error) {
-      console.error('Error selecting family:', error)
-    }
+const VERB_TYPE_OPTS = [
+  { id: 'all',       label: 'todos',       tag: 'AMPLIO',  gloss: 'sin filtro',      ex: 'reg · irreg' },
+  { id: 'regular',   label: 'regulares',   tag: 'SISTEMA', gloss: 'siguen la regla', ex: 'hablar · comer · vivir' },
+  { id: 'irregular', label: 'irregulares', tag: 'TENSIÓN', gloss: 'casos duros',     ex: 'ser · estar · tener · ir' },
+]
+
+const FALLBACK_FAMILIES = [
+  { id: 'G_VERBS',   name: 'Irregulares en YO',  description: 'tener, poner, salir, conocer, vencer' },
+  { id: 'UIR_Y',     name: '-uir (inserción y)',  description: 'construir, huir' },
+  { id: 'PRET_UV',   name: 'Pretérito -uv-',      description: 'andar, estar, tener' },
+  { id: 'PRET_U',    name: 'Pretérito -u-',       description: 'poder, poner, saber' },
+  { id: 'PRET_J',    name: 'Pretérito -j-',       description: 'decir, traer' },
+]
+
+/* ── Family options builder ── */
+function buildFamilyOptions(settings, selectFamily, onStartPractice) {
+  const { specificTense, specificMood } = settings
+
+  const allOpt = {
+    id: '__all__',
+    label: 'todas las familias',
+    tag: 'AMPLIO',
+    gloss: 'sin filtrar',
+    ex: 'máxima variedad',
+    onSelect: () => selectFamily(null, onStartPractice),
   }
 
-  // Level test handlers
-  const handleStartLevelTest = () => {
-    setShowLevelTest(true)
+  let groups = []
+  if (specificTense && shouldUseSimplifiedGrouping(specificTense)) {
+    groups = getSimplifiedGroupsForTense(specificTense) || []
+  } else if (specificMood && !specificTense && shouldUseSimplifiedGroupingForMood(specificMood)) {
+    groups = getSimplifiedGroupsForMood(specificMood) || []
   }
 
-  const handleLevelTestComplete = (result) => {
-    setShowLevelTest(false)
-    if (result) {
-      setLastPlacementResult(result)
-      setShowPlacementSummary(Boolean(result.report))
-      setReportSaved(Boolean(result.report && settings.placementTestReport && settings.placementTestReport.testId === result.report.testId))
-    }
-    if (result && result.determinedLevel) {
-      selectLevel(result.determinedLevel)
-    }
+  if (groups.length > 0) {
+    return [
+      allOpt,
+      ...groups.map(g => ({
+        id: g.id,
+        label: g.name,
+        tag: 'GRUPO',
+        gloss: g.explanation || '',
+        ex: g.description || '',
+        onSelect: () => selectFamily(g.id, onStartPractice),
+      })),
+    ]
   }
 
-  const handleLevelTestCancel = () => {
-    setShowLevelTest(false)
-  }
+  const families = specificTense
+    ? getFamiliesForTense(specificTense)
+    : specificMood
+      ? getFamiliesForMood(specificMood)
+      : FALLBACK_FAMILIES
 
-  const handleSavePlacementReport = () => {
-    if (!lastPlacementResult?.report) return
-    if (typeof settings.setPlacementTestReport === 'function') {
-      settings.setPlacementTestReport(lastPlacementResult.report)
-      setReportSaved(true)
-    }
-  }
-
-  const handleRetakePlacementTest = () => {
-    setShowPlacementSummary(false)
-    setShowLevelTest(true)
-  }
-
-  const handleClosePlacementSummary = () => {
-    setShowPlacementSummary(false)
-  }
-
-  // Unified back behavior: use browser history for both UI and hardware back
-  const handleBack = () => {
-    try {
-      window.history.back()
-    } catch {
-      /* ignore */
-    }
-  }
-
-  return (
-    <div className="App">
-      <div className="onboarding main-menu-onboarding">
-        <div className="center-column">
-          {showPlacementSummary && lastPlacementResult?.report && (
-            <PlacementReportModal
-              result={lastPlacementResult}
-              reportSaved={reportSaved}
-              onClose={handleClosePlacementSummary}
-              onRetake={handleRetakePlacementTest}
-              onSave={handleSavePlacementReport}
-            />
-          )}
-
-          {/* Show level test if active */}
-          {showLevelTest ? (
-            <PlacementTest
-              onComplete={handleLevelTestComplete}
-              onCancel={handleLevelTestCancel}
-            />
-          ) : (
-            <>
-              <section className={`menu-shell menu-shell-${shellLayout}`} data-step={stepMeta.step}>
-                <header className={`menu-hero menu-hero-${shellLayout}`}>
-                  <div className="menu-hero-main">
-                    <div className="menu-step-line">
-                      <span className="menu-step-index">{stepMeta.step}</span>
-                      <span className="menu-step-kicker">{stepMeta.kicker}</span>
-                    </div>
-                    <h1>{stepMeta.title}</h1>
-                    <p className="menu-hero-description">{stepMeta.description}</p>
-                  </div>
-
-                  <div className="menu-brand-column">
-                    <ClickableCard className="app-logo" onClick={() => handleHome(setCurrentMode)} title="Ir al menú ¿Qué querés practicar?">
-                      <img src="/verbosmain_transparent.png" alt="VerbOS" width="160" height="160" />
-                    </ClickableCard>
-
-                    <div className="menu-brand-caption">
-                      <span>VERBOS</span>
-                      <span>Sistema de menús</span>
-                    </div>
-                  </div>
-                </header>
-
-              </section>
-
-              {/* Step 1: Dialect Selection */}
-              {onboardingStep === 1 && (
-                <DialectSelection onSelectDialect={handleSelectDialect} />
-              )}
-
-              {/* Step 2: Level Selection Mode */}
-              {onboardingStep === 2 && (
-                <LevelSelection
-                  onSelectLevel={handleSelectLevel}
-                  onSelectPracticeMode={handleSelectPracticeMode}
-                  onGoToLevelDetails={goToLevelDetails}
-                  onBack={handleBack}
-                  showLevelDetails={false}
-                  onGoToProgress={onGoToProgress}
-                  onStartLearningNewTense={onStartLearningNewTense}
-                  onStartLevelTest={handleStartLevelTest}
-                />
-              )}
-
-              {/* Step 3: Specific Level Selection */}
-              {onboardingStep === 3 && (
-                <LevelSelection
-                  onSelectLevel={handleSelectLevel}
-                  onSelectPracticeMode={handleSelectPracticeMode}
-                  onGoToLevelDetails={goToLevelDetails}
-                  onBack={handleBack}
-                  showLevelDetails={true}
-                  onStartLevelTest={handleStartLevelTest}
-                />
-              )}
-
-              {/* Step 4: Practice Mode Selection */}
-              {onboardingStep === 4 && (
-                <PracticeModeSelection
-                  onSelectPracticeMode={handleSelectPracticeMode}
-                  onBack={handleBack}
-                  settings={settings}
-                />
-              )}
-
-              {/* Step 5: MoodTenseSelection (for theme practice) OR VerbTypeSelection (for mixed practice) */}
-              {onboardingStep === 5 && (
-                <>
-                  {settings.practiceMode === 'mixed' ? (
-                    <VerbTypeSelection
-                      onSelectVerbType={(verbType) => handleSelectVerbType(verbType, onStartPractice)}
-                      onBack={handleBack}
-                    />
-                  ) : (
-                    <MoodTenseSelection
-                      settings={settings}
-                      onSelectMood={handleSelectMood}
-                      onSelectTense={handleSelectTense}
-                      onBack={handleBack}
-                      getAvailableMoodsForLevel={getAvailableMoodsForLevel}
-                      getAvailableTensesForLevelAndMood={getAvailableTensesForLevelAndMood}
-                      getModeSamples={getModeSamples}
-                      getConjugationExample={getConjugationExample}
-                    />
-                  )}
-                </>
-              )}
-
-              {/* Step 6: MoodTenseSelection for mixed practice OR Tense selection after mood in theme practice */}
-              {onboardingStep === 6 && (
-                <>
-                  {settings.practiceMode === 'mixed' && settings.verbType === 'irregular' && !(settings.specificMood === 'nonfinite' && (settings.specificTense === 'ger' || settings.specificTense === 'nonfiniteMixed')) ? (
-                    <FamilySelection
-                      settings={settings}
-                      onSelectFamily={(familyId) => handleSelectFamily(familyId, onStartPractice)}
-                      onBack={handleBack}
-                    />
-                  ) : (
-                    <MoodTenseSelection
-                      settings={settings}
-                      onSelectMood={handleSelectMood}
-                      onSelectTense={handleSelectTense}
-                      onBack={handleBack}
-                      getAvailableMoodsForLevel={getAvailableMoodsForLevel}
-                      getAvailableTensesForLevelAndMood={getAvailableTensesForLevelAndMood}
-                      getModeSamples={getModeSamples}
-                      getConjugationExample={getConjugationExample}
-                    />
-                  )}
-                </>
-              )}
-
-              {/* Step 7: VerbTypeSelection for any practice mode */}
-              {onboardingStep === 7 && (
-                <VerbTypeSelection
-                  onSelectVerbType={(verbType) => handleSelectVerbType(verbType, onStartPractice)}
-                  onBack={handleBack}
-                />
-              )}
-
-              {/* Step 8: Family Selection for Irregular Verbs */}
-              {onboardingStep === 8 && settings.verbType === 'irregular' && !(settings.specificMood === 'nonfinite' && (settings.specificTense === 'ger' || settings.specificTense === 'nonfiniteMixed')) && (
-                <FamilySelection
-                  settings={settings}
-                  onSelectFamily={(familyId) => handleSelectFamily(familyId, onStartPractice)}
-                  onBack={handleBack}
-                />
-              )}
-            </>
-          )}
-        </div>
-
-      </div>
-    </div>
-  );
+  return [
+    allOpt,
+    ...((families || FALLBACK_FAMILIES).slice(0, 8).map(f => ({
+      id: f.id,
+      label: f.name,
+      tag: 'FAMILIA',
+      gloss: f.description || '',
+      ex: f.description || '',
+      onSelect: () => selectFamily(f.id, onStartPractice),
+    }))),
+  ]
 }
 
+/* ── Step config builder ── */
+function buildStep(step, settings, handlers) {
+  const {
+    selectDialect, selectLevel, selectPracticeMode, selectMood, selectTense,
+    selectVerbType, selectFamily, goToLevelDetails, onStartPractice,
+    onGoToProgress, onStartLearningNewTense, onStartLevelTest,
+    getAvailableMoodsForLevel, getAvailableTensesForLevelAndMood,
+  } = handlers
+
+  switch (step) {
+    case 1:
+      return {
+        n: '01', kicker: 'VARIANTE',
+        prompt: 'Hablás...', aux: 'Definí el sistema pronominal antes de empezar.',
+        options: [
+          { id: 'rioplatense', label: 'vos',           tag: 'AR · UY', gloss: 'rioplatense', ex: 'vos tenés / vos hablás', onSelect: () => selectDialect('rioplatense') },
+          { id: 'la_general',  label: 'tú',            tag: 'LATAM',   gloss: 'estándar',    ex: 'tú tienes / tú hablas',  onSelect: () => selectDialect('la_general') },
+          { id: 'peninsular',  label: 'tú · vosotros', tag: 'ES',      gloss: 'peninsular',  ex: 'vosotros tenéis',        onSelect: () => selectDialect('peninsular') },
+          { id: 'both',        label: 'todos',          tag: 'MIX',     gloss: 'sin filtro',  ex: 'tú · vos · vosotros',   onSelect: () => selectDialect('both') },
+        ],
+      }
+
+    case 2:
+      return {
+        n: '02', kicker: 'ENTRADA',
+        prompt: 'Querés...', aux: 'Cuatro accesos. Cada uno con su lógica.',
+        options: [
+          { id: 'levels',   label: 'practicar por nivel', tag: 'A1 → C2', gloss: 'progresión cefr', ex: 'recorrido estructurado',    onSelect: goToLevelDetails },
+          { id: 'theme',    label: 'practicar por tema',  tag: 'FOCO',    gloss: 'tiempo verbal',   ex: 'presente · subjuntivo · etc.', onSelect: () => selectPracticeMode('theme', onStartPractice) },
+          { id: 'learn',    label: 'aprender',            tag: 'GUIADO',  gloss: 'lecciones',       ex: 'explicación + drill',        onSelect: onStartLearningNewTense },
+          { id: 'progress', label: 'ver mi progreso',     tag: 'DATA',    gloss: 'analíticas',      ex: 'mapa de calor + srs',        onSelect: onGoToProgress },
+        ],
+      }
+
+    case 3:
+      return {
+        n: '03', kicker: 'NIVEL',
+        prompt: 'Tu nivel es...', aux: 'Elegí un tramo CEFR o dejá que el test te ubique.',
+        options: [
+          { id: 'A1',   label: 'A1',           tag: 'PRINCIPIANTE', gloss: 'acceso',               ex: 'presente',               onSelect: () => selectLevel('A1') },
+          { id: 'A2',   label: 'A2',           tag: 'ELEMENTAL',    gloss: 'base',                  ex: 'pretéritos · futuro',    onSelect: () => selectLevel('A2') },
+          { id: 'B1',   label: 'B1',           tag: 'INTERMEDIO',   gloss: 'tracción',              ex: 'condicional · perfectos',onSelect: () => selectLevel('B1') },
+          { id: 'B2',   label: 'B2',           tag: 'INTERMEDIO+',  gloss: 'precisión',             ex: 'subjuntivo imperfecto',  onSelect: () => selectLevel('B2') },
+          { id: 'C1',   label: 'C1',           tag: 'AVANZADO',     gloss: 'matiz',                 ex: 'discurso fluido',        onSelect: () => selectLevel('C1') },
+          { id: 'C2',   label: 'C2',           tag: 'SUPERIOR',     gloss: 'dominio',               ex: 'nativo completo',        onSelect: () => selectLevel('C2') },
+          ...(onStartLevelTest ? [{ id: 'test', label: 'test de nivel', tag: 'AUTO', gloss: 'diagnóstico adaptativo', ex: '5 min · te ubica', onSelect: onStartLevelTest }] : []),
+        ],
+      }
+
+    case 4:
+      return {
+        n: '04', kicker: 'FORMA',
+        prompt: 'Querés trabajar...', aux: 'Mezcla amplia o foco quirúrgico.',
+        options: [
+          { id: 'mixed',    label: 'todo mezclado',     tag: 'AMPLIO',  gloss: 'panorama', ex: 'todos los modos y tiempos', onSelect: () => selectPracticeMode('mixed', onStartPractice) },
+          { id: 'specific', label: 'un bloque puntual', tag: 'PRECISO', gloss: 'foco',     ex: 'un modo, un tiempo',        onSelect: () => selectPracticeMode('specific') },
+        ],
+      }
+
+    case 5: {
+      if (settings.practiceMode === 'mixed') {
+        return {
+          n: '05', kicker: 'MATERIAL',
+          prompt: 'Verbos...', aux: 'El generador filtra por tipo. La práctica no cambia.',
+          options: VERB_TYPE_OPTS.map(o => ({ ...o, onSelect: () => selectVerbType(o.id, onStartPractice) })),
+        }
+      }
+      const availMoods = settings.level && settings.practiceMode === 'specific'
+        ? getAvailableMoodsForLevel(settings.level).map(id => MOOD_OPTS.find(m => m.id === id)).filter(Boolean)
+        : MOOD_OPTS
+      return {
+        n: '05', kicker: 'MODO VERBAL',
+        prompt: 'Trabajás...', aux: 'Segmentá la práctica por bloque verbal.',
+        options: availMoods.map(o => ({ ...o, onSelect: () => selectMood(o.id) })),
+      }
+    }
+
+    case 6: {
+      if (settings.practiceMode === 'mixed' && settings.verbType === 'irregular') {
+        return {
+          n: '06', kicker: 'FAMILIA IRREGULAR',
+          prompt: 'Foco en...', aux: 'Acotá la familia para un drill más deliberado.',
+          options: buildFamilyOptions(settings, selectFamily, onStartPractice),
+        }
+      }
+      if (!settings.specificMood) return null
+      const tenses = settings.level
+        ? getAvailableTensesForLevelAndMood(settings.level, settings.specificMood)
+        : getTensesForMood(settings.specificMood)
+      const moodTag = getMoodLabel(settings.specificMood).toUpperCase().slice(0, 3)
+      return {
+        n: '06', kicker: 'TIEMPO',
+        prompt: 'Atacás...', aux: 'Recorte exacto del drill.',
+        options: tenses.map(t => ({
+          id: t,
+          label: getTenseLabel(t),
+          tag: moodTag,
+          gloss: getMoodLabel(settings.specificMood),
+          ex: '',
+          onSelect: () => selectTense(t),
+        })),
+      }
+    }
+
+    case 7:
+      return {
+        n: '07', kicker: 'TIPO',
+        prompt: 'Verbos...', aux: 'Último filtro antes de entrar al drill.',
+        options: VERB_TYPE_OPTS.map(o => ({ ...o, onSelect: () => selectVerbType(o.id, onStartPractice) })),
+      }
+
+    case 8: {
+      return {
+        n: '08', kicker: 'FAMILIAS',
+        prompt: 'Foco en...', aux: 'Si querés, trabajá patrones puntuales.',
+        options: buildFamilyOptions(settings, selectFamily, onStartPractice),
+      }
+    }
+
+    default:
+      return null
+  }
+}
+
+/* ── Breadcrumb builder ── */
+function buildBreadcrumb(settings) {
+  const items = []
+  const dialectMap = { rioplatense: 'vos', la_general: 'tú', peninsular: 'tú·vosotros', global: 'todos' }
+  if (settings.region) items.push({ label: 'DIALECTO', value: dialectMap[settings.region] || settings.region })
+  if (settings.level) items.push({ label: 'NIVEL', value: settings.level })
+  const modeMap = { mixed: 'mezclado', specific: 'específico', theme: 'por tema' }
+  if (settings.practiceMode) items.push({ label: 'MODO', value: modeMap[settings.practiceMode] || settings.practiceMode })
+  if (settings.specificMood) items.push({ label: 'MODO·V', value: getMoodLabel(settings.specificMood) })
+  return items.slice(-3)
+}
+
+/* ──────────────────────────────
+   StepView — two-panel layout
+────────────────────────────── */
+function StepView({ stepConfig, animKey, onSelect }) {
+  const [focusIdx, setFocusIdx] = useState(0)
+  const { n, kicker, prompt, aux, options } = stepConfig
+
+  useEffect(() => { setFocusIdx(0) }, [animKey])
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handle = (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setFocusIdx(i => Math.min(options.length - 1, i + 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setFocusIdx(i => Math.max(0, i - 1))
+      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        e.preventDefault()
+        onSelect(options[focusIdx])
+      } else if (/^[1-9]$/.test(e.key)) {
+        const idx = parseInt(e.key, 10) - 1
+        if (idx < options.length) { setFocusIdx(idx); onSelect(options[idx]) }
+      }
+    }
+    window.addEventListener('keydown', handle)
+    return () => window.removeEventListener('keydown', handle)
+  }, [focusIdx, options, onSelect])
+
+  const focused = options[focusIdx] || options[0]
+
+  // Dynamic font size for focal word
+  const len = (focused?.label || '').length
+  const lenFactor = len <= 6 ? 1 : len <= 10 ? 0.78 : len <= 16 ? 0.58 : len <= 22 ? 0.44 : 0.34
+  const focalSize = `clamp(44px, ${Math.max(5, 12 * lenFactor)}vw, ${Math.round(180 * lenFactor)}px)`
+  const optionFontSize = '26px'
+
+  return (
+    <div key={animKey} className="vo-step vo-lift-in">
+      {/* LEFT: focal word display */}
+      <div className="vo-left">
+        <div className="vo-step-tag">──── {kicker}</div>
+
+        {/* Ghost step number watermark */}
+        <div className="vo-watermark" aria-hidden="true">{n}</div>
+
+        <div className="vo-left-bottom">
+          <div className="vo-aux">▸ {aux}</div>
+          <div className="vo-prompt">{prompt}</div>
+
+          {/* Focal option — huge italic */}
+          <div
+            key={focused?.id ?? 'x'}
+            className="vo-focal-word vo-scan-in"
+            style={{ fontSize: focalSize, color: ACCENT }}
+          >
+            {focused?.label}
+            <span
+              className="vo-cursor"
+              style={{
+                display: 'inline-block',
+                width: '0.07em',
+                height: '0.68em',
+                background: ACCENT,
+                marginLeft: '0.05em',
+                verticalAlign: 'baseline',
+                transform: 'translateY(-0.05em)',
+              }}
+            />
+          </div>
+
+          {/* Metadata strip */}
+          {focused && (
+            <div className="vo-meta">
+              <div className="vo-meta-item">
+                <span className="vo-meta-key">TAG</span>
+                <span className="vo-meta-val">{focused.tag}</span>
+              </div>
+              <div className="vo-meta-item">
+                <span className="vo-meta-key">TIPO</span>
+                <span className="vo-meta-val">{focused.gloss}</span>
+              </div>
+              {focused.ex && (
+                <div className="vo-meta-item vo-meta-right">
+                  <span className="vo-meta-key">EJEMPLO</span>
+                  <span className="vo-meta-val vo-meta-ex" style={{ color: ACCENT }}>{focused.ex}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* RIGHT: option list */}
+      <div className="vo-right vo-noscroll">
+        <div className="vo-options-label">
+          OPCIONES · {String(options.length).padStart(2, '0')} ────
+        </div>
+
+        <div className="vo-options-list">
+          {options.map((opt, i) => {
+            const active = i === focusIdx
+            return (
+              <div
+                key={opt.id ?? i}
+                className="vo-option"
+                style={{ paddingLeft: active ? 76 : 52, paddingTop: 14, paddingBottom: 14 }}
+                onMouseEnter={() => setFocusIdx(i)}
+                onClick={() => onSelect(opt)}
+              >
+                {/* Number box */}
+                <div className="vo-option-num" style={{ color: active ? ACCENT : INK3 }}>
+                  <span className="vo-option-num-box" style={{ borderColor: active ? ACCENT : LINE }}>
+                    {i + 1}
+                  </span>
+                  {active && <span className="vo-option-tick" style={{ background: ACCENT }} />}
+                </div>
+
+                {/* Label */}
+                <div
+                  className="vo-option-label"
+                  style={{
+                    fontSize: optionFontSize,
+                    fontWeight: active ? 700 : 400,
+                    fontStyle: active ? 'italic' : 'normal',
+                    color: active ? INK : INK2,
+                  }}
+                >
+                  {opt.label}
+                </div>
+
+                {/* Tag */}
+                <div className="vo-option-tag" style={{ color: active ? ACCENT : INK3 }}>
+                  {opt.tag}
+                </div>
+
+                {/* Arrow */}
+                <div
+                  className="vo-option-arrow"
+                  style={{
+                    color: ACCENT,
+                    opacity: active ? 1 : 0,
+                    transform: active ? 'translateX(0)' : 'translateX(-6px)',
+                  }}
+                >
+                  →
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ────────────────────────────────────────────
+   Corner crosshairs — purely decorative
+──────────────────────────────────────────── */
+function Crosshairs() {
+  const positions = [
+    { top: 56, left: 12 },
+    { top: 56, right: 12 },
+    { bottom: 44, left: 12 },
+    { bottom: 44, right: 12 },
+  ]
+  return positions.map((pos, i) => (
+    <div key={i} className="vo-crosshair" style={pos}>
+      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+        <path d="M0 7H14M7 0V14" stroke={ACCENT} strokeWidth="1" />
+      </svg>
+    </div>
+  ))
+}
+
+/* ──────────────────────────────────────────
+   Placement report modal (kept from original)
+────────────────────────────────────────── */
 function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }) {
   const report = result.report
   const accuracy = report?.summary?.accuracy ? Math.round(report.summary.accuracy * 100) : 0
@@ -400,7 +432,7 @@ function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }
             <span className="summary-value">{accuracy}%</span>
           </div>
           <div className="summary-card">
-            <span className="summary-label">Promedio de respuesta</span>
+            <span className="summary-label">Promedio</span>
             <span className="summary-value">{averageSeconds}s</span>
           </div>
           <div className="summary-card">
@@ -413,8 +445,8 @@ function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }
           <section className="placement-report-section">
             <h4>Recomendaciones</h4>
             <ul>
-              {report.recommendations.map((recommendation, index) => (
-                <li key={`${report.testId}-rec-${index}`}>{recommendation}</li>
+              {report.recommendations.map((rec, idx) => (
+                <li key={`${report.testId}-rec-${idx}`}>{rec}</li>
               ))}
             </ul>
           </section>
@@ -428,7 +460,7 @@ function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }
                 const [mood, tense] = area.key.split('_')
                 return (
                   <li key={`${report.testId}-${area.key}`}>
-                    {`${tense} (${mood}) • Precisión ${(area.accuracy * 100).toFixed(0)}%`}
+                    {`${tense} (${mood}) · Precisión ${(area.accuracy * 100).toFixed(0)}%`}
                   </li>
                 )
               })}
@@ -437,9 +469,7 @@ function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }
         )}
 
         <footer className="placement-report-actions">
-          <button type="button" className="placement-report-button secondary" onClick={onRetake}>
-            Repetir test
-          </button>
+          <button type="button" className="placement-report-button secondary" onClick={onRetake}>Repetir test</button>
           <button
             type="button"
             className={`placement-report-button primary ${reportSaved ? 'saved' : ''}`}
@@ -447,13 +477,207 @@ function PlacementReportModal({ result, reportSaved, onClose, onRetake, onSave }
           >
             {reportSaved ? 'Actualizar guardado' : 'Guardar en ajustes'}
           </button>
-          <button type="button" className="placement-report-button ghost" onClick={onClose}>
-            Cerrar
-          </button>
+          <button type="button" className="placement-report-button ghost" onClick={onClose}>Cerrar</button>
         </footer>
       </div>
     </div>
   )
 }
 
-export default OnboardingFlow;
+/* ──────────────────────────────────────────
+   Main OnboardingFlow component
+────────────────────────────────────────── */
+function OnboardingFlow({
+  onStartPractice,
+  setCurrentMode,
+  onStartLearningNewTense,
+  onboardingStep,
+  selectDialect,
+  selectLevel,
+  selectPracticeMode,
+  selectMood,
+  selectTense,
+  selectVerbType,
+  selectFamily,
+  goToLevelDetails,
+  handleHome,
+  settings,
+  getAvailableMoodsForLevel,
+  getAvailableTensesForLevelAndMood,
+  onGoToProgress,
+}) {
+  const [showLevelTest, setShowLevelTest]             = useState(false)
+  const [showPlacementSummary, setShowPlacementSummary] = useState(false)
+  const [lastPlacementResult, setLastPlacementResult]   = useState(null)
+  const [reportSaved, setReportSaved]                   = useState(false)
+  const [animKey, setAnimKey]                           = useState(0)
+
+  // Bump animKey on step change to trigger animations
+  const prevStep = useRef(onboardingStep)
+  useEffect(() => {
+    if (onboardingStep !== prevStep.current) {
+      prevStep.current = onboardingStep
+      setAnimKey(k => k + 1)
+    }
+  }, [onboardingStep])
+
+  const handleStartLevelTest = useCallback(() => setShowLevelTest(true), [])
+
+  const handleLevelTestComplete = useCallback((result) => {
+    setShowLevelTest(false)
+    if (result) {
+      setLastPlacementResult(result)
+      setShowPlacementSummary(Boolean(result.report))
+      setReportSaved(Boolean(
+        result.report &&
+        settings.placementTestReport &&
+        settings.placementTestReport.testId === result.report.testId
+      ))
+    }
+    if (result?.determinedLevel) selectLevel(result.determinedLevel)
+  }, [selectLevel, settings.placementTestReport])
+
+  const handleSavePlacementReport = useCallback(() => {
+    if (!lastPlacementResult?.report) return
+    if (typeof settings.setPlacementTestReport === 'function') {
+      settings.setPlacementTestReport(lastPlacementResult.report)
+      setReportSaved(true)
+    }
+  }, [lastPlacementResult, settings])
+
+  const handleBack = useCallback(() => {
+    try { window.history.back() } catch { /* ignore */ }
+  }, [])
+
+  const handleLogoClick = useCallback(() => {
+    handleHome(setCurrentMode)
+  }, [handleHome, setCurrentMode])
+
+  // Global back keyboard shortcut
+  useEffect(() => {
+    const fn = (e) => {
+      if (showLevelTest) return
+      if (e.key === 'Escape' || e.key === 'ArrowLeft') {
+        e.preventDefault(); handleBack()
+      } else if (e.key === 'Backspace' && document.activeElement.tagName !== 'INPUT') {
+        e.preventDefault(); handleBack()
+      }
+    }
+    window.addEventListener('keydown', fn)
+    return () => window.removeEventListener('keydown', fn)
+  }, [handleBack, showLevelTest])
+
+  const handlers = useMemo(() => ({
+    selectDialect,
+    selectLevel,
+    selectPracticeMode,
+    selectMood,
+    selectTense,
+    selectVerbType,
+    selectFamily,
+    goToLevelDetails,
+    onStartPractice,
+    onGoToProgress,
+    onStartLearningNewTense,
+    onStartLevelTest: handleStartLevelTest,
+    getAvailableMoodsForLevel,
+    getAvailableTensesForLevelAndMood,
+  }), [
+    selectDialect, selectLevel, selectPracticeMode, selectMood, selectTense,
+    selectVerbType, selectFamily, goToLevelDetails, onStartPractice, onGoToProgress,
+    onStartLearningNewTense, handleStartLevelTest, getAvailableMoodsForLevel,
+    getAvailableTensesForLevelAndMood,
+  ])
+
+  const stepConfig = useMemo(
+    () => buildStep(onboardingStep, settings, handlers),
+    [onboardingStep, settings.practiceMode, settings.verbType, settings.specificMood, settings.level, settings.region, handlers]
+  )
+
+  const breadcrumb = useMemo(() => buildBreadcrumb(settings), [settings])
+
+  const handleOptionSelect = useCallback((opt) => {
+    opt.onSelect()
+  }, [])
+
+  const TOTAL_STEPS = 8
+
+  return (
+    <div className="verbos-onboarding">
+      {/* Background grid */}
+      <div className="vo-grid" aria-hidden="true" />
+      <div className="vo-vignette" aria-hidden="true" />
+      <Crosshairs />
+
+      {/* Top header */}
+      <header className="vo-header">
+        <div className="vo-logo" onClick={handleLogoClick} title="Ir al inicio">
+          <div className="vo-logo-dot" style={{ background: ACCENT }} />
+          <span className="vo-logo-name">
+            VERB<span style={{ color: ACCENT }}>/</span>OS
+          </span>
+          <span style={{ marginLeft: 8 }}>v0.1</span>
+        </div>
+
+        <div className="vo-breadcrumb" aria-label="Progreso de configuración">
+          {breadcrumb.length === 0
+            ? <span style={{ color: INK3 }}>— · —</span>
+            : breadcrumb.map((item, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <span className="vo-breadcrumb-sep">/</span>}
+                <span>
+                  <span className="vo-breadcrumb-label">{item.label}</span>
+                  <span className="vo-breadcrumb-val">{item.value}</span>
+                </span>
+              </React.Fragment>
+            ))
+          }
+        </div>
+
+        <div className="vo-step-counter" style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
+          STEP <span>{String(onboardingStep).padStart(2, '0')}</span> / {String(TOTAL_STEPS).padStart(2, '0')}
+        </div>
+      </header>
+
+      {/* Main content area */}
+      {showLevelTest ? (
+        <div className="vo-placement-overlay">
+          <PlacementTest
+            onComplete={handleLevelTestComplete}
+            onCancel={() => setShowLevelTest(false)}
+          />
+        </div>
+      ) : stepConfig ? (
+        <StepView
+          stepConfig={stepConfig}
+          animKey={animKey}
+          onSelect={handleOptionSelect}
+        />
+      ) : null}
+
+      {/* Placement report modal */}
+      {showPlacementSummary && lastPlacementResult?.report && (
+        <PlacementReportModal
+          result={lastPlacementResult}
+          reportSaved={reportSaved}
+          onClose={() => setShowPlacementSummary(false)}
+          onRetake={() => { setShowPlacementSummary(false); setShowLevelTest(true) }}
+          onSave={handleSavePlacementReport}
+        />
+      )}
+
+      {/* Bottom status bar */}
+      <footer className="vo-footer">
+        <div className="vo-footer-hints">
+          <span><em>↑↓</em> navegá</span>
+          <span><em>↵ / →</em> seleccioná</span>
+          <span><em>← / esc</em> volver</span>
+        </div>
+        <div style={{ color: INK2 }}>{stepConfig?.kicker}</div>
+        <div>SISTEMA · OK</div>
+      </footer>
+    </div>
+  )
+}
+
+export default OnboardingFlow


### PR DESCRIPTION
Complete visual overhaul of OnboardingFlow using the two-panel asymmetric design from the claude.ai/design handoff. Replaces the card-grid layout with a full-screen dark brutalist UI while keeping all existing hook logic and step branching intact.

Design system:
- Dark bg (#0c0c0c), ivory text (#f4f1ea), hot accent (#ff4d1c)
- Inter Tight (focal word, headings) + JetBrains Mono (labels, chrome)
- 64px background grid, radial vignette, SVG crosshairs at corners
- Fixed top bar: VERB/OS logo + breadcrumb + step counter
- Fixed bottom bar: keyboard hints + section label + status

Layout & interactions:
- Two-panel split: left = monumental italic focal word + metadata strip; right = numbered option list
- Keyboard nav: ↑↓ navigate, ↵/→ select, ←/Esc/Backspace go back, 1–9 jump
- scan-in clip-path animation on focal word swap
- lift-in animation on step transitions
- Mouse hover syncs with keyboard focus state
- All 8 onboarding steps covered (dialect → entry → level → mode → verb type → mood → tense → family) including placement test overlay and placement report modal