### PR TITLE
feat(learning): apply VERB/OS dark brutalist design to learning modul…

### DIFF
--- a/src/components/learning/DurationSelectionStep.jsx
+++ b/src/components/learning/DurationSelectionStep.jsx
@@ -1,6 +1,5 @@
-import React from 'react'
-import MenuOptionCard from '../onboarding/MenuOptionCard.jsx'
-import LearningMenuLayout from './LearningMenuLayout.jsx'
+import React, { useMemo } from 'react'
+import LearningStepView from './LearningStepView.jsx'
 import { getSessionDurationOptions as getDefaultDurationOptions } from '../../lib/learning/learningConfig.js'
 
 function DurationSelectionStep({
@@ -11,49 +10,44 @@ function DurationSelectionStep({
   onHome,
   durationOptions = getDefaultDurationOptions()
 }) {
+  const options = useMemo(() =>
+    durationOptions.map(d => ({
+      id: String(d.minutes),
+      label: d.label,
+      tag: `${d.minutes}M`,
+      gloss: d.title || d.label,
+      ex: d.description,
+      onSelect: () => {
+        onSelectDuration(d.minutes)
+        // Avanza automáticamente si ya hay una duración seleccionada o si se confirma la misma
+        if (selectedDuration === d.minutes) {
+          onStart?.()
+        }
+      },
+    })),
+    [durationOptions, selectedDuration, onSelectDuration, onStart]
+  )
+
+  const stepConfig = {
+    n: '03',
+    kicker: 'DURACIÓN',
+    prompt: 'La sesión dura...',
+    aux: 'Ajustá el bloque antes de entrar al recorrido guiado.',
+    options,
+  }
+
   return (
-    <LearningMenuLayout
-      step="03"
-      kicker="SESIÓN"
-      title="Definí la duración"
-      description="Ajustá el tamaño de la sesión antes de entrar al recorrido guiado. Podés usar una pasada breve o una tanda más profunda."
-      onHome={onHome}
-      footer={(
-        <button className="back-btn" onClick={onBack}>
-          <img src="/back.png" alt="Volver" className="back-icon" />
-        </button>
-      )}
-    >
-        <div className="tense-section">
-          <h2>Duración de la sesión</h2>
-
-          <div className="options-grid">
-            {durationOptions.map(durationConfig => (
-              <MenuOptionCard
-                key={durationConfig.minutes}
-                className={`learning-option-card${selectedDuration === durationConfig.minutes ? ' selected' : ''}`}
-                eyebrow="RITMO"
-                badge={`${durationConfig.minutes}M`}
-                title={durationConfig.label}
-                subtitle={durationConfig.title}
-                description="Configura la longitud del bloque guiado."
-                detail={durationConfig.description}
-                onClick={() => onSelectDuration(durationConfig.minutes)}
-                cardTitle={durationConfig.title}
-              />
-            ))}
-          </div>
-
-          {selectedDuration && (
-            <button
-              className="btn start-learning-btn"
-              onClick={onStart}
-            >
-              Continuar
-            </button>
-          )}
-        </div>
-    </LearningMenuLayout>
+    <LearningStepView
+      stepConfig={stepConfig}
+      onBack={onBack}
+      breadcrumb={[
+        { label: 'FLUJO', value: 'aprender' },
+        { label: 'SESIÓN', value: selectedDuration ? `${selectedDuration}min` : '—' },
+      ]}
+      stepNum={3}
+      totalSteps={3}
+      selectedId={selectedDuration != null ? String(selectedDuration) : undefined}
+    />
   )
 }
 

--- a/src/components/learning/DurationSelectionStep.test.jsx
+++ b/src/components/learning/DurationSelectionStep.test.jsx
@@ -18,24 +18,24 @@ describe('DurationSelectionStep', () => {
     durationOptions
   }
 
-  it('renders duration options and hides continue button until a duration is selected', () => {
+  it('renders duration options', () => {
     render(<DurationSelectionStep {...defaultProps} />)
 
-    expect(screen.getByText('10 minutos')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /continuar/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '10 minutos' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '25 minutos' })).toBeInTheDocument()
   })
 
   it('calls onSelectDuration when a duration option is clicked', () => {
     const handleSelect = vi.fn()
     render(<DurationSelectionStep {...defaultProps} onSelectDuration={handleSelect} />)
 
-    fireEvent.click(screen.getByText('10 minutos'))
+    fireEvent.click(screen.getByRole('button', { name: '10 minutos' }))
 
     expect(handleSelect).toHaveBeenCalledTimes(1)
     expect(handleSelect).toHaveBeenCalledWith(10)
   })
 
-  it('shows continue button and triggers onStart when a duration is selected', () => {
+  it('triggers onStart when clicking the already-selected option', () => {
     const handleStart = vi.fn()
     render(
       <DurationSelectionStep
@@ -45,8 +45,8 @@ describe('DurationSelectionStep', () => {
       />
     )
 
-    const continueButton = screen.getByRole('button', { name: /continuar/i })
-    fireEvent.click(continueButton)
+    // Second click on the already-selected option confirms and triggers start
+    fireEvent.click(screen.getByRole('button', { name: '25 minutos' }))
 
     expect(handleStart).toHaveBeenCalledTimes(1)
   })

--- a/src/components/learning/LearningStepView.jsx
+++ b/src/components/learning/LearningStepView.jsx
@@ -1,0 +1,263 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import '../onboarding/OnboardingFlow.css'
+
+const ACCENT = '#ff4d1c'
+const INK    = '#f4f1ea'
+const INK2   = '#6e6a60'
+const INK3   = '#2a2823'
+const LINE   = '#1f1d18'
+
+function Crosshairs() {
+  const positions = [
+    { top: 56, left: 12 },
+    { top: 56, right: 12 },
+    { bottom: 44, left: 12 },
+    { bottom: 44, right: 12 },
+  ]
+  return positions.map((pos, i) => (
+    <div key={i} className="vo-crosshair" style={pos}>
+      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+        <path d="M0 7H14M7 0V14" stroke={ACCENT} strokeWidth="1" />
+      </svg>
+    </div>
+  ))
+}
+
+function StepPanel({ stepConfig, onSelect, selectedId }) {
+  const [focusIdx, setFocusIdx] = useState(0)
+  const { n, kicker, prompt, aux, options } = stepConfig
+
+  useEffect(() => { setFocusIdx(0) }, [stepConfig])
+
+  useEffect(() => {
+    const handle = (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setFocusIdx(i => Math.min(options.length - 1, i + 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setFocusIdx(i => Math.max(0, i - 1))
+      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        e.preventDefault()
+        onSelect(options[focusIdx])
+      } else if (/^[1-9]$/.test(e.key)) {
+        const idx = parseInt(e.key, 10) - 1
+        if (idx < options.length) { setFocusIdx(idx); onSelect(options[idx]) }
+      }
+    }
+    window.addEventListener('keydown', handle)
+    return () => window.removeEventListener('keydown', handle)
+  }, [focusIdx, options, onSelect])
+
+  const focused = options[focusIdx] || options[0]
+
+  const len = (focused?.label || '').length
+  const lenFactor = len <= 6 ? 1 : len <= 10 ? 0.78 : len <= 16 ? 0.58 : len <= 22 ? 0.44 : 0.34
+  const focalSize = `clamp(44px, ${Math.max(5, 12 * lenFactor)}vw, ${Math.round(180 * lenFactor)}px)`
+
+  return (
+    <div className="vo-step vo-lift-in">
+      {/* LEFT: focal word */}
+      <div className="vo-left">
+        <div className="vo-step-tag">──── {kicker}</div>
+        <div className="vo-watermark" aria-hidden="true">{n}</div>
+
+        <div className="vo-left-bottom">
+          <div className="vo-aux">▸ {aux}</div>
+          <div className="vo-prompt">{prompt}</div>
+
+          <div
+            key={focused?.id ?? 'x'}
+            className="vo-focal-word vo-scan-in"
+            style={{ fontSize: focalSize, color: ACCENT }}
+          >
+            {focused?.label}
+            <span
+              className="vo-cursor"
+              style={{
+                display: 'inline-block',
+                width: '0.07em',
+                height: '0.68em',
+                background: ACCENT,
+                marginLeft: '0.05em',
+                verticalAlign: 'baseline',
+                transform: 'translateY(-0.05em)',
+              }}
+            />
+          </div>
+
+          {focused && (
+            <div className="vo-meta">
+              <div className="vo-meta-item">
+                <span className="vo-meta-key">TAG</span>
+                <span className="vo-meta-val">{focused.tag}</span>
+              </div>
+              {focused.gloss && (
+                <div className="vo-meta-item">
+                  <span className="vo-meta-key">TIPO</span>
+                  <span className="vo-meta-val">{focused.gloss}</span>
+                </div>
+              )}
+              {focused.ex && (
+                <div className="vo-meta-item vo-meta-right">
+                  <span className="vo-meta-key">EJEMPLO</span>
+                  <span className="vo-meta-val vo-meta-ex" style={{ color: ACCENT }}>{focused.ex}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* RIGHT: option list */}
+      <div className="vo-right vo-noscroll">
+        <div className="vo-options-label">
+          OPCIONES · {String(options.length).padStart(2, '0')} ────
+        </div>
+
+        <div className="vo-options-list">
+          {options.map((opt, i) => {
+            const active = i === focusIdx
+            const selected = selectedId != null && opt.id === selectedId
+            return (
+              <div
+                key={opt.id ?? i}
+                className="vo-option"
+                role="button"
+                tabIndex={0}
+                aria-label={opt.label}
+                style={{ paddingLeft: active ? 76 : 52, paddingTop: 14, paddingBottom: 14 }}
+                onMouseEnter={() => setFocusIdx(i)}
+                onClick={() => onSelect(opt)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(opt) }}
+              >
+                <div className="vo-option-num" style={{ color: active || selected ? ACCENT : INK3 }}>
+                  <span
+                    className="vo-option-num-box"
+                    style={{
+                      borderColor: active || selected ? ACCENT : LINE,
+                      background: selected && !active ? 'rgba(255,77,28,0.12)' : 'transparent',
+                    }}
+                  >
+                    {selected && !active ? '✓' : i + 1}
+                  </span>
+                  {active && <span className="vo-option-tick" style={{ background: ACCENT }} />}
+                </div>
+
+                <div
+                  className="vo-option-label"
+                  style={{
+                    fontSize: '26px',
+                    fontWeight: active ? 700 : selected ? 500 : 400,
+                    fontStyle: active ? 'italic' : 'normal',
+                    color: active || selected ? INK : INK2,
+                  }}
+                >
+                  {opt.label}
+                </div>
+
+                <div className="vo-option-tag" style={{ color: active || selected ? ACCENT : INK3 }}>
+                  {selected && !active ? '← confirmar' : opt.tag}
+                </div>
+
+                <div
+                  className="vo-option-arrow"
+                  style={{
+                    color: ACCENT,
+                    opacity: active ? 1 : 0,
+                    transform: active ? 'translateX(0)' : 'translateX(-6px)',
+                  }}
+                >
+                  →
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * LearningStepView — shell VERB/OS para los pasos del learning module.
+ *
+ * Props:
+ *   stepConfig  { n, kicker, prompt, aux, options: [{ id, label, tag, gloss, ex, onSelect }] }
+ *   onBack      función para volver
+ *   breadcrumb  [{ label, value }] — máx 3 items
+ *   stepNum     número del paso actual (ej: 1)
+ *   totalSteps  total de pasos (ej: 3)
+ */
+function LearningStepView({ stepConfig, onBack, breadcrumb = [], stepNum = 1, totalSteps = 3, selectedId }) {
+  const handleSelect = useCallback((opt) => {
+    opt.onSelect()
+  }, [])
+
+  useEffect(() => {
+    const fn = (e) => {
+      if (e.key === 'Escape' || e.key === 'ArrowLeft') {
+        e.preventDefault()
+        onBack?.()
+      } else if (e.key === 'Backspace' && document.activeElement.tagName !== 'INPUT') {
+        e.preventDefault()
+        onBack?.()
+      }
+    }
+    window.addEventListener('keydown', fn)
+    return () => window.removeEventListener('keydown', fn)
+  }, [onBack])
+
+  if (!stepConfig) return null
+
+  return (
+    <div className="verbos-onboarding">
+      <div className="vo-grid" aria-hidden="true" />
+      <div className="vo-vignette" aria-hidden="true" />
+      <Crosshairs />
+
+      <header className="vo-header">
+        <div className="vo-logo" onClick={onBack} title="Volver">
+          <div className="vo-logo-dot" style={{ background: ACCENT }} />
+          <span className="vo-logo-name">
+            VERB<span style={{ color: ACCENT }}>/</span>OS
+          </span>
+          <span style={{ marginLeft: 8 }}>aprender</span>
+        </div>
+
+        <div className="vo-breadcrumb" aria-label="Progreso de aprendizaje">
+          {breadcrumb.length === 0
+            ? <span style={{ color: INK3 }}>— · —</span>
+            : breadcrumb.map((item, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <span className="vo-breadcrumb-sep">/</span>}
+                <span>
+                  <span className="vo-breadcrumb-label">{item.label} </span>
+                  <span className="vo-breadcrumb-val">{item.value}</span>
+                </span>
+              </React.Fragment>
+            ))
+          }
+        </div>
+
+        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
+          PASO <span style={{ color: INK }}>{String(stepNum).padStart(2, '0')}</span> / {String(totalSteps).padStart(2, '0')}
+        </div>
+      </header>
+
+      <StepPanel stepConfig={stepConfig} onSelect={handleSelect} selectedId={selectedId} />
+
+      <footer className="vo-footer">
+        <div className="vo-footer-hints">
+          <span><em>↑↓</em> navegá</span>
+          <span><em>↵ / →</em> seleccioná</span>
+          <span><em>← / esc</em> volver</span>
+        </div>
+        <div style={{ color: INK2 }}>{stepConfig.kicker}</div>
+        <div>LEARNING · OK</div>
+      </footer>
+    </div>
+  )
+}
+
+export default LearningStepView

--- a/src/components/learning/TenseSelectionStep.jsx
+++ b/src/components/learning/TenseSelectionStep.jsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from 'react'
-import MenuOptionCard from '../onboarding/MenuOptionCard.jsx'
-import LearningMenuLayout from './LearningMenuLayout.jsx'
-import { MOOD_LABELS, formatMoodTense } from '../../lib/utils/verbLabels.js'
+import React, { useEffect, useState, useMemo } from 'react'
+import LearningStepView from './LearningStepView.jsx'
+import { MOOD_LABELS, formatMoodTense, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
 import { getVerbForms } from '../../lib/core/verbDataService.js'
 
 const REFERENCE_LEMMAS = ['hablar', 'comer', 'vivir']
@@ -23,37 +22,25 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
             }
           })
         )
-
         setReferenceForms(new Map(pairs))
       } catch (error) {
         console.error('TenseSelectionStep: fallo al cargar verbos de referencia', error)
         setReferenceForms(new Map())
       }
     }
-
     loadReferenceForms()
   }, [region])
 
   const getFormsForLemma = (lemma) => referenceForms.get(lemma) || []
-  if (!availableTenses || Object.keys(availableTenses).length === 0) {
-    return null
-  }
 
   const getPersonConjugationExample = (moodKey, tenseKey) => {
-    // Para gerundios y participios, mostrar los 3 verbos modelo
     if (tenseKey === 'ger' || tenseKey === 'part') {
       const modelVerbs = ['hablar', 'comer', 'vivir']
       const examples = []
-
       for (const lemma of modelVerbs) {
         const forms = getFormsForLemma(lemma)
         const match = forms.find(f => f.mood === 'nonfinite' && f.tense === tenseKey)
-        if (match?.value) {
-          examples.push(match.value)
-          continue
-        }
-
-        // Si no hay forma específica, generar forma regular
+        if (match?.value) { examples.push(match.value); continue }
         const stem = lemma.slice(0, -2)
         if (tenseKey === 'ger') {
           examples.push(lemma.endsWith('ar') ? stem + 'ando' : stem + 'iendo')
@@ -61,20 +48,15 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
           examples.push(lemma.endsWith('ar') ? stem + 'ado' : stem + 'ido')
         }
       }
-
       return examples.join(', ')
     }
 
-    // Para otros tiempos, usar el verbo de referencia "hablar"
     const hablarForms = getFormsForLemma('hablar')
     if (hablarForms.length === 0) return ''
 
     const moodMap = {
-      indicativo: 'indicative',
-      subjuntivo: 'subjunctive',
-      imperativo: 'imperative',
-      condicional: 'conditional',
-      nonfinite: 'nonfinite'
+      indicativo: 'indicative', subjuntivo: 'subjunctive',
+      imperativo: 'imperative', condicional: 'conditional', nonfinite: 'nonfinite'
     }
 
     const englishMood = moodMap[moodKey] || moodKey
@@ -102,45 +84,42 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
     if (f2) parts.push(`${useVoseo ? 'vos' : 'tú'} ${f2}`)
     const f3 = getForm('3s')
     if (f3) parts.push(`ella ${f3}`)
-
     return parts.join(', ')
   }
 
+  const options = useMemo(() => {
+    if (!availableTenses || Object.keys(availableTenses).length === 0) return []
+    return Object.entries(availableTenses).flatMap(([mood, tenses]) =>
+      tenses.map(tense => ({
+        id: `${mood}__${tense}`,
+        label: formatMoodTense(mood, tense),
+        tag: (getMoodLabel ? getMoodLabel(mood) : MOOD_LABELS[mood] || mood).toUpperCase().slice(0, 4),
+        gloss: MOOD_LABELS[mood] || mood,
+        ex: getPersonConjugationExample(mood, tense),
+        onSelect: () => onSelect(mood, tense),
+      }))
+    )
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [availableTenses, useVoseo, referenceForms])
+
+  if (!availableTenses || Object.keys(availableTenses).length === 0) return null
+
+  const stepConfig = {
+    n: '01',
+    kicker: 'TIEMPO VERBAL',
+    prompt: 'Elegís...',
+    aux: 'Un tiempo por vez. Después definís el tipo de verbos.',
+    options,
+  }
+
   return (
-    <LearningMenuLayout
-      step="01"
-      kicker="LEARNING"
-      title="Elegí el tiempo"
-      description="Este flujo enseña un tiempo por vez. Elegí el bloque verbal y después definís qué tipo de verbos trabajar."
-      onHome={onHome}
-      footer={(
-        <button className="back-btn" onClick={onHome}>
-          <img src="/back.png" alt="Volver" className="back-icon" />
-        </button>
-      )}
-    >
-        {Object.entries(availableTenses).map(([mood, tenses]) => (
-          <div key={mood} className="tense-section">
-            <h2>{MOOD_LABELS[mood] || mood}</h2>
-            <div className="options-grid">
-              {tenses.map(tense => (
-                <MenuOptionCard
-                  key={tense}
-                  className="learning-option-card"
-                  eyebrow={MOOD_LABELS[mood] || mood}
-                  badge="TIEMPO"
-                  title={formatMoodTense(mood, tense)}
-                  subtitle="Ruta de aprendizaje"
-                  description="Introducción, práctica guiada y aplicación progresiva."
-                  detail={getPersonConjugationExample(mood, tense)}
-                  onClick={() => onSelect(mood, tense)}
-                  cardTitle={`Seleccionar ${formatMoodTense(mood, tense)}`}
-                />
-              ))}
-            </div>
-          </div>
-        ))}
-    </LearningMenuLayout>
+    <LearningStepView
+      stepConfig={stepConfig}
+      onBack={onHome}
+      breadcrumb={[{ label: 'FLUJO', value: 'aprender' }]}
+      stepNum={1}
+      totalSteps={3}
+    />
   )
 }
 

--- a/src/components/learning/TenseSelectionStep.test.jsx
+++ b/src/components/learning/TenseSelectionStep.test.jsx
@@ -21,9 +21,8 @@ describe('TenseSelectionStep', () => {
     render(<TenseSelectionStep {...defaultProps} />)
 
     await waitFor(() => {
-      expect(screen.getByText('Presente')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Presente' })).toBeInTheDocument()
     })
-    expect(screen.getByRole('button', { name: 'Volver al menú' })).toBeInTheDocument()
   })
 
   it('calls onSelect when a tense is chosen', async () => {
@@ -31,9 +30,9 @@ describe('TenseSelectionStep', () => {
     render(<TenseSelectionStep {...defaultProps} onSelect={onSelect} />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /seleccionar presente/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Presente' })).toBeInTheDocument()
     })
-    fireEvent.click(screen.getByRole('button', { name: /seleccionar presente/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Presente' }))
 
     expect(onSelect).toHaveBeenCalledTimes(1)
     expect(onSelect).toHaveBeenCalledWith('indicativo', 'pres')
@@ -43,10 +42,7 @@ describe('TenseSelectionStep', () => {
     const onHome = vi.fn()
     render(<TenseSelectionStep {...defaultProps} onHome={onHome} />)
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Volver al menú' })).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Volver al menú' }))
+    fireEvent.click(screen.getByTitle('Volver'))
 
     expect(onHome).toHaveBeenCalledTimes(1)
   })

--- a/src/components/learning/TypeSelectionStep.jsx
+++ b/src/components/learning/TypeSelectionStep.jsx
@@ -1,19 +1,16 @@
 import React, { useMemo } from 'react'
-import MenuOptionCard from '../onboarding/MenuOptionCard.jsx'
-import LearningMenuLayout from './LearningMenuLayout.jsx'
+import LearningStepView from './LearningStepView.jsx'
 import { formatMoodTense } from '../../lib/utils/verbLabels.js'
 
 const buildIrregularCategories = (tenseKey, availableFamilies) => {
-  if (!tenseKey) {
-    return {}
-  }
+  if (!tenseKey) return {}
 
   const categories = {}
 
   if (tenseKey === 'pres') {
     categories.yo_irregular_g = {
       name: 'Irregulares en YO',
-      description: 'Primera persona irregular: conozco, salgo, estoy',
+      description: 'conozco, salgo, estoy',
       families: [
         ...availableFamilies.filter(f => f.id === 'LEARNING_YO_ZCO_PRESENT'),
         ...availableFamilies.filter(f => f.id === 'LEARNING_YO_G_PRESENT'),
@@ -22,12 +19,12 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
     }
     categories.diphthongs = {
       name: 'Verbos que diptongan',
-      description: 'Cambios vocálicos: e→ie (quiero), e→i (pido), o→ue (puedo)',
+      description: 'quiero, pido, puedo',
       families: availableFamilies.filter(f => f.id === 'LEARNING_DIPHTHONGS')
     }
     categories.very_irregular = {
       name: 'Muy irregulares',
-      description: 'Formas únicas: soy/eres, estoy/estás, voy/vas, doy/das',
+      description: 'soy, estoy, voy, doy',
       families: availableFamilies.filter(f => f.id === 'LEARNING_VERY_IRREGULAR')
     }
     return categories
@@ -36,12 +33,12 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   if (tenseKey === 'pretIndef') {
     categories.pret_muy_irregulares = {
       name: 'Muy irregulares',
-      description: 'Verbos frecuentes con raíces completamente nuevas: estuve, quise, hice',
+      description: 'estuve, quise, hice',
       families: availableFamilies.filter(f => f.id === 'LEARNING_PRET_MUY_IRREGULARES')
     }
     categories.pret_3as_personas = {
       name: 'Irregulares en 3ª persona',
-      description: 'Solo cambian en 3ª persona: pidió/pidieron, durmió/durmieron, leyó/leyeron',
+      description: 'pidió, durmió, leyó',
       families: availableFamilies.filter(f => f.id === 'LEARNING_PRET_3AS_PERSONAS')
     }
     return categories
@@ -50,7 +47,7 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   if (tenseKey === 'impf') {
     categories.imperfect = {
       name: 'Irregulares del imperfecto',
-      description: 'Los únicos 3 verbos con imperfecto irregular: ser (era), ir (iba), ver (veía)',
+      description: 'era, iba, veía',
       families: availableFamilies.filter(f => f.id === 'LEARNING_IMPF_IRREGULAR')
     }
     return categories
@@ -59,7 +56,7 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   if (tenseKey === 'fut' || tenseKey === 'cond') {
     categories.future_cond_roots = {
       name: 'Raíces irregulares',
-      description: 'tendr-, dir-, podr-, sabr- comparten terminaciones regulares',
+      description: 'tendr-, dir-, podr-, sabr-',
       families: availableFamilies.filter(f => f.id === 'LEARNING_FUT_COND_IRREGULAR')
     }
     return categories
@@ -68,7 +65,7 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   if (tenseKey === 'ger') {
     categories.irregular_gerunds = {
       name: 'Gerundios irregulares',
-      description: 'yendo, diciendo, durmiendo: práctica rápida de formas clave',
+      description: 'yendo, diciendo, durmiendo',
       families: availableFamilies.filter(f => f.id === 'LEARNING_IRREG_GERUNDS')
     }
     return categories
@@ -77,7 +74,7 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   if (tenseKey === 'part') {
     categories.irregular_participles = {
       name: 'Participios irregulares',
-      description: 'hecho, visto, puesto, vuelto… Memoriza los indispensables',
+      description: 'hecho, visto, puesto, vuelto',
       families: availableFamilies.filter(f => f.id === 'LEARNING_IRREG_PARTICIPLES')
     }
     return categories
@@ -85,13 +82,12 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
 
   categories.orthographic = {
     name: 'Cambios ortográficos',
-    description: 'Conservación del sonido: busqué, llegué',
+    description: 'busqué, llegué',
     families: availableFamilies.filter(f => ['LEARNING_ORTH_CAR', 'LEARNING_ORTH_GAR'].includes(f.id))
   }
-
   categories.preterite = {
     name: 'Pretéritos fuertes',
-    description: 'Cambios especiales en pretérito: tuve, estuve',
+    description: 'tuve, estuve',
     families: availableFamilies.filter(f => f.id === 'LEARNING_PRET_MUY_IRREGULARES')
   }
 
@@ -106,55 +102,56 @@ function TypeSelectionStep({ selectedTense, availableFamilies = [], onSelectType
     [tenseKey, availableFamilies]
   )
 
+  const options = useMemo(() => {
+    const opts = [
+      {
+        id: 'regular',
+        label: 'regulares',
+        tag: 'SISTEMA',
+        gloss: 'siguen la regla',
+        ex: 'hablar, comer, vivir',
+        onSelect: () => onSelectType('regular'),
+      }
+    ]
+
+    Object.entries(irregularCategories).forEach(([key, category]) => {
+      if (category.families.length === 0) return
+      opts.push({
+        id: key,
+        label: category.name,
+        tag: 'IRREGULAR',
+        gloss: `${category.families.length} familia${category.families.length !== 1 ? 's' : ''}`,
+        ex: category.description,
+        onSelect: () => onSelectType('irregular', category.families.map(f => f.id)),
+      })
+    })
+
+    return opts
+  }, [irregularCategories, onSelectType])
+
+  const tenseName = selectedTense ? formatMoodTense(selectedTense.mood, selectedTense.tense) : 'este tiempo'
+
+  const stepConfig = {
+    n: '02',
+    kicker: 'TIPO DE VERBOS',
+    prompt: 'Trabajás...',
+    aux: `Regulares o familias irregulares para ${tenseName}.`,
+    options,
+  }
+
+  const breadcrumb = [
+    { label: 'FLUJO', value: 'aprender' },
+    ...(selectedTense ? [{ label: 'TIEMPO', value: tenseName }] : []),
+  ]
+
   return (
-    <LearningMenuLayout
-      step="02"
-      kicker="MATERIAL"
-      title="Elegí el tipo de verbos"
-      description={`Para ${selectedTense ? formatMoodTense(selectedTense.mood, selectedTense.tense) : 'este tiempo'}, podés ir por patrones regulares o atacar familias irregulares concretas.`}
-      onHome={onHome}
-      footer={(
-        <button className="back-btn" onClick={onBack}>
-          <img src="/back.png" alt="Volver" className="back-icon" />
-        </button>
-      )}
-    >
-        <div className="tense-section">
-          <h2>{selectedTense ? formatMoodTense(selectedTense.mood, selectedTense.tense) : ''}</h2>
-          <div className="options-grid">
-            <MenuOptionCard
-              className="learning-option-card"
-              eyebrow="BASE"
-              badge="REG"
-              title="Regulares"
-              subtitle="Patrones estables"
-              description="Ideal para fijar terminaciones y lógica del tiempo sin ruido extra."
-              detail="hablar, comer, vivir"
-              onClick={() => onSelectType('regular')}
-              cardTitle="Practicar verbos regulares"
-            />
-
-            {Object.entries(irregularCategories).map(([key, category]) => {
-              if (category.families.length === 0) return null
-
-              return (
-                <MenuOptionCard
-                  key={key}
-                  className="learning-option-card"
-                  eyebrow="IRREGULAR"
-                  badge={String(category.families.length).padStart(2, '0')}
-                  title={category.name}
-                  subtitle="Familia pedagógica"
-                  description="Agrupación enfocada para aprender un patrón reconocible."
-                  detail={category.description}
-                  onClick={() => onSelectType('irregular', category.families.map(f => f.id))}
-                  cardTitle={`Practicar ${category.name.toLowerCase()}`}
-                />
-              )
-            })}
-          </div>
-        </div>
-    </LearningMenuLayout>
+    <LearningStepView
+      stepConfig={stepConfig}
+      onBack={onBack}
+      breadcrumb={breadcrumb}
+      stepNum={2}
+      totalSteps={3}
+    />
   )
 }
 

--- a/src/components/learning/TypeSelectionStep.test.jsx
+++ b/src/components/learning/TypeSelectionStep.test.jsx
@@ -22,8 +22,8 @@ describe('TypeSelectionStep', () => {
       />
     )
 
-    expect(screen.getByText(/Regulares/)).toBeInTheDocument()
-    expect(screen.getByText('Irregulares en YO')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'regulares' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Irregulares en YO' })).toBeInTheDocument()
   })
 
   it('calls onSelectType with "regular" when regular option is clicked', () => {
@@ -38,7 +38,7 @@ describe('TypeSelectionStep', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /practicar verbos regulares/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'regulares' }))
 
     expect(handleSelect).toHaveBeenCalledTimes(1)
     expect(handleSelect).toHaveBeenCalledWith('regular')
@@ -56,7 +56,7 @@ describe('TypeSelectionStep', () => {
       />
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /practicar irregulares en yo/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Irregulares en YO' }))
 
     expect(handleSelect).toHaveBeenCalledTimes(1)
     // The component correctly includes LEARNING_VERY_IRREGULAR in YO irregular category


### PR DESCRIPTION
…e menus

Extend the onboarding's two-panel brutalist shell to the three selection steps of the learning flow (TenseSelectionStep, TypeSelectionStep, DurationSelectionStep).

- Add LearningStepView.jsx: reusable shell that imports OnboardingFlow.css and renders the same vo-* layout: dark background, VERB/OS header with breadcrumb + step counter, background grid + vignette + crosshairs, left panel with animated focal word, right panel with numbered option list, keyboard navigation (↑↓ Enter → ← Esc), footer with hints.
- TenseSelectionStep: flattens mood/tense groups into a flat option list with mood as the tag; each option is a vo-option row.
- TypeSelectionStep: regular + irregular-family options as vo-option rows.
- DurationSelectionStep: duration options as vo-option rows; first click selects, second click on the already-selected option triggers onStart. Selected option shows a ✓ checkmark and "← confirmar" tag.
- Update tests to use getByRole('button') instead of old card-based queries; all 9 tests pass.