### PR TITLE
feat(learning): aplicar rediseño del ícono de micrófono al módulo de …

### DIFF
--- a/src/components/learning/EndingsDrill.jsx
+++ b/src/components/learning/EndingsDrill.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback, Suspense } from 'react';
-import { SpeakerSvg } from '../shared/DrillIcons.jsx';
+import { SpeakerSvg, AccentsSvg, MicSvg, ChartSvg, HomeSvg } from '../shared/DrillIcons.jsx';
 import { diffChars } from 'diff';
 import { useSettings } from '../../state/settings.js';
 import { categorizeLearningVerb } from '../../lib/data/learningIrregularFamilies.js';
@@ -205,6 +205,7 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
   const settings = useSettings();
   const [showAccentKeys, setShowAccentKeys] = useState(false);
   const [showPronunciation, setShowPronunciation] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
   const pronunciationPanelRef = useRef(null);
 
   // console.log('EndingsDrill settings:', { useVoseo: settings.useVoseo, useVosotros: settings.useVosotros });
@@ -640,6 +641,7 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
             onClose={() => handleTogglePronunciation(false)}
             handleResult={handleDrillResult}
             onContinue={handleContinueFromPronunciation}
+            onRecordingChange={setIsRecording}
           />
         </Suspense>
       )}
@@ -739,10 +741,14 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
 
         {/* Utilities */}
         <div className="ld-utils">
-          <button className="ld-util-btn" onClick={() => setShowAccentKeys(v => !v)} title="Tildes" style={{ background: showAccentKeys ? ACCENT : 'transparent', color: showAccentKeys ? '#0c0c0c' : INK2 }}>Ñ</button>
-          <button className="ld-util-btn" onClick={() => handleTogglePronunciation()} title="Pronunciación">◉</button>
-          {onGoToProgress && <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas">⬡</button>}
-          {onHome && <button className="ld-util-btn" onClick={onHome} title="Inicio">⌂</button>}
+          <button className={`ld-util-btn${showAccentKeys ? ' ld-util-active' : ''}`} onClick={() => setShowAccentKeys(v => !v)} title="Tildes" aria-label="Tildes" aria-pressed={showAccentKeys}>
+            <AccentsSvg size={18} />
+          </button>
+          <button className={`ld-util-btn${showPronunciation ? ' ld-util-active' : ''}${isRecording ? ' ld-util-recording' : ''}`} onClick={() => handleTogglePronunciation()} title="Pronunciación" aria-label="Pronunciación" aria-pressed={showPronunciation}>
+            <MicSvg size={18} />
+          </button>
+          {onGoToProgress && <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas" aria-label="Métricas"><ChartSvg size={18} /></button>}
+          {onHome && <button className="ld-util-btn" onClick={onHome} title="Inicio" aria-label="Inicio"><HomeSvg size={18} /></button>}
         </div>
       </div>
 

--- a/src/components/learning/LearningDrill.css
+++ b/src/components/learning/LearningDrill.css
@@ -235,6 +235,28 @@
   color: #ff4d1c;
 }
 
+/* Punto pulsante en el ícono del micrófono mientras se graba */
+.ld-util-btn.ld-util-recording {
+  position: relative;
+}
+
+.ld-util-btn.ld-util-recording::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff4d1c;
+  animation: ldRecDot 1s ease-in-out infinite;
+}
+
+@keyframes ldRecDot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.7); }
+}
+
 /* ── Mobile ── */
 @media (max-width: 680px) {
   .ld-main {

--- a/src/components/learning/LearningDrill.jsx
+++ b/src/components/learning/LearningDrill.jsx
@@ -156,6 +156,7 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
   const settings = useSettings();
   const [showAccentKeys, setShowAccentKeys] = useState(false);
   const [showPronunciation, setShowPronunciation] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
   const pronunciationPanelRef = useRef(null);
 
   // Toggle pronunciation function
@@ -978,6 +979,7 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
             onClose={() => handleTogglePronunciation(false)}
             handleResult={handleDrillResult}
             onContinue={handleContinueFromPronunciation}
+            onRecordingChange={setIsRecording}
           />
         </Suspense>
       )}
@@ -1053,7 +1055,7 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
           <button className={`ld-util-btn${showAccentKeys ? ' ld-util-active' : ''}`} onClick={() => setShowAccentKeys(v => !v)} title="Tildes" aria-label="Tildes" aria-pressed={showAccentKeys}>
             <AccentsSvg size={18} />
           </button>
-          <button className="ld-util-btn" onClick={() => handleTogglePronunciation()} title="Pronunciación" aria-label="Pronunciación">
+          <button className={`ld-util-btn${showPronunciation ? ' ld-util-active' : ''}${isRecording ? ' ld-util-recording' : ''}`} onClick={() => handleTogglePronunciation()} title="Pronunciación" aria-label="Pronunciación" aria-pressed={showPronunciation}>
             <MicSvg size={18} />
           </button>
           <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas" aria-label="Métricas">


### PR DESCRIPTION
…aprendizaje

- LearningDrill: agrega estado isRecording, pasa onRecordingChange al PronunciationPanel, añade clases ld-util-active (panel abierto) y ld-util-recording (grabando) al botón mic
- EndingsDrill: reemplaza íconos Unicode (Ñ, ◉, ⬡, ⌂) por SVGs compartidos de DrillIcons, agrega estado isRecording y onRecordingChange, alinea comportamiento visual con drill principal
- LearningDrill.css: agrega animación ldRecDot para el punto pulsante durante grabación