### PR TITLE
Claude/recursing wright f56f34

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -222,20 +222,23 @@ body {
   border: 1px solid transparent;
   padding: 6px;
   line-height: 0;
-  color: var(--text);
+  color: rgba(244, 241, 234, 0.55);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: all 0.1s ease;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+
+.icon-btn svg {
+  display: block;
+  flex-shrink: 0;
 }
 
 .icon-btn:hover {
-  transform: translate(-2px, -2px);
   border: 1px solid var(--border-active);
-  background: var(--bg);
-  color: var(--text);
-  box-shadow: var(--shadow-hard-sm);
+  background: rgba(255, 255, 255, 0.05);
+  color: #f4f1ea;
 }
 
 .icon-btn:hover img {

--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -39,10 +39,49 @@ function buildBreadcrumb(settings) {
   return items.slice(-3)
 }
 
+/* Inline SVG icon components — use currentColor so CSS color/opacity applies cleanly */
+const ConfigSvg = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+    <line x1="4" y1="6" x2="20" y2="6"/>
+    <line x1="4" y1="12" x2="20" y2="12"/>
+    <line x1="4" y1="18" x2="20" y2="18"/>
+    <circle cx="8" cy="6" r="2" fill="currentColor" stroke="none"/>
+    <circle cx="16" cy="12" r="2" fill="currentColor" stroke="none"/>
+    <circle cx="10" cy="18" r="2" fill="currentColor" stroke="none"/>
+  </svg>
+)
+
+const AccentsSvg = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <text x="2" y="19" fontFamily="serif" fontSize="18" fontWeight="bold" fill="currentColor">Ñ</text>
+  </svg>
+)
+
 const MicSvg = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" style={{ width: 20, height: 20 }}>
+  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
     <path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z"/>
     <path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/>
+  </svg>
+)
+
+const DiceSvg = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
+    <rect x="3" y="3" width="18" height="18" rx="2"/>
+    <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="8.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="8.5" cy="12" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="12" r="1.2" fill="currentColor" stroke="none"/>
+  </svg>
+)
+
+const ChartSvg = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <rect x="3" y="12" width="4" height="9" rx="0.5"/>
+    <rect x="10" y="6" width="4" height="15" rx="0.5"/>
+    <rect x="17" y="9" width="4" height="12" rx="0.5"/>
+    <line x1="2" y1="21.5" x2="22" y2="21.5" stroke="currentColor" strokeWidth="1.5"/>
   </svg>
 )
 
