### PR TITLE
feat(drill): apply VERB/OS dark brutalist design to practice screen

### DIFF
--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -1,5 +1,43 @@
 import React from 'react'
 import { useSettings } from '../../state/settings.js'
+import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
+
+const DIALECT_LABEL = {
+  rioplatense: 'vos',
+  la_general:  'tú',
+  peninsular:  'tú·vos',
+  both:        'todos',
+}
+
+const MODE_LABEL = {
+  mixed:  'mixto',
+  specific: 'específico',
+  review: 'repaso srs',
+  theme:  'por tema',
+}
+
+function buildBreadcrumb(settings) {
+  const items = []
+
+  if (settings.region) {
+    items.push({ label: 'DIALECTO', value: DIALECT_LABEL[settings.region] || settings.region })
+  }
+
+  if (settings.level) {
+    items.push({ label: 'NIVEL', value: settings.level })
+  }
+
+  if (settings.practiceMode) {
+    items.push({ label: 'MODO', value: MODE_LABEL[settings.practiceMode] || settings.practiceMode })
+  }
+
+  if (settings.practiceMode === 'specific' && settings.specificMood && settings.specificTense) {
+    const { tenseLabel } = getSafeMoodTenseLabels(settings.specificMood, settings.specificTense)
+    items.push({ label: 'FOCO', value: tenseLabel })
+  }
+
+  return items.slice(-3)
+}
 
 function DrillHeader({
   onToggleQuickSwitch,
@@ -16,30 +54,50 @@ function DrillHeader({
 }) {
   const settings = useSettings()
   const isReviewMode = settings.practiceMode === 'review'
+  const breadcrumb = buildBreadcrumb(settings)
 
   return (
     <header className="header">
-      {isReviewMode && (
-        <div className="srs-mode-badge">
-          <img src="/icons/timer.png" alt="SRS" className="srs-badge-icon" />
-          <span>Sesión de Repaso SRS</span>
-        </div>
-      )}
+      {/* Left: VERB/OS logo → home */}
+      <div className="vd-logo" onClick={onHome} title="Ir al inicio">
+        <div className="vd-logo-dot" />
+        <span className="vd-logo-name">
+          VERB<span style={{ color: '#ff4d1c' }}>/</span>OS
+        </span>
+      </div>
+
+      {/* Center: practice context breadcrumb */}
+      <div className="vd-breadcrumb" aria-label="Contexto de práctica">
+        {isReviewMode ? (
+          <span className="srs-mode-badge">
+            <img src="/icons/timer.png" alt="SRS" className="srs-badge-icon" />
+            <span>REPASO SRS</span>
+          </span>
+        ) : breadcrumb.length === 0 ? (
+          <span style={{ color: '#2a2823' }}>— · —</span>
+        ) : (
+          breadcrumb.map((item, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && <span className="vd-breadcrumb-sep">/</span>}
+              <span>
+                <span className="vd-breadcrumb-label">{item.label} </span>
+                <span className="vd-breadcrumb-val">{item.value}</span>
+              </span>
+            </React.Fragment>
+          ))
+        )}
+      </div>
+
+      {/* Right: action icon buttons */}
       <div className="icon-row">
         <button
           type="button"
-          onClick={() => {
-            if (showQuickSwitch) {
-              onToggleQuickSwitch(false)
-            } else {
-              onToggleQuickSwitch(true)
-            }
-          }}
+          onClick={() => onToggleQuickSwitch(showQuickSwitch ? false : true)}
           className="icon-btn"
           title="Cambiar rápido"
           aria-label="Cambiar rápido"
         >
-          <img src="/config.png" alt="Config" className="menu-icon" />
+          <img src="/config.png" alt="Config" />
         </button>
 
         <button
@@ -49,53 +107,37 @@ function DrillHeader({
           title="Tildes"
           aria-label="Tildes"
         >
-          <img src="/enie.png" alt="Tildes" className="menu-icon" />
-        </button>
-
-        <button
-          type="button"
-          onClick={onHome}
-          className="icon-btn"
-          title="Menú"
-          aria-label="Menú"
-        >
-          <img src="/home.png" alt="Menú" className="menu-icon" />
+          <img src="/enie.png" alt="Tildes" />
         </button>
 
         <button
           type="button"
           onClick={() => onTogglePronunciation()}
           className="icon-btn"
-          title="Práctica de pronunciación"
-          aria-label="Práctica de pronunciación"
+          title="Pronunciación"
+          aria-label="Pronunciación"
         >
-          <img src="/boca.png" alt="Pronunciación" className="menu-icon-pronunciation" />
+          <img src="/boca.png" alt="Pronunciación" />
         </button>
 
         <button
           type="button"
-          onClick={() => {
-            if (showGames) {
-              onToggleGames(false)
-            } else {
-              onToggleGames(true)
-            }
-          }}
+          onClick={() => onToggleGames(showGames ? false : true)}
           className="icon-btn"
           title="Juegos"
           aria-label="Juegos"
         >
-          <img src="/dice.png" alt="Juegos" className="menu-icon" />
+          <img src="/dice.png" alt="Juegos" />
         </button>
 
         <button
           type="button"
           onClick={() => onNavigateToProgress()}
           className="icon-btn"
-          title="Progreso y Analíticas"
-          aria-label="Progreso y Analíticas"
+          title="Progreso"
+          aria-label="Progreso"
         >
-          <img src="/icons/chart.png" alt="Progreso" className="menu-icon" />
+          <img src="/icons/chart.png" alt="Progreso" />
         </button>
       </div>
     </header>

--- a/src/components/drill/DrillMode.jsx
+++ b/src/components/drill/DrillMode.jsx
@@ -70,6 +70,7 @@ import { safeLazy } from '../../lib/utils/lazyImport.js';
 import { useSessionStore } from '../../state/session.js'
 import { createLogger } from '../../lib/utils/logger.js'
 import { buildGenerationDetail, buildGenerationSuggestions } from './generationDiagnostics.js'
+import './DrillVerbos.css'
 
 const QuickSwitchPanel = safeLazy(() => import('./QuickSwitchPanel.jsx'))
 const GamesPanel = safeLazy(() => import('./GamesPanel.jsx'))
@@ -449,8 +450,29 @@ function DrillMode({
     return () => window.removeEventListener('progress:navigate', handler)
   }, [setDrillRuntimeContext, onStartSpecificPractice, onRegenerateItem, onPracticeModeChange, settings])
 
+  /* ── Decorative corner crosshairs ── */
+  const crosshairPositions = [
+    { top: 56, left: 12 },
+    { top: 56, right: 12 },
+    { bottom: 44, left: 12 },
+    { bottom: 44, right: 12 },
+  ]
+
   return (
-    <div className="App">
+    <div className="verbos-drill">
+      {/* Background grid */}
+      <div className="vd-grid" aria-hidden="true" />
+      <div className="vd-vignette" aria-hidden="true" />
+
+      {/* Corner crosshairs */}
+      {crosshairPositions.map((pos, i) => (
+        <div key={i} className="vd-crosshair" style={pos} aria-hidden="true">
+          <svg width="14" height="14" viewBox="0 0 14 14">
+            <path d="M0 7H14M7 0V14" stroke="#ff4d1c" strokeWidth="1" />
+          </svg>
+        </div>
+      ))}
+
       <DrillHeader
         onToggleQuickSwitch={handleToggleQuickSwitch}
         onToggleAccentKeys={handleToggleAccentKeys}
@@ -466,7 +488,7 @@ function DrillMode({
       />
 
       {showQuickSwitch && (
-        <Suspense fallback={<div className="loading">Cargando opciones rápidas...</div>}>
+        <Suspense fallback={<div className="loading">CARGANDO...</div>}>
           <QuickSwitchPanel
             settings={settings}
             onApply={handleQuickSwitchApply}
@@ -479,7 +501,7 @@ function DrillMode({
       )}
 
       {showGames && (
-        <Suspense fallback={<div className="loading">Cargando juegos...</div>}>
+        <Suspense fallback={<div className="loading">CARGANDO...</div>}>
           <GamesPanel
             settings={settings}
             onClose={() => handleToggleGames(false)}
@@ -489,7 +511,7 @@ function DrillMode({
       )}
 
       {showPronunciation && (
-        <Suspense fallback={<div className="loading">Cargando pronunciación...</div>}>
+        <Suspense fallback={<div className="loading">CARGANDO...</div>}>
           <PronunciationPanel
             ref={pronunciationPanelRef}
             currentItem={currentItem}
@@ -511,7 +533,7 @@ function DrillMode({
         ) : loadingError ? (
           <div className="loading-error">
             <div className="error-message">
-              <h3>⚠️ Error de generación</h3>
+              <h3>ERROR DE GENERACIÓN</h3>
               <p>{loadingError}</p>
               {generationIssue && (
                 <div className="generation-diagnostics">
@@ -526,14 +548,15 @@ function DrillMode({
                     <p>Detalle técnico: {generationIssue.error}</p>
                   )}
                   {Array.isArray(generationIssue.suggestions) && generationIssue.suggestions.length > 0 && (
-                    <ul>
+                    <ul style={{ marginTop: 8, paddingLeft: 0, listStyle: 'none' }}>
                       {generationIssue.suggestions.map((suggestion) => (
-                        <li key={suggestion.id}>
+                        <li key={suggestion.id} style={{ marginBottom: 6 }}>
                           {suggestion.reason}
                           <button
                             type="button"
+                            className="retry-button"
                             onClick={() => applyGenerationSuggestion(suggestion.id)}
-                            style={{ marginLeft: '8px' }}
+                            style={{ marginLeft: 8 }}
                           >
                             {suggestion.label}
                           </button>
@@ -553,13 +576,13 @@ function DrillMode({
                   }}
                   className="retry-button"
                 >
-                  🔄 Intentar de nuevo
+                  REINTENTAR
                 </button>
                 <button
                   onClick={() => window.location.reload()}
                   className="reload-button"
                 >
-                  🔄 Recargar página
+                  RECARGAR
                 </button>
               </div>
             </div>
@@ -568,53 +591,42 @@ function DrillMode({
           <div className="loading">
             {loadingTimeout ? (
               <div>
-                <div>⏳ Generando ejercicio...</div>
-                <div style={{ fontSize: '0.9em', marginTop: '10px', opacity: 0.7 }}>
-                  Esto está tardando más de lo esperado. Si el problema persiste, intenta cambiar la configuración.
+                <div>GENERANDO EJERCICIO...</div>
+                <div style={{ marginTop: 10, opacity: 0.6 }}>
+                  Esto está tardando más de lo esperado.
                 </div>
                 {generationIssue && (
-                  <div style={{ marginTop: '12px', fontSize: '0.9em', opacity: 0.85 }}>
-                    <div><strong>Diagnóstico:</strong> {generationIssue.detail}</div>
-                    {typeof generationIssue.totalForms === 'number' && typeof generationIssue.eligibleForms === 'number' && (
-                      <div>Formas totales: {generationIssue.totalForms} · Elegibles: {generationIssue.eligibleForms}</div>
-                    )}
-                    {generationIssue.filteringReport?.emptyReason && (
-                      <div>Causa detectada: {generationIssue.filteringReport.emptyReason}</div>
-                    )}
-                    {Array.isArray(generationIssue.suggestions) && generationIssue.suggestions.length > 0 && (
-                      <ul style={{ marginTop: '8px' }}>
-                        {generationIssue.suggestions.map((suggestion) => (
-                          <li key={suggestion.id}>
-                            {suggestion.reason}
-                            <button
-                              type="button"
-                              onClick={() => applyGenerationSuggestion(suggestion.id)}
-                              style={{ marginLeft: '8px' }}
-                            >
-                              {suggestion.label}
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
+                  <div style={{ marginTop: 12, opacity: 0.85 }}>
+                    <div>DIAGNÓSTICO: {generationIssue.detail}</div>
+                    {typeof generationIssue.totalForms === 'number' && (
+                      <div>Formas: {generationIssue.totalForms} · Elegibles: {generationIssue.eligibleForms}</div>
                     )}
                   </div>
                 )}
                 <button
-                  onClick={() => {
-                    logger.debug('🔄 DrillMode: Manual retry triggered by user')
-                    onRegenerateItem()
-                  }}
-                  style={{ marginTop: '15px', padding: '8px 16px' }}
+                  onClick={() => onRegenerateItem()}
+                  className="retry-button"
+                  style={{ marginTop: 14 }}
                 >
-                  Forzar regeneración
+                  FORZAR REGENERACIÓN
                 </button>
               </div>
             ) : (
-              'Cargando próxima conjugación...'
+              'CARGANDO...'
             )}
           </div>
         )}
       </main>
+
+      {/* Footer with keyboard hints */}
+      <footer className="vd-footer">
+        <div className="vd-footer-hints">
+          <span><em>↵</em> verificar · continuar</span>
+          <span><em>esc</em> limpiar</span>
+        </div>
+        <div style={{ color: '#6e6a60' }}>PRÁCTICA</div>
+        <div>SISTEMA · OK</div>
+      </footer>
     </div>
   )
 }

--- a/src/components/drill/DrillVerbos.css
+++ b/src/components/drill/DrillVerbos.css
@@ -1,0 +1,836 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design tokens (scoped) ── */
+.verbos-drill {
+  --vd-bg:       #0c0c0c;
+  --vd-ink:      #f4f1ea;
+  --vd-ink2:     #6e6a60;
+  --vd-ink3:     #2a2823;
+  --vd-line:     #1f1d18;
+  --vd-accent:   #ff4d1c;
+  --vd-green:    #5ee6a5;
+  --vd-red:      #ff6b6b;
+  --vd-font:     'Inter Tight', -apple-system, sans-serif;
+  --vd-mono:     'JetBrains Mono', monospace;
+}
+
+/* ── Wrapper ── */
+.verbos-drill {
+  position: fixed;
+  inset: 0;
+  background: var(--vd-bg);
+  color: var(--vd-ink);
+  font-family: var(--vd-font);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'ss01', 'ss02', 'cv11';
+  overflow: hidden;
+  z-index: 0;
+}
+
+.verbos-drill * {
+  box-sizing: border-box;
+}
+
+.verbos-drill ::selection {
+  background: var(--vd-accent);
+  color: var(--vd-bg);
+}
+
+/* ── Scrollbar hidden ── */
+.verbos-drill ::-webkit-scrollbar { display: none; }
+.verbos-drill * { scrollbar-width: none; }
+
+/* ── Keyframes ── */
+@keyframes vdLiftIn {
+  from { transform: translateY(10px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+@keyframes vdScanIn {
+  from { clip-path: inset(0 100% 0 0); }
+  to   { clip-path: inset(0 0%   0 0); }
+}
+
+@keyframes vdBlink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@keyframes vdShake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-6px); }
+  40% { transform: translateX(6px); }
+  60% { transform: translateX(-4px); }
+  80% { transform: translateX(4px); }
+}
+
+@keyframes vdCorrect {
+  0%   { opacity: 0; transform: translateY(8px); }
+  60%  { transform: translateY(-2px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes vdIncorrect {
+  0%   { opacity: 0; transform: translateX(-8px); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+/* ── Background grid ── */
+.vd-grid {
+  position: fixed;
+  inset: 44px 0 32px 0;
+  background-image:
+    linear-gradient(var(--vd-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--vd-line) 1px, transparent 1px);
+  background-size: 64px 64px;
+  opacity: 0.55;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.vd-vignette {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,0.55) 100%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.vd-crosshair {
+  position: fixed;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* ── Header ── */
+.verbos-drill .header {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--vd-line);
+  background: var(--vd-bg);
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  z-index: 50;
+  flex-direction: row;
+  gap: 0;
+}
+
+/* VERB/OS logo in header */
+.vd-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.vd-logo-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--vd-accent);
+  flex-shrink: 0;
+}
+
+.vd-logo-name {
+  color: var(--vd-ink);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+/* Breadcrumb (practice context) */
+.vd-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  flex: 1;
+  justify-content: center;
+  max-width: 50%;
+}
+
+.vd-breadcrumb-sep { color: var(--vd-ink3); }
+.vd-breadcrumb-label { color: var(--vd-ink2); }
+.vd-breadcrumb-val {
+  color: var(--vd-ink);
+  margin-left: 4px;
+}
+
+/* Icon buttons in header */
+.verbos-drill .icon-row {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.verbos-drill .icon-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 5px;
+  line-height: 0;
+  color: var(--vd-ink2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.verbos-drill .icon-btn img {
+  filter: invert(1) brightness(0.55);
+  width: 18px;
+  height: 18px;
+}
+
+.verbos-drill .icon-btn:hover {
+  border-color: var(--vd-line);
+  color: var(--vd-ink);
+}
+
+.verbos-drill .icon-btn:hover img {
+  filter: invert(1) brightness(1);
+}
+
+.verbos-drill .icon-btn:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+/* SRS badge in header */
+.verbos-drill .srs-mode-badge {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  border: 1px solid var(--vd-accent);
+  color: var(--vd-accent);
+  padding: 3px 8px;
+  background: transparent;
+  border-radius: 0;
+}
+
+.verbos-drill .srs-badge-icon {
+  filter: invert(1) sepia(1) saturate(5) hue-rotate(320deg);
+  width: 12px;
+  height: 12px;
+}
+
+/* ── Footer ── */
+.vd-footer {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  border-top: 1px solid var(--vd-line);
+  background: var(--vd-bg);
+  font-family: var(--vd-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vd-ink3);
+  z-index: 50;
+}
+
+.vd-footer-hints { display: flex; gap: 16px; }
+.vd-footer-hints span { white-space: nowrap; }
+.vd-footer-hints em { font-style: normal; color: var(--vd-ink2); }
+
+/* ── Main content area ── */
+.verbos-drill .main-content {
+  position: absolute;
+  top: 44px;
+  bottom: 32px;
+  left: 0;
+  right: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 20px;
+  z-index: 3;
+  max-width: none;
+  margin: 0;
+  min-height: 0;
+}
+
+/* ── Drill container ── */
+.verbos-drill .drill-container {
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  max-width: 560px;
+  width: 100%;
+  text-align: center;
+  box-shadow: none;
+  margin: 0 auto;
+  position: relative;
+}
+
+/* ── Verb lemma — focal display ── */
+.verbos-drill .verb-lemma {
+  font-family: var(--vd-font);
+  font-weight: 900;
+  font-style: italic;
+  font-size: clamp(52px, 10vw, 120px);
+  letter-spacing: -0.055em;
+  line-height: 0.9;
+  text-transform: lowercase;
+  color: var(--vd-accent);
+  margin-bottom: 20px;
+  animation: vdScanIn 0.4s cubic-bezier(0.7, 0, 0.2, 1) both;
+}
+
+/* ── Conjugation context ── */
+.verbos-drill .conjugation-context {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  margin-bottom: 12px;
+  font-weight: 400;
+}
+
+/* ── Person display ── */
+.verbos-drill .person-display {
+  font-family: var(--vd-font);
+  font-size: 1.5rem;
+  font-weight: 300;
+  color: var(--vd-ink2);
+  margin-bottom: 24px;
+  letter-spacing: -0.01em;
+  text-transform: none;
+}
+
+/* ── Separator line ── */
+.verbos-drill .drill-container::after {
+  content: '';
+  display: block;
+  height: 1px;
+  background: var(--vd-line);
+  margin: 0 0 24px;
+}
+
+/* ── Input container ── */
+.verbos-drill .input-container {
+  margin-bottom: 20px;
+}
+
+/* ── Conjugation input ── */
+.verbos-drill .conjugation-input {
+  width: 100%;
+  max-width: 420px;
+  padding: 14px 20px;
+  font-family: var(--vd-mono);
+  font-size: 1.1rem;
+  font-weight: 400;
+  letter-spacing: 0.06em;
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--vd-ink);
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+  caret-color: var(--vd-accent);
+  box-shadow: none;
+}
+
+.verbos-drill .conjugation-input:focus {
+  outline: none;
+  border-color: var(--vd-accent);
+  background: rgba(255, 77, 28, 0.04);
+  box-shadow: none;
+  transform: none;
+}
+
+.verbos-drill .conjugation-input::placeholder {
+  color: var(--vd-ink3);
+  font-style: italic;
+}
+
+.verbos-drill .conjugation-input.correct {
+  border-color: var(--vd-green);
+  background: rgba(94, 230, 165, 0.06);
+  animation: none;
+}
+
+.verbos-drill .conjugation-input.incorrect {
+  border-color: var(--vd-red);
+  background: rgba(255, 107, 107, 0.06);
+  animation: vdShake 0.4s ease;
+}
+
+/* ── Accent keypad ── */
+.verbos-drill .accent-keypad {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 12px;
+}
+
+.verbos-drill .accent-key {
+  background: transparent;
+  border: 1px solid var(--vd-line);
+  color: var(--vd-ink2);
+  padding: 6px 10px;
+  font-family: var(--vd-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.12s;
+  border-radius: 0;
+}
+
+.verbos-drill .accent-key:hover {
+  border-color: var(--vd-accent);
+  color: var(--vd-accent);
+  background: rgba(255, 77, 28, 0.08);
+  transform: none;
+  box-shadow: none;
+}
+
+.verbos-drill .accent-key:active {
+  transform: none;
+  box-shadow: none;
+}
+
+/* ── Action buttons ── */
+.verbos-drill .action-buttons {
+  margin-bottom: 16px;
+}
+
+.verbos-drill .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--vd-accent);
+  color: var(--vd-bg);
+  border: none;
+  padding: 13px 28px;
+  border-radius: 0;
+  font-family: var(--vd-mono);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  min-width: 140px;
+  min-height: 44px;
+  position: relative;
+  box-shadow: none;
+}
+
+.verbos-drill .btn:hover {
+  opacity: 0.88;
+  transform: none;
+  box-shadow: none;
+}
+
+.verbos-drill .btn:active {
+  opacity: 0.75;
+  transform: none;
+  box-shadow: none;
+}
+
+.verbos-drill .btn:disabled {
+  background: var(--vd-line);
+  color: var(--vd-ink3);
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+/* ── Result feedback ── */
+.verbos-drill .result {
+  padding: 16px 20px;
+  margin-top: 12px;
+  border: 1px solid;
+  font-family: var(--vd-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  animation: vdLiftIn 0.3s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+  background: transparent;
+}
+
+.verbos-drill .result.correct {
+  border-color: var(--vd-green);
+  color: var(--vd-green);
+  animation: vdCorrect 0.3s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+.verbos-drill .result.incorrect {
+  border-color: var(--vd-red);
+  color: var(--vd-red);
+  animation: vdIncorrect 0.3s ease both;
+}
+
+.verbos-drill .result p {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: inherit;
+  margin: 0;
+  font-family: var(--vd-mono);
+  text-align: center;
+}
+
+.verbos-drill .result p strong {
+  color: var(--vd-ink);
+}
+
+.verbos-drill .result-top {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.verbos-drill .tts-btn {
+  background: transparent;
+  border: none;
+  padding: 0;
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+
+.verbos-drill .tts-btn:hover { opacity: 1; }
+.verbos-drill .tts-btn img {
+  width: 20px;
+  height: 20px;
+  filter: invert(1);
+}
+
+/* ── Diff component ── */
+.verbos-drill .diff-container {
+  margin-top: 10px;
+  padding: 8px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+}
+
+/* ── Reverse mode ── */
+.verbos-drill .reverse-container {
+  background: transparent;
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.verbos-drill .reverse-badge {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-accent);
+  border: 1px solid var(--vd-accent);
+  padding: 3px 8px;
+  border-radius: 0;
+  display: inline-block;
+  margin-bottom: 10px;
+}
+
+.verbos-drill .reverse-subtle {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  color: var(--vd-ink2);
+  margin-bottom: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.verbos-drill .reverse-divider {
+  height: 1px;
+  background: var(--vd-line);
+  margin: 8px 0 14px;
+}
+
+.verbos-drill .reverse-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 12px;
+}
+
+.verbos-drill .reverse-grid-single {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.verbos-drill .reverse-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+}
+
+.verbos-drill .reverse-label {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  color: var(--vd-ink2);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.verbos-drill .reverse-input {
+  width: 100%;
+  padding: 10px 14px;
+  font-family: var(--vd-mono);
+  font-size: 0.9rem;
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  background: rgba(255,255,255,0.03);
+  color: var(--vd-ink);
+  caret-color: var(--vd-accent);
+}
+
+.verbos-drill .reverse-input:focus {
+  outline: none;
+  border-color: var(--vd-accent);
+}
+
+.verbos-drill .reverse-select {
+  width: 100%;
+  padding: 9px 14px;
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  background: var(--vd-bg);
+  color: var(--vd-ink);
+  font-family: var(--vd-mono);
+}
+
+/* ── Double mode ── */
+.verbos-drill .double-container {
+  margin-bottom: 16px;
+}
+
+.verbos-drill .double-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.verbos-drill .double-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  background: transparent;
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  padding: 12px;
+}
+
+/* ── Loading states ── */
+.verbos-drill .drill-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.verbos-drill .loading-spinner {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+}
+
+.verbos-drill .loading {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  text-align: center;
+  padding: 20px;
+}
+
+.verbos-drill .loading-error {
+  width: 100%;
+  max-width: 500px;
+}
+
+.verbos-drill .error-message {
+  border: 1px solid var(--vd-red);
+  padding: 20px;
+}
+
+.verbos-drill .error-message h3 {
+  font-family: var(--vd-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-red);
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+.verbos-drill .error-message p {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  color: var(--vd-ink2);
+  margin-bottom: 8px;
+  text-transform: none;
+  letter-spacing: 0.06em;
+}
+
+.verbos-drill .error-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.verbos-drill .retry-button,
+.verbos-drill .reload-button {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: transparent;
+  border: 1px solid var(--vd-line);
+  color: var(--vd-ink2);
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.verbos-drill .retry-button:hover,
+.verbos-drill .reload-button:hover {
+  border-color: var(--vd-accent);
+  color: var(--vd-accent);
+}
+
+/* ── Generation diagnostics ── */
+.verbos-drill .generation-diagnostics {
+  font-family: var(--vd-mono);
+  font-size: 9.5px;
+  color: var(--vd-ink2);
+  margin-top: 10px;
+  letter-spacing: 0.08em;
+}
+
+/* ── Quick switch / Games panels overlay ── */
+.verbos-drill .quick-switch-panel {
+  background: var(--vd-bg);
+  border: 1px solid var(--vd-line);
+  border-radius: 0;
+  padding: 24px;
+  margin: 0 auto;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: none;
+}
+
+.verbos-drill .quick-switch-panel .setting-group {
+  margin-bottom: 14px;
+}
+
+.verbos-drill .quick-switch-panel .setting-select {
+  padding: 9px 12px;
+  border-radius: 0;
+  border: 1px solid var(--vd-line);
+  background: var(--vd-bg);
+  color: var(--vd-ink);
+  font-family: var(--vd-mono);
+  font-size: 11px;
+}
+
+/* Loading fallback for panels */
+.verbos-drill .loading {
+  font-family: var(--vd-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  padding: 14px;
+}
+
+/* ── Resistance HUD & Session HUD ── */
+/* Scoped overrides - keep the existing styles but adjust colors */
+.verbos-drill .resistance-hud {
+  margin-top: 16px;
+}
+
+/* ── Panel overlay areas (QuickSwitch, Games, Pronunciation) ── */
+/* These appear after DrillHeader and before main-content */
+.verbos-drill > div.quick-switch-panel,
+.verbos-drill > div.games-panel,
+.verbos-drill > div.pronunciation-panel-safe {
+  position: absolute;
+  top: 44px;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  background: var(--vd-bg);
+  border-bottom: 1px solid var(--vd-line);
+}
+
+/* ── Mobile ── */
+@media (max-width: 680px) {
+  .verbos-drill .verb-lemma {
+    font-size: clamp(40px, 14vw, 72px);
+  }
+
+  .verbos-drill .main-content {
+    justify-content: flex-start;
+    padding-top: 32px;
+  }
+
+  .vd-breadcrumb {
+    display: none;
+  }
+
+  .vd-footer-hints {
+    gap: 8px;
+  }
+
+  .verbos-drill .double-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .verbos-drill .reverse-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Fade-in animation ── */
+.verbos-drill .fade-in {
+  animation: vdLiftIn 0.3s cubic-bezier(0.2, 0.9, 0.3, 1) both;
+}
+
+/* ── btn-secondary variant ── */
+.verbos-drill .btn-secondary {
+  background: transparent;
+  color: var(--vd-ink);
+  border: 1px solid var(--vd-line);
+  box-shadow: none;
+}
+
+.verbos-drill .btn-secondary:hover {
+  border-color: var(--vd-accent);
+  color: var(--vd-accent);
+}


### PR DESCRIPTION
Extends the VERB/OS aesthetic (introduced in onboarding and learning modules) to the main drill/practice screen, keeping all existing functionality intact: games, resistance timer, accent keypad, quick switch, pronunciation panel, and session progress HUD.

Changes:
- DrillVerbos.css: new scoped stylesheet with the full VERB/OS token set (#0c0c0c bg, Inter Tight + JetBrains Mono, #ff4d1c accent, #1f1d18 grid lines). Overrides drill classes inside .verbos-drill so there is zero risk of bleeding into other views.
- DrillMode.jsx: wraps the drill in .verbos-drill; adds background grid, radial vignette, corner crosshairs, and a fixed footer bar with keyboard hints (same pattern as onboarding).
- DrillHeader.jsx: replaces the plain icon row with the VERB/OS header layout — VERB/OS logo on the left (doubles as home button), practice context breadcrumb in the centre (dialect / level / mode / focus), and action icon buttons on the right.