@@ -106,7 +145,7 @@ function DrillHeader({
           aria-label="Configuración rápida"
           aria-pressed={showQuickSwitch}
         >
-          <img src="/config.png" alt="Config" />
+          <ConfigSvg />
         </button>
 
         <button
@@ -116,7 +155,7 @@ function DrillHeader({
           title="Tildes especiales"
           aria-label="Tildes especiales"
         >
-          <img src="/enie.png" alt="Tildes" />
+          <AccentsSvg />
         </button>
 
         <button
@@ -138,7 +177,7 @@ function DrillHeader({
           aria-label="Modos de juego"
           aria-pressed={showGames}
         >
-          <img src="/dice.png" alt="Juegos" />
+          <DiceSvg />
         </button>
 
         <button
@@ -148,7 +187,7 @@ function DrillHeader({
           title="Progreso"
           aria-label="Progreso"
         >
-          <img src="/icons/chart.png" alt="Progreso" />
+          <ChartSvg />
         </button>
       </div>
     </header>

--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSettings } from '../../state/settings.js'
 import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
+import { ConfigSvg, AccentsSvg, MicSvg, DiceSvg, ChartSvg } from '../shared/DrillIcons.jsx'
 
 const DIALECT_LABEL = {
   rioplatense: 'vos',
@@ -38,52 +39,6 @@ function buildBreadcrumb(settings) {
 
   return items.slice(-3)
 }
-
-/* Inline SVG icon components — use currentColor so CSS color/opacity applies cleanly */
-const ConfigSvg = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
-    <line x1="4" y1="6" x2="20" y2="6"/>
-    <line x1="4" y1="12" x2="20" y2="12"/>
-    <line x1="4" y1="18" x2="20" y2="18"/>
-    <circle cx="8" cy="6" r="2" fill="currentColor" stroke="none"/>
-    <circle cx="16" cy="12" r="2" fill="currentColor" stroke="none"/>
-    <circle cx="10" cy="18" r="2" fill="currentColor" stroke="none"/>
-  </svg>
-)
-
-const AccentsSvg = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-    <text x="2" y="19" fontFamily="serif" fontSize="18" fontWeight="bold" fill="currentColor">Ñ</text>
-  </svg>
-)
-
-const MicSvg = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z"/>
-    <path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/>
-  </svg>
-)
-
-const DiceSvg = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" xmlns="http://www.w3.org/2000/svg">
-    <rect x="3" y="3" width="18" height="18" rx="2"/>
-    <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
-    <circle cx="15.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
-    <circle cx="8.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
-    <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
-    <circle cx="8.5" cy="12" r="1.2" fill="currentColor" stroke="none"/>
-    <circle cx="15.5" cy="12" r="1.2" fill="currentColor" stroke="none"/>
-  </svg>
-)
-
-const ChartSvg = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-    <rect x="3" y="12" width="4" height="9" rx="0.5"/>
-    <rect x="10" y="6" width="4" height="15" rx="0.5"/>
-    <rect x="17" y="9" width="4" height="12" rx="0.5"/>
-    <line x1="2" y1="21.5" x2="22" y2="21.5" stroke="currentColor" strokeWidth="1.5"/>
-  </svg>
-)
 
 function DrillHeader({
   onToggleQuickSwitch,

--- a/src/components/drill/DrillVerbos.css
+++ b/src/components/drill/DrillVerbos.css
@@ -178,47 +178,40 @@
 .verbos-drill .icon-btn {
   background: transparent;
   border: 1px solid transparent;
-  padding: 6px 7px;
+  padding: 5px 7px;
   line-height: 0;
-  color: var(--vd-ink2);
+  /* Muted white — clearly visible but not blinding */
+  color: rgba(244, 241, 234, 0.55);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
   position: relative;
 }
 
-.verbos-drill .icon-btn img,
 .verbos-drill .icon-btn svg {
-  filter: invert(1) brightness(0.72);
-  width: 20px;
-  height: 20px;
+  width: 22px;
+  height: 22px;
   display: block;
+  flex-shrink: 0;
 }
 
 .verbos-drill .icon-btn:hover {
   border-color: var(--vd-line);
-  background: rgba(255,255,255,0.04);
+  background: rgba(255,255,255,0.05);
   color: var(--vd-ink);
   transform: none;
   box-shadow: none;
 }
 
-.verbos-drill .icon-btn:hover img,
-.verbos-drill .icon-btn:hover svg {
-  filter: invert(1) brightness(1);
-}
-
 .verbos-drill .icon-btn.active {
   border-color: var(--vd-accent);
-  background: rgba(255, 77, 28, 0.08);
+  background: rgba(255, 77, 28, 0.1);
+  color: var(--vd-accent);
 }
 
-.verbos-drill .icon-btn.active img,
-.verbos-drill .icon-btn.active svg {
-  filter: invert(1) sepia(1) saturate(5) hue-rotate(320deg) brightness(1);
-}
+/* No filter overrides needed — SVGs use currentColor */
 
 /* Pronunciation icon — pulsing dot when recording */
 .verbos-drill .icon-btn.recording::after {

--- a/src/components/learning/CommunicativePractice.jsx
+++ b/src/components/learning/CommunicativePractice.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { BackSvg } from '../shared/DrillIcons.jsx';
 import { formatMoodTense } from '../../lib/utils/verbLabels.js';
 import { updateSchedule } from '../../lib/progress/srs.js';
 import { getCurrentUserId } from '../../lib/progress/userManager/index.js';
@@ -581,7 +582,7 @@ function CommunicativePractice({ tense, eligibleForms, onBack, onFinish }) {
       <div className="center-column">
         <div className="drill-header-learning">
             <button onClick={onBack} className="back-btn-drill">
-                <img src="/back.png" alt="Volver" className="back-icon" />
+                <BackSvg size={20} />
             </button>
             <h2>Práctica Comunicativa: {formatMoodTense(tense.mood, tense.tense)}</h2>
         </div>

--- a/src/components/learning/EndingsDrill.jsx
+++ b/src/components/learning/EndingsDrill.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback, Suspense } from 'react';
+import { SpeakerSvg } from '../shared/DrillIcons.jsx';
 import { diffChars } from 'diff';
 import { useSettings } from '../../state/settings.js';
 import { categorizeLearningVerb } from '../../lib/data/learningIrregularFamilies.js';
@@ -681,7 +682,7 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
                   : <span className="ld-incorrect">→ <strong>{result.value}</strong></span>
                 }
                 <button type="button" className="ld-tts-btn" onClick={handleSpeak} title="Pronunciar" aria-label="Pronunciar">
-                  <img src="/megaf-imperat.png" alt="Pronunciar" style={{ width:20,height:20,filter:'invert(1) opacity(0.6)' }} />
+                  <SpeakerSvg />
                 </button>
               </div>
             )}

--- a/src/components/learning/LearningDrill.css
+++ b/src/components/learning/LearningDrill.css
@@ -130,13 +130,23 @@
 
 .ld-tts-btn {
   background: transparent;
-  border: none;
+  border: 1px solid #1f1d18;
   cursor: pointer;
-  padding: 4px;
-  opacity: 0.5;
-  transition: opacity 0.15s;
+  padding: 5px 8px;
+  color: rgba(244, 241, 234, 0.55);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: color 0.15s, border-color 0.15s;
 }
-.ld-tts-btn:hover { opacity: 1; }
+.ld-tts-btn:hover {
+  color: #f4f1ea;
+  border-color: #ff4d1c;
+}
 
 /* ── Accent keypad ── */
 .ld-accent-row {
@@ -204,16 +214,24 @@
 .ld-util-btn {
   background: transparent;
   border: 1px solid #1f1d18;
-  color: #6e6a60;
-  font-size: 14px;
-  padding: 8px 12px;
+  color: rgba(244, 241, 234, 0.55);
+  padding: 8px 10px;
   cursor: pointer;
-  transition: all 0.15s;
-  line-height: 1;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  line-height: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .ld-util-btn:hover {
   border-color: #ff4d1c;
+  color: #f4f1ea;
+}
+
+.ld-util-active {
+  border-color: #ff4d1c;
+  background: rgba(255, 77, 28, 0.1);
   color: #ff4d1c;
 }
 

--- a/src/components/learning/LearningDrill.jsx
+++ b/src/components/learning/LearningDrill.jsx
@@ -48,6 +48,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback, useMemo, Suspense } from 'react';
+import { AccentsSvg, MicSvg, ChartSvg, HomeSvg, SpeakerSvg } from '../shared/DrillIcons.jsx';
 import { TENSE_LABELS } from '../../lib/utils/verbLabels.js';
 import SessionSummary from './SessionSummary.jsx';
 import { useProgressTracking } from '../../features/drill/useProgressTracking.js';
@@ -1015,8 +1016,8 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
                   ? <span className="ld-correct">✓ correcto</span>
                   : <span className="ld-incorrect">→ <strong>{currentItem.value}</strong></span>
                 }
-                <button type="button" className="ld-tts-btn" onClick={handleSpeak} title="Pronunciar" aria-label="Pronunciar">
-                  <img src="/megaf-imperat.png" alt="Pronunciar" style={{ width: 20, height: 20, filter: 'invert(1) opacity(0.6)' }} />
+                <button type="button" className="ld-tts-btn" onClick={handleSpeak} title="Escuchar pronunciación" aria-label="Escuchar pronunciación">
+                  <SpeakerSvg /><span>escuchar</span>
                 </button>
               </div>
             )}
@@ -1049,10 +1050,18 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
 
         {/* Utility row */}
         <div className="ld-utils">
-          <button className="ld-util-btn" onClick={() => setShowAccentKeys(v => !v)} title="Tildes" style={{ fontFamily: 'JetBrains Mono, monospace', background: showAccentKeys ? ACCENT : 'transparent', color: showAccentKeys ? '#0c0c0c' : INK2 }}>Ñ</button>
-          <button className="ld-util-btn" onClick={() => handleTogglePronunciation()} title="Pronunciación" style={{ fontFamily: 'JetBrains Mono, monospace' }}>◉</button>
-          <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas" style={{ fontFamily: 'JetBrains Mono, monospace' }}>⬡</button>
-          <button className="ld-util-btn" onClick={onHome} title="Inicio" style={{ fontFamily: 'JetBrains Mono, monospace' }}>⌂</button>
+          <button className={`ld-util-btn${showAccentKeys ? ' ld-util-active' : ''}`} onClick={() => setShowAccentKeys(v => !v)} title="Tildes" aria-label="Tildes" aria-pressed={showAccentKeys}>
+            <AccentsSvg size={18} />
+          </button>
+          <button className="ld-util-btn" onClick={() => handleTogglePronunciation()} title="Pronunciación" aria-label="Pronunciación">
+            <MicSvg size={18} />
+          </button>
+          <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas" aria-label="Métricas">
+            <ChartSvg size={18} />
+          </button>
+          <button className="ld-util-btn" onClick={onHome} title="Inicio" aria-label="Inicio">
+            <HomeSvg size={18} />
+          </button>
         </div>
       </div>
 

--- a/src/components/learning/MeaningfulPractice.jsx
+++ b/src/components/learning/MeaningfulPractice.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { BackSvg, HomeSvg } from '../shared/DrillIcons.jsx';
 import { formatMoodTense } from '../../lib/utils/verbLabels.js';
 import { updateSchedule } from '../../lib/progress/srs.js';
 import { getCurrentUserId } from '../../lib/progress/userManager/index.js';
@@ -890,12 +891,12 @@ function MeaningfulPractice({
         <div className="header-nav">
           {onBack && (
             <button onClick={onBack} className="back-to-menu-btn" aria-label="Volver">
-              <img src="/back.png" alt="Volver" className="back-icon" />
+              <BackSvg size={20} />
             </button>
           )}
           {onHome && (
             <button onClick={onHome} className="icon-btn" aria-label="Inicio" title="Inicio">
-              <img src="/home.png" alt="Inicio" className="menu-icon" />
+              <HomeSvg size={20} />
             </button>
           )}
       </div>

--- a/src/components/learning/NonfiniteGuidedDrill.jsx
+++ b/src/components/learning/NonfiniteGuidedDrill.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { BackSvg, AccentsSvg, ChartSvg, HomeSvg } from '../shared/DrillIcons.jsx'
 import { useSettings } from '../../state/settings.js'
 import { buildGerund, buildParticiple } from '../../lib/core/nonfiniteBuilder.js'
 import { getVerbByLemma, preloadNonfiniteSets } from '../../lib/core/verbDataService.js'
@@ -393,7 +394,7 @@ function NonfiniteGuidedDrill({
         <header className="header">
           <div className="icon-row">
             <button onClick={onBack} className="icon-btn" title="Volver" aria-label="Volver">
-              <img src="/back.png" alt="Volver" className="menu-icon" />
+              <BackSvg size={20} />
             </button>
           </div>
         </header>
@@ -419,16 +420,16 @@ function NonfiniteGuidedDrill({
             title="Tildes"
             aria-label="Tildes"
           >
-            <img src="/enie.png" alt="Tildes" className="menu-icon" />
+            <AccentsSvg size={20} />
           </button>
           {onGoToProgress && (
             <button onClick={onGoToProgress} className="icon-btn" title="Métricas" aria-label="Métricas">
-              <img src="/icons/chart.png" alt="Métricas" className="menu-icon" />
+              <ChartSvg size={20} />
             </button>
           )}
           {onHome && (
             <button onClick={onHome} className="icon-btn" title="Inicio" aria-label="Inicio">
-              <img src="/home.png" alt="Inicio" className="menu-icon" />
+              <HomeSvg size={20} />
             </button>
           )}
         </div>

--- a/src/components/learning/PronunciationPractice.jsx
+++ b/src/components/learning/PronunciationPractice.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { BackSvg } from '../shared/DrillIcons.jsx';
 import { TENSE_LABELS } from '../../lib/utils/verbLabels.js';
 import SpeechRecognitionService from '../../lib/pronunciation/speechRecognition.js';
 import PronunciationAnalyzer from '../../lib/pronunciation/pronunciationAnalyzer.js';
@@ -354,7 +355,7 @@ function PronunciationPractice({ tense, eligibleForms, onBack, onContinue }) {
           <div className="pronunciation-container">
             <div className="drill-header">
               <button onClick={onBack} className="back-to-menu-btn">
-                <img src="/back.png" alt="Volver" className="back-icon" />
+                <BackSvg size={20} />
                 Volver
               </button>
               <h2>Práctica de Pronunciación</h2>
@@ -639,7 +640,7 @@ function PronunciationPractice({ tense, eligibleForms, onBack, onContinue }) {
           <div className="pronunciation-container">
             <div className="drill-header">
               <button onClick={onBack} className="back-to-menu-btn">
-                <img src="/back.png" alt="Volver" className="back-icon" />
+                <BackSvg size={20} />
                 Volver
               </button>
               <h2>Práctica de Pronunciación</h2>
@@ -661,7 +662,7 @@ function PronunciationPractice({ tense, eligibleForms, onBack, onContinue }) {
           <div className="pronunciation-container">
             <div className="drill-header">
               <button onClick={onBack} className="back-to-menu-btn">
-                <img src="/back.png" alt="Volver" className="back-icon" />
+                <BackSvg size={20} />
                 Volver
               </button>
               <h2>Práctica de Pronunciación</h2>

--- a/src/components/shared/DrillIcons.jsx
+++ b/src/components/shared/DrillIcons.jsx
@@ -1,0 +1,77 @@
+/**
+ * DrillIcons — SVG icon components compartidos entre el drill principal
+ * y los drills del módulo de aprendizaje.
+ *
+ * Todos usan fill/stroke="currentColor" para heredar el color del CSS.
+ * Tamaño por defecto: 22×22 (override con width/height props o CSS).
+ */
+
+const SIZE = 22
+
+export const ConfigSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="4" y1="6" x2="20" y2="6"/>
+    <line x1="4" y1="12" x2="20" y2="12"/>
+    <line x1="4" y1="18" x2="20" y2="18"/>
+    <circle cx="8"  cy="6"  r="2" fill="currentColor" stroke="none"/>
+    <circle cx="16" cy="12" r="2" fill="currentColor" stroke="none"/>
+    <circle cx="10" cy="18" r="2" fill="currentColor" stroke="none"/>
+  </svg>
+)
+
+export const AccentsSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <text x="2" y="19" fontFamily="serif" fontSize="18" fontWeight="bold" fill="currentColor">Ñ</text>
+  </svg>
+)
+
+export const MicSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 14c1.66 0 3-1.34 3-3V5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3z"/>
+    <path d="M17 11c0 2.76-2.24 5-5 5s-5-2.24-5-5H5c0 3.53 2.61 6.43 6 6.92V21h2v-3.08c3.39-.49 6-3.39 6-6.92h-2z"/>
+  </svg>
+)
+
+export const DiceSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2"/>
+    <circle cx="8.5"  cy="8.5"  r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="8.5"  r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="8.5"  cy="12"   r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="12"   r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="8.5"  cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+    <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+  </svg>
+)
+
+export const ChartSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <rect x="3"  y="12" width="4" height="9"  rx="0.5"/>
+    <rect x="10" y="6"  width="4" height="15" rx="0.5"/>
+    <rect x="17" y="9"  width="4" height="12" rx="0.5"/>
+    <rect x="2"  y="21" width="20" height="1.5" rx="0.5"/>
+  </svg>
+)
+
+export const BackSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="15 18 9 12 15 6"/>
+  </svg>
+)
+
+export const HomeSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"/>
+    <polyline points="9 21 9 13 15 13 15 21"/>
+  </svg>
+)
+
+export const SpeakerSvg = ({ size = 18 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/>
+  </svg>
+)


### PR DESCRIPTION
## Resumen
Tres mejoras visuales y de UX relacionadas con los íconos y la pronunciación.
## Cambios
### 1. Panel de pronunciación (rediseño)
- Palabra target en tipografía grande naranja (no más panel genérico)
- Botón de micrófono prominente con animación pulsante
- Botón speaker para escuchar pronunciación correcta
- Waveform en tiempo real durante la grabación
- Barra de precisión con colores semánticos
### 2. Íconos del header del drill — fix crítico de visibilidad
- `dice.png` era blanco → invertido a negro → invisible en fondo oscuro
- `chart.png` tenía alpha ≈ 0 → transparente
- Reemplazados todos los PNG por SVGs inline con `currentColor`
- Íconos claros en reposo, blancos al hover, naranja en estado activo
### 3. Unificación de íconos entre drill y módulo de aprendizaje
- Crea `src/components/shared/DrillIcons.jsx` con 8 SVGs compartidos
- LearningDrill: `Ñ/◉/⬡/⌂` unicode → SVGs
- NonfiniteGuidedDrill: `back.png/enie.png/chart.png/home.png` → SVGs
- EndingsDrill, MeaningfulPractice, CommunicativePractice, PronunciationPractice: idem