### PR TITLE
feat(learning): rediseño de NarrativeIntroduction al nivel visual del…

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -1,18 +1,67 @@
-/* Narrative Introduction - VERB/OS shell */
-
 /* ── VERB/OS shell overrides for NarrativeIntroduction ── */
 .ni-right-panel {
   gap: 0;
+  justify-content: flex-start !important;
+  overflow-y: auto;
 }
 
 .ni-content-inner {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0;
   width: 100%;
   padding-bottom: 2rem;
 }
 
+/* Section headers — in-flow, monospace muted label + hairline */
+.ni-section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #2a2823;
+  margin-bottom: 20px;
+}
+
+.ni-section-header::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #1f1d18;
+}
+
+/* Story block */
+.ni-story-block {
+  margin-bottom: 36px;
+}
+
+.ni-story-title {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 13px;
+  font-style: italic;
+  font-weight: 300;
+  letter-spacing: 0.03em;
+  color: #6e6a60;
+  margin-bottom: 20px;
+  line-height: 1.5;
+  text-transform: none;
+}
+
+.ni-not-implemented {
+  color: #6e6a60;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+}
+
+/* Analysis block */
+.ni-analysis-block {
+  margin-bottom: 24px;
+}
+
+/* Continue button */
 .ni-continue-btn {
   align-self: flex-end;
   background: #ff4d1c;
@@ -27,22 +76,19 @@
   cursor: pointer;
   transition: opacity 0.15s;
   text-transform: lowercase;
-  margin-top: 0.5rem;
+  margin-top: 8px;
 }
 
 .ni-continue-btn:hover { opacity: 0.85; }
 .ni-continue-btn:active { opacity: 0.7; }
 
+.ni-continue-arrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8em;
+  font-style: normal;
+}
+
 .ni-leaving { opacity: 0; transition: opacity 0.3s; }
-
-/* story-placeholder and deconstruction-placeholder: tweak for right-panel context */
-.ni-content-inner .story-placeholder {
-  margin-bottom: 0;
-}
-
-.ni-content-inner .deconstruction-placeholder {
-  margin-bottom: 0;
-}
 
 @media (max-width: 680px) {
   .ni-continue-btn {
@@ -51,137 +97,17 @@
   }
 }
 
-/* ── Legacy styles below ── */
-
-.narrative-intro {
-  max-width: 800px;
-  margin: 0 auto;
-  width: 100%;
-  text-align: center;
-}
-
-.narrative-header {
-  position: relative;
-  margin-bottom: 3rem;
-}
-
-.narrative-header .back-btn {
-  position: absolute;
-  top: -1rem;
-  left: 0;
-  margin: 0;
-  background: transparent;
-  border: 2px solid var(--text);
-  border-radius: 0;
-  padding: 0.5rem;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.narrative-header .back-btn:hover {
-  background: var(--text);
-  box-shadow: 4px 4px 0px var(--accent-orange);
-  transform: translate(-2px, -2px);
-}
-
-.narrative-header .back-btn:active {
-  transform: translate(2px, 2px);
-  box-shadow: 0px 0px 0px var(--accent-orange);
-}
-
-.narrative-header .back-btn:hover img {
-  filter: invert(1);
-}
-
-.narrative-header h1 {
-  font-size: 4.5rem;
-  font-weight: 800;
-  text-transform: uppercase;
-  margin-bottom: 0.5rem;
-  color: var(--text);
-  letter-spacing: -0.04em;
-  line-height: 0.95;
-}
-
-.narrative-intro .narrative-header .subtitle {
-  font-size: 1.25rem;
-  margin-bottom: 0;
-  color: var(--accent-orange) !important;
-  line-height: 1.5;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-}
-
-.narrative-content {
-  margin-bottom: 2rem;
-}
-
-/* Enhanced page-level transitions for smooth flow */
-.page-transition {
-  opacity: 0;
-  transform: translateY(12px) scale(0.98);
-  transition: opacity 380ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
-    transform 380ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
-
-.page-transition.page-in {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-
-.page-transition.page-out {
-  opacity: 0;
-  transform: translateY(-8px) scale(1.02);
-  transition: opacity 280ms cubic-bezier(0.55, 0.06, 0.68, 0.19),
-    transform 280ms cubic-bezier(0.55, 0.06, 0.68, 0.19);
-}
-
-/* Story section */
-.story-placeholder {
-  background: rgba(10, 10, 10, 0.4);
-  border: 2px solid var(--text);
-  border-top: 6px solid var(--accent-orange);
-  padding: 2.5rem 2rem;
-  margin-bottom: 2rem;
-  position: relative;
-}
-
-.story-placeholder::before {
-  content: "DATA_SET //";
-  position: absolute;
-  top: -24px;
-  right: 0;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--accent-orange);
-  letter-spacing: 0.1em;
-}
-
-.story-placeholder h3 {
-  font-size: 1rem;
-  font-family: var(--font-mono);
-  font-weight: 600;
-  margin-bottom: 1.5rem;
-  color: var(--text);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  padding-bottom: 0.75rem;
-}
+/* ── Story sentences ── */
 
 .story-sentence {
-  font-size: 1.15rem;
-  line-height: 1.65;
-  margin-bottom: 1rem;
-  color: var(--text);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  margin-bottom: 0.75rem;
+  color: #f4f1ea;
   opacity: 0;
-  /* hidden until animated in */
-  transform: translateY(12px);
-  transition: all 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-  letter-spacing: 0.01em;
+  transform: translateY(10px);
+  transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
+              transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .story-sentence.visible {
@@ -189,54 +115,17 @@
   transform: translateY(0);
 }
 
-/* Ensure newly mounted sentences animate in consistently across mobile/desktop */
-.story-sentence.enter {
-  animation: storySentenceIn 600ms cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-@keyframes storySentenceIn {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 .story-sentence .highlight {
-  color: #000000;
-  background: var(--accent-orange);
-  font-weight: 800;
-  padding: 0.15em 0.4em;
-  border: none;
-  font-family: var(--font-mono);
-  font-size: 0.9em;
+  color: #0c0c0c;
+  background: #ff4d1c;
+  font-weight: 700;
+  padding: 0.1em 0.35em;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.88em;
   text-transform: uppercase;
-  box-shadow: 2px 2px 0px var(--text);
 }
 
-/* Verb deconstruction section */
-.deconstruction-placeholder {
-  background: transparent;
-  border: 2px solid var(--text);
-  padding: 0;
-  position: relative;
-}
-
-.deconstruction-placeholder::before {
-  content: "ANALYSIS //";
-  position: absolute;
-  top: -24px;
-  left: 0;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text);
-  opacity: 0.6;
-  letter-spacing: 0.1em;
-}
+/* ── Deconstruction list ── */
 
 .deconstruction-list {
   display: flex;
@@ -248,8 +137,8 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem 2rem;
-  border-bottom: 1px solid var(--border);
+  padding: 1.25rem 0;
+  border-bottom: 1px solid #1f1d18;
   gap: 1.5rem;
 }
 
@@ -257,89 +146,78 @@
   border-bottom: none;
 }
 
+/* Verb lemma */
 .verb-lemma {
-  font-size: 1rem;
-  color: var(--text);
-  letter-spacing: 0.05em;
+  font-size: 0.95rem;
+  color: #f4f1ea;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   font-weight: 700;
-  animation: slideInFromTop 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
+  font-family: 'JetBrains Mono', monospace;
   flex-shrink: 0;
 }
 
-.lemma-stem {
-  color: var(--text);
-}
+.lemma-stem  { color: #f4f1ea; }
+.group-label { color: #ff4d1c; opacity: 0.85; }
 
-.group-label {
-  color: var(--accent-orange);
-  opacity: 0.9;
-  margin-left: 0rem;
-  /* glue suffix to stem (e.g., habl-ar) */
-}
-
+/* Verb deconstruction row */
 .verb-deconstruction {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.75rem;
-  font-family: var(--font-mono);
-  font-size: 1.1rem;
+  gap: 0.6rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
   font-weight: 600;
   flex-grow: 1;
   flex-wrap: wrap;
 }
 
-/* Irregular forms: show base in white, irregular fragments in orange with emphasis */
-.verb-deconstruction.irregular .conjugated-form {
-  color: var(--text);
-}
+/* Irregular forms */
+.verb-deconstruction.irregular .conjugated-form { color: #f4f1ea; }
 
 .verb-deconstruction.irregular .conjugated-form .irreg-frag {
-  color: var(--accent-orange);
+  color: #ff4d1c;
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: var(--accent-orange);
+  text-decoration-color: #ff4d1c;
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
 
-/* Global irregular fragment style for narrative sentences */
 .irreg-frag {
-  color: var(--accent-orange) !important;
+  color: #ff4d1c !important;
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: var(--accent-orange);
+  text-decoration-color: #ff4d1c;
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
 
-/* Override irreg-frag inside sentence highlights (orange bg → orange text is invisible) */
+/* Overrides inside orange backgrounds */
 .story-sentence .highlight .irreg-frag {
   color: #ffffff !important;
   text-decoration-color: #ffffff;
 }
 
-/* Override irreg-frag inside yo-form-highlight (orange bg → orange text is invisible) */
 .yo-form-highlight .irreg-frag {
   color: #ffffff !important;
   text-decoration-color: #ffffff;
 }
 
 .verb-deconstruction.irregular .form-separator {
-  color: var(--text);
-  opacity: 0.9;
+  color: #6e6a60;
 }
 
+/* Stem box */
 .verb-stem {
-  color: var(--text);
+  color: #f4f1ea;
   background: transparent;
-  padding: 0.5rem 1rem;
-  border: 2px solid var(--text);
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #2a2823;
   text-transform: uppercase;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.05em;
-  animation: fadeSlideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
 }
 
 .verb-endings {
@@ -350,331 +228,69 @@
 .ending-carousel {
   display: flex;
   gap: 0.2rem;
-  /* Allow wrapping to avoid overflow */
   flex-wrap: wrap;
 }
 
 .ending-item {
-  color: var(--bg);
-  background: var(--text);
-  padding: 0.5rem 0.75rem;
-  border: none;
-  font-size: 1.2em;
-  font-weight: 800;
+  color: #0c0c0c;
+  background: #f4f1ea;
+  padding: 0.4rem 0.65rem;
+  font-size: 1em;
+  font-weight: 700;
   text-transform: uppercase;
-  animation: fadeSlideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   opacity: 0;
-  transform: translateY(12px);
+  transform: translateY(10px);
 }
 
-.ending-item:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.ending-item:nth-child(2) {
-  animation-delay: 0.15s;
-}
-
-.ending-item:nth-child(3) {
-  animation-delay: 0.2s;
-}
-
-.ending-item:nth-child(4) {
-  animation-delay: 0.25s;
-}
-
-.ending-item:nth-child(5) {
-  animation-delay: 0.3s;
-}
-
-.ending-item:nth-child(6) {
-  animation-delay: 0.35s;
-}
+.ending-item:nth-child(1) { animation-delay: 0.05s; }
+.ending-item:nth-child(2) { animation-delay: 0.10s; }
+.ending-item:nth-child(3) { animation-delay: 0.15s; }
+.ending-item:nth-child(4) { animation-delay: 0.20s; }
+.ending-item:nth-child(5) { animation-delay: 0.25s; }
+.ending-item:nth-child(6) { animation-delay: 0.30s; }
 
 @keyframes fadeSlideUp {
-  0% {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  0%   { opacity: 0; transform: translateY(10px); }
+  100% { opacity: 1; transform: translateY(0); }
 }
 
-@keyframes slideInFromTop {
-  from {
-    opacity: 0;
-    transform: translateY(-15px) scale(0.95);
-  }
+/* ── Group items — clean, no heavy box ── */
 
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes fadeInScale {
-  from {
-    opacity: 0;
-    transform: scale(0.9);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-/* Continue button */
-.narrative-intro .btn {
-  margin: 2rem auto 0;
-  max-width: 300px;
-  gap: 0.5rem;
-  background: var(--text);
-  color: var(--bg);
+.deconstruction-item.strong-preterite-group,
+.deconstruction-item.future-root-group,
+.deconstruction-item.nonfinite-irregular-group {
   border: none;
-  border-radius: 0;
-  text-transform: uppercase;
-  font-family: var(--font-mono);
-  font-weight: 800;
-  letter-spacing: 0.15em;
-  padding: 1.25rem 2rem;
-  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 6px 6px 0px var(--accent-orange);
-}
-
-.narrative-intro .btn:hover {
-  transform: translate(-2px, -2px);
-  box-shadow: 8px 8px 0px var(--accent-orange);
-  color: var(--bg);
-}
-
-.narrative-intro .btn:active {
-  transform: translate(4px, 4px);
-  box-shadow: 2px 2px 0px var(--accent-orange);
-}
-
-/* Mobile optimizations */
-@media (max-width: 768px) {
-  .narrative-header h1 {
-    font-size: 2.5rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .narrative-header .subtitle {
-    font-size: 1rem;
-  }
-
-  /* Ajuste: menos padding vertical en el cuadro de narrativa en móvil */
-  .story-placeholder {
-    padding: 0.9rem 1.1rem;
-  }
-
-  .deconstruction-placeholder {
-    padding: 0;
-  }
-
-  .deconstruction-item {
-    flex-direction: column;
-    align-items: flex-start;
-    padding: 1.25rem;
-    gap: 1rem;
-  }
-
-  .verb-deconstruction {
-    justify-content: flex-start;
-  }
-
-  .story-placeholder h3 {
-    font-size: 1.25rem;
-    margin-bottom: 0.7rem;
-  }
-
-  .story-sentence {
-    font-size: 1rem;
-    margin-bottom: 0.55rem;
-  }
-
-  .verb-deconstruction {
-    font-size: 1.2rem;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-  }
-
-  .deconstruction-list {
-    grid-template-columns: 1fr;
-  }
-
-  .ending-carousel {
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .narrative-content {
-    margin-bottom: 2rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .narrative-header h1 {
-    font-size: 2rem;
-  }
-
-  .story-placeholder {
-    padding: 0.75rem 0.9rem;
-  }
-
-  .deconstruction-placeholder {
-    padding: 0;
-  }
-
-  .deconstruction-item {
-    padding: 1rem;
-  }
-
-  .verb-deconstruction {
-    font-size: 1rem;
-  }
-
-  .verb-stem,
-  .ending-item {
-    padding: 0.4rem 0.75rem;
-    font-size: 0.9rem;
-  }
-}
-
-/* Estilos para irregulares de YO con conjugación completa */
-.irregular-yo-verbs-full-conjugation {
+  border-bottom: 1px solid #1f1d18;
+  padding: 1.5rem 0;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  width: 100%;
-}
-
-.irregular-yo-verb-complete {
-  background: transparent;
-  border: 2px solid var(--text);
-  padding: 2rem 1.5rem;
-  display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 1.25rem;
   position: relative;
 }
 
-.irregular-yo-verb-complete::before {
-  content: "IRREG_1S //";
-  position: absolute;
-  top: -12px;
-  left: 16px;
-  background: var(--bg);
-  padding: 0 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text);
-  letter-spacing: 0.1em;
-}
-
-.irregular-yo-verb-complete .verb-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  justify-content: center;
-}
-
-.irregular-yo-verb-complete .yo-form-highlight {
-  font-size: 1.5rem;
-  font-weight: 800;
-  color: var(--bg);
-  background: var(--accent-orange);
-  padding: 0.5rem 1rem;
-  border: none;
-  font-family: var(--font-mono);
+.deconstruction-item.strong-preterite-group::before,
+.deconstruction-item.future-root-group::before,
+.deconstruction-item.nonfinite-irregular-group::before {
+  all: unset;
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  box-shadow: 4px 4px 0px var(--text);
+  color: #2a2823;
+  align-self: flex-start;
 }
 
-.irregular-yo-verb-complete .all-forms-display {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: center;
-  padding-top: 1rem;
-  border-top: 2px dashed rgba(255, 255, 255, 0.15);
-}
+.deconstruction-item.strong-preterite-group::before  { content: 'RAÍCES'; }
+.deconstruction-item.future-root-group::before       { content: 'RAÍCES IRREGULARES'; }
+.deconstruction-item.nonfinite-irregular-group::before { content: 'FORMAS NO FINITAS'; }
 
-.irregular-yo-verb-complete .form-item {
-  font-size: 1rem;
-  color: var(--text);
-  padding: 0.4rem 0.8rem;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  font-family: var(--font-mono);
-}
-
-.irregular-yo-verb-complete .form-item.yo-form-irregular {
-  font-weight: 800;
-  color: var(--bg);
-  background: var(--text);
-  border: 1px solid var(--text);
-}
-
-/* Estilos para pretéritos fuertes agrupados */
-.deconstruction-item.strong-preterite-group {
-  background: transparent;
-  border: 2px solid var(--text);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  position: relative;
-  animation: strongPreteriteAppear 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.deconstruction-item.strong-preterite-group::before {
-  content: "STRONG_PRET //";
-  position: absolute;
-  top: -12px;
-  left: 16px;
-  background: var(--bg);
-  padding: 0 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text);
-  letter-spacing: 0.1em;
-}
-
-.deconstruction-item.future-root-group {
-  background: transparent;
-  border: 2px solid var(--text);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  align-items: center;
-}
-
-.deconstruction-item.future-root-group::before {
-  content: "FUT_ROOT //";
-  position: absolute;
-  top: -12px;
-  left: 16px;
-  background: var(--bg);
-  padding: 0 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text);
-  letter-spacing: 0.1em;
-}
-
+/* Future / conditional root items */
 .future-root-verbs {
   display: flex;
-  gap: 1.5rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
   justify-content: center;
 }
@@ -682,146 +298,130 @@
 .future-root-item {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
   align-items: center;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 1.25rem;
-  min-width: 160px;
+  padding: 1rem 1.25rem;
+  border: 1px solid #1f1d18;
+  min-width: 140px;
 }
 
 .future-root-highlight {
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   font-weight: 800;
-  color: var(--bg);
-  background: var(--accent-orange);
-  padding: 0.2rem 0.6rem;
-  letter-spacing: 0.08em;
-  font-family: var(--font-mono);
-  box-shadow: 3px 3px 0px var(--text);
+  color: #0c0c0c;
+  background: #ff4d1c;
+  padding: 0.15rem 0.5rem;
+  letter-spacing: 0.06em;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .regular-stem-base {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   font-weight: 500;
-  color: var(--text);
+  color: #f4f1ea;
   letter-spacing: 0.02em;
 }
 
 .regular-stem-suffix {
-  font-size: 1.2rem;
-  color: rgba(245, 245, 245, 0.5);
+  font-size: 1.1rem;
+  color: #2a2823;
 }
 
 .regular-ending-highlight {
-  font-size: 1.2rem;
+  font-size: 1.1rem;
   font-weight: 700;
-  color: var(--accent-orange);
-  letter-spacing: 0.05em;
+  color: #ff4d1c;
+  letter-spacing: 0.04em;
   text-decoration: underline;
-  text-decoration-color: rgba(253, 126, 20, 0.4);
+  text-decoration-color: rgba(255, 77, 28, 0.4);
   text-underline-offset: 3px;
 }
 
 .future-root-example {
-  font-size: 0.95rem;
-  color: rgba(245, 245, 245, 0.78);
+  font-size: 0.9rem;
+  color: #6e6a60;
   text-align: center;
 }
 
 .root-endings {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.5rem;
   align-items: center;
 }
 
 .root-endings-title {
-  font-size: 0.9rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: rgba(245, 245, 245, 0.62);
+  letter-spacing: 0.12em;
+  color: #6e6a60;
 }
 
-.deconstruction-item.nonfinite-irregular-group {
-  background: transparent;
-  border: 2px solid var(--text);
-  padding: 2rem 1.5rem;
-  margin-bottom: 2rem;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.deconstruction-item.nonfinite-irregular-group::before {
-  content: "NON_FINITE //";
-  position: absolute;
-  top: -12px;
-  left: 16px;
-  background: var(--bg);
-  padding: 0 0.5rem;
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  color: var(--text);
-  letter-spacing: 0.1em;
-}
-
+/* Non-finite (gerund / participle) */
 .nonfinite-title {
-  font-size: 1rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-weight: 600;
-  color: var(--text);
-  text-align: center;
+  letter-spacing: 0.12em;
+  color: #6e6a60;
+  align-self: center;
 }
 
 .nonfinite-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.85rem;
   justify-content: center;
 }
 
 .nonfinite-item {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 0.85rem 1.25rem;
+  gap: 0.65rem;
+  border: 1px solid #1f1d18;
+  padding: 0.75rem 1rem;
 }
 
-.nonfinite-item .arrow {
-  color: var(--text);
-  font-weight: 800;
-}
+.nonfinite-item .arrow { color: #6e6a60; font-weight: 700; }
 
 .nonfinite-highlight {
   font-weight: 800;
-  color: var(--bg);
-  background: var(--accent-orange);
-  padding: 0.2rem 0.5rem;
-  letter-spacing: 0.06em;
-  font-family: var(--font-mono);
+  color: #0c0c0c;
+  background: #ff4d1c;
+  padding: 0.15rem 0.45rem;
+  letter-spacing: 0.05em;
+  font-family: 'JetBrains Mono', monospace;
 }
 
-@keyframes strongPreteriteAppear {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
+/* ── Verb lemma large (used in group items) ── */
 
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.verb-lemma-large {
+  font-size: 1.3rem;
+  color: #f4f1ea;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-weight: 800;
 }
+
+.lemma-stem-large  { color: #f4f1ea; font-weight: 800; }
+.group-label-large { color: #f4f1ea; opacity: 0.45; font-weight: 800; }
+
+.stem-vowel-highlight-large {
+  color: #0c0c0c;
+  background: #ff4d1c;
+  font-weight: 800;
+  font-size: 1.05em;
+  padding: 0 0.12em;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* ── Strong preterites ── */
 
 .strong-verbs-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.8rem;
+  gap: 0.75rem;
   justify-content: center;
   align-items: center;
 }
@@ -830,273 +430,147 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  animation: verbItemSlideIn 0.5s ease-out both;
+  animation: verbItemSlideIn 0.45s ease-out both;
 }
-
-.strong-verb-item:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.strong-verb-item:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.strong-verb-item:nth-child(3) {
-  animation-delay: 0.3s;
-}
+.strong-verb-item:nth-child(1) { animation-delay: 0.05s; }
+.strong-verb-item:nth-child(2) { animation-delay: 0.12s; }
+.strong-verb-item:nth-child(3) { animation-delay: 0.19s; }
 
 @keyframes verbItemSlideIn {
-  from {
-    opacity: 0;
-    transform: translateX(-15px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
-}
-
-.strong-verb-item .verb-lemma {
-  font-size: 0.9rem;
-  color: var(--text);
-  animation: none;
-}
-
-/* Estilos para verbos más grandes */
-.verb-lemma-large {
-  font-size: 1.5rem;
-  color: var(--text);
-  letter-spacing: 0.02em;
-  animation: none;
-  text-transform: uppercase;
-  font-weight: 800;
-}
-
-.lemma-stem-large {
-  color: var(--text);
-  font-weight: 800;
-}
-
-.group-label-large {
-  color: var(--text);
-  opacity: 0.6;
-  font-weight: 800;
-}
-
-/* Highlighting for changing stem vowels in infinitives */
-.irregular-stem-highlight {
-  color: var(--bg);
-  background: var(--accent-orange);
-  font-weight: 800;
-  padding: 0 0.15em;
-  font-family: var(--font-mono);
-}
-
-/* Larger highlighting for initial presentation */
-.stem-vowel-highlight-large {
-  color: var(--bg);
-  background: var(--accent-orange);
-  font-weight: 800;
-  font-size: 1.1em;
-  padding: 0 0.15em;
-  font-family: var(--font-mono);
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 1; transform: translateX(0); }
 }
 
 .strong-verb-item .arrow {
-  color: var(--text);
-  font-weight: 800;
-  font-size: 1.3rem;
-}
-
-.irregular-stem {
+  color: #6e6a60;
+  font-weight: 700;
   font-size: 1.1rem;
-  font-weight: 800;
-  color: var(--bg);
-  background: var(--text);
-  padding: 0.4rem 0.8rem;
-  border: none;
-  font-family: var(--font-mono);
 }
 
 .irregular-stem-large {
-  font-size: 1.4rem;
+  font-size: 1.3rem;
   font-weight: 800;
-  color: var(--bg);
-  background: var(--text);
-  padding: 0.5rem 1rem;
-  border: none;
-  font-family: var(--font-mono);
-  box-shadow: 4px 4px 0px var(--accent-orange);
+  color: #0c0c0c;
+  background: #f4f1ea;
+  padding: 0.4rem 0.85rem;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .plus-symbol {
-  font-size: 1.5rem;
-  color: var(--text);
+  font-size: 1.3rem;
+  color: #2a2823;
   font-weight: 600;
-  animation: fadeIn 0.5s ease-in-out 0.5s both;
+  animation: fadeIn 0.4s ease-in-out 0.4s both;
 }
 
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
 .strong-endings-carousel {
   display: flex;
-  gap: 0.3rem;
+  gap: 0.25rem;
   flex-wrap: wrap;
   justify-content: center;
 }
 
 .strong-ending-item {
-  color: var(--bg);
-  background: var(--text);
-  padding: 0.4rem 0.8rem;
-  border: none;
-  font-size: 1rem;
-  font-weight: 800;
-  font-family: var(--font-mono);
+  color: #0c0c0c;
+  background: #f4f1ea;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
   text-transform: uppercase;
-  animation: fadeSlideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   opacity: 0;
-  transform: translateY(12px);
+  transform: translateY(10px);
+}
+.strong-ending-item:nth-child(1) { animation-delay: 0.55s; }
+.strong-ending-item:nth-child(2) { animation-delay: 0.62s; }
+.strong-ending-item:nth-child(3) { animation-delay: 0.69s; }
+.strong-ending-item:nth-child(4) { animation-delay: 0.76s; }
+.strong-ending-item:nth-child(5) { animation-delay: 0.83s; }
+.strong-ending-item:nth-child(6) { animation-delay: 0.90s; }
+
+/* ── Irregular YO conjugation ── */
+
+.irregular-yo-verbs-full-conjugation {
+  display: flex;
+  flex-direction: column;
+  gap: 1px; /* collapse borders */
+  width: 100%;
 }
 
-.strong-ending-item:nth-child(1) {
-  animation-delay: 0.7s;
+.irregular-yo-verb-complete {
+  border: none;
+  border-bottom: 1px solid #1f1d18;
+  padding: 1.25rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
 }
 
-.strong-ending-item:nth-child(2) {
-  animation-delay: 0.8s;
+.irregular-yo-verb-complete:last-child { border-bottom: none; }
+
+.irregular-yo-verb-complete .verb-header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
 }
 
-.strong-ending-item:nth-child(3) {
-  animation-delay: 0.9s;
+.irregular-yo-verb-complete .yo-form-highlight {
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #0c0c0c;
+  background: #ff4d1c;
+  padding: 0.4rem 0.85rem;
+  font-family: 'JetBrains Mono', monospace;
+  text-transform: uppercase;
 }
 
-.strong-ending-item:nth-child(4) {
-  animation-delay: 1.0s;
+.irregular-yo-verb-complete .all-forms-display {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #1f1d18;
 }
 
-.strong-ending-item:nth-child(5) {
-  animation-delay: 1.1s;
-}
-
-.strong-ending-item:nth-child(6) {
-  animation-delay: 1.2s;
-}
-
-@keyframes fadeSlideUp {
-  0% {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Responsividad para pretéritos fuertes agrupados */
-@media (max-width: 768px) {
-  .strong-verbs-container {
-    flex-direction: column;
-    gap: 0.6rem;
-  }
-
-  .strong-verb-item {
-    justify-content: center;
-  }
-
-  .verb-lemma-large {
-    font-size: 1.2rem;
-  }
-
-  .irregular-stem-large {
-    font-size: 1.2rem;
-    padding: 0.35rem 0.7rem;
-  }
-
-  .strong-verb-item .arrow {
-    font-size: 1.2rem;
-  }
-
-  .plus-symbol {
-    font-size: 1.3rem;
-  }
-
-  .strong-ending-item {
-    font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .deconstruction-item.strong-preterite-group {
-    padding: 1rem 0.8rem;
-  }
-
-  .verb-lemma-large {
-    font-size: 1.1rem;
-  }
-
-  .irregular-stem-large {
-    font-size: 1.1rem;
-    padding: 0.3rem 0.6rem;
-  }
-
-  .strong-verb-item .arrow {
-    font-size: 1.1rem;
-  }
-
-  .strong-endings-carousel {
-    gap: 0.2rem;
-  }
-
-  .irregular-stem {
-    font-size: 0.9rem;
-    padding: 0.25rem 0.5rem;
-  }
-}
-
-/* Estilos para verbos irregulares solo en terceras personas */
-.deconstruction-item.third-person-irregular-group {
+.irregular-yo-verb-complete .form-item {
+  font-size: 0.9rem;
+  color: #6e6a60;
+  padding: 0.3rem 0.65rem;
   background: transparent;
-  border: 1px solid var(--border);
-  padding: 1.5rem;
-  margin-bottom: 1.5rem;
-  animation: fadeSlideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  border: 1px solid #1f1d18;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.irregular-yo-verb-complete .form-item.yo-form-irregular {
+  font-weight: 800;
+  color: #f4f1ea;
+  background: #2a2823;
+  border-color: #2a2823;
+}
+
+/* ── Third-person irregulars ── */
+
+.deconstruction-item.third-person-irregular-group {
+  border: none;
+  border-bottom: 1px solid #1f1d18;
+  padding: 1.5rem 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.2rem;
-}
-
-@keyframes thirdPersonIrregularAppear {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  gap: 1rem;
 }
 
 .third-person-verbs-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.8rem;
+  gap: 0.65rem;
   justify-content: center;
   align-items: center;
 }
@@ -1104,256 +578,184 @@
 .third-person-verb-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  animation: verbItemSlideIn 0.5s ease-out both;
+  gap: 0.4rem;
+  animation: verbItemSlideIn 0.45s ease-out both;
 }
+.third-person-verb-item:nth-child(1) { animation-delay: 0.05s; }
+.third-person-verb-item:nth-child(2) { animation-delay: 0.12s; }
+.third-person-verb-item:nth-child(3) { animation-delay: 0.19s; }
 
-.third-person-verb-item:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.third-person-verb-item:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.third-person-verb-item:nth-child(3) {
-  animation-delay: 0.3s;
-}
-
-.third-person-verb-item .verb-lemma {
-  font-size: 0.9rem;
-  color: var(--text);
-  animation: none;
-}
-
-.regular-forms-section {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.8rem;
-  background: transparent;
-  border: 1px solid var(--border);
-  padding: 1.5rem;
-  width: 100%;
-}
-
-.regular-forms-title {
-  font-size: 0.9rem;
-  color: var(--accent-green);
-  font-weight: 500;
-  margin-bottom: 0.3rem;
-}
-
-.regular-forms-display {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
+.regular-forms-section,
 .irregular-forms-section {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.8rem;
-  background: transparent;
-  border: 1px solid var(--border);
-  padding: 1.5rem;
+  gap: 0.65rem;
+  padding: 1rem;
   width: 100%;
+  border: 1px solid #1f1d18;
+}
+
+.regular-forms-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  color: #6e6a60;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .irregular-forms-title {
-  font-size: 0.9rem;
-  color: var(--accent-orange);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  color: #ff4d1c;
   font-weight: 500;
-  margin-bottom: 0.3rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
+.regular-forms-display,
 .irregular-forms-display {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
   justify-content: center;
-  align-items: center;
-}
-
-.irregular-form-example {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  background: transparent;
-  border: 1px solid var(--border);
-  padding: 0.4rem 0.6rem;
-  font-family: 'Courier New', monospace;
-  font-size: 0.85rem;
-  animation: irregularFormFadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
-}
-
-.irregular-form-example:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.irregular-form-example:nth-child(2) {
-  animation-delay: 0.15s;
-}
-
-.irregular-form-example:nth-child(3) {
-  animation-delay: 0.2s;
-}
-
-@keyframes irregularFormFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.irregular-form-example .base-form {
-  color: var(--text);
-}
-
-.irregular-form-example .irregular-part {
-  color: var(--accent-orange);
-  font-weight: 600;
 }
 
 .irregular-stem-comparison {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  background: transparent;
-  border: 1px solid var(--border);
-  padding: 0.8rem;
-  animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+  gap: 0.4rem;
+  border: 1px solid #1f1d18;
+  padding: 0.7rem 0.9rem;
+  animation: fadeSlideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .stem-change-display {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  font-family: 'Courier New', monospace;
+  gap: 0.35rem;
+  font-family: 'JetBrains Mono', monospace;
   font-weight: 600;
-}
-
-.normal-stem {
-  color: var(--accent-green);
-  background: transparent;
-  padding: 0;
-  border: none;
   font-size: 0.9rem;
 }
 
-.arrow {
-  color: var(--accent-blue);
-  font-weight: 700;
-  font-size: 1rem;
-}
-
-.irregular-stem-highlight {
-  color: var(--accent-orange);
-  background: transparent;
-  padding: 0;
-  border: none;
-  font-size: 0.9rem;
-  font-weight: 700;
-}
+.normal-stem          { color: #6e6a60; }
+.arrow                { color: #2a2823; font-weight: 700; }
+.irregular-stem-highlight { color: #ff4d1c; font-weight: 700; }
 
 .resulting-forms {
   display: flex;
-  gap: 0.3rem;
+  gap: 0.25rem;
   align-items: center;
 }
 
 .irregular-form {
-  color: var(--text);
-  background: transparent;
+  color: #f4f1ea;
   padding: 0.2rem 0.4rem;
-  border: 1px solid var(--border);
+  border: 1px solid #1f1d18;
   font-size: 0.8rem;
-  font-family: 'Courier New', monospace;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .regular-ending-item {
-  color: var(--accent-green);
+  color: #6e6a60;
   background: transparent;
-  padding: 0.35rem 0.55rem;
-  border: 1px solid var(--border);
-  font-size: 0.9rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid #1f1d18;
+  font-size: 0.88rem;
   font-weight: 600;
-  font-family: 'Courier New', monospace;
-  animation: fadeSlideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  font-family: 'JetBrains Mono', monospace;
+  animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   opacity: 0;
-  transform: translateY(12px);
+  transform: translateY(10px);
+}
+.regular-ending-item:nth-child(1) { animation-delay: 0.05s; }
+.regular-ending-item:nth-child(2) { animation-delay: 0.10s; }
+.regular-ending-item:nth-child(3) { animation-delay: 0.15s; }
+.regular-ending-item:nth-child(4) { animation-delay: 0.20s; }
+
+/* Formation formula */
+.formation-formula {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.regular-ending-item:nth-child(1) {
-  animation-delay: 0.1s;
+.infinitive-part {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  color: #6e6a60;
+  border: 1px solid #1f1d18;
+  padding: 0.3rem 0.6rem;
 }
 
-.regular-ending-item:nth-child(2) {
-  animation-delay: 0.15s;
+.irregular-stem {
+  font-size: 1rem;
+  font-weight: 800;
+  color: #0c0c0c;
+  background: #f4f1ea;
+  padding: 0.35rem 0.7rem;
+  font-family: 'JetBrains Mono', monospace;
 }
 
-.regular-ending-item:nth-child(3) {
-  animation-delay: 0.2s;
+/* ── Animations ── */
+
+@keyframes slideInFromTop {
+  from { opacity: 0; transform: translateY(-12px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
-.regular-ending-item:nth-child(4) {
-  animation-delay: 0.25s;
+@keyframes fadeInScale {
+  from { opacity: 0; transform: scale(0.9); }
+  to   { opacity: 1; transform: scale(1); }
 }
 
-/* Responsividad para verbos irregulares de terceras personas */
+/* ── Mobile ── */
+
 @media (max-width: 768px) {
-  .third-person-verbs-container {
+  .ni-story-block  { margin-bottom: 24px; }
+  .ni-section-header { margin-bottom: 14px; }
+
+  .story-sentence  { font-size: 0.97rem; margin-bottom: 0.6rem; }
+
+  .deconstruction-item {
     flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem 0;
+    gap: 0.75rem;
+  }
+
+  .verb-deconstruction {
+    justify-content: flex-start;
+    font-size: 0.95rem;
+    flex-wrap: wrap;
     gap: 0.6rem;
   }
 
-  .third-person-verb-item {
-    justify-content: center;
-  }
+  .verb-lemma-large { font-size: 1.1rem; }
+  .irregular-stem-large { font-size: 1.1rem; padding: 0.3rem 0.6rem; }
+  .strong-verb-item .arrow { font-size: 1rem; }
+  .plus-symbol { font-size: 1.1rem; }
+  .strong-ending-item { font-size: 0.8rem; padding: 0.25rem 0.5rem; }
 
-  .regular-forms-display,
-  .irregular-forms-display {
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .irregular-form-example {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.5rem;
-  }
-
-  .regular-ending-item {
-    font-size: 0.8rem;
-    padding: 0.25rem 0.5rem;
-  }
+  .regular-forms-section,
+  .irregular-forms-section { padding: 0.75rem; }
 }
 
 @media (max-width: 480px) {
-  .deconstruction-item.third-person-irregular-group {
-    padding: 1rem 0.8rem;
-  }
+  .story-sentence { font-size: 0.92rem; }
 
-  .regular-forms-section,
-  .irregular-forms-section {
-    padding: 0.8rem;
-  }
+  .deconstruction-item { padding: 0.85rem 0; }
 
-  .irregular-form-example {
-    font-size: 0.75rem;
-    padding: 0.25rem 0.4rem;
-  }
+  .verb-stem,
+  .ending-item { padding: 0.35rem 0.6rem; font-size: 0.85rem; }
 
-  .regular-ending-item {
-    font-size: 0.75rem;
-    padding: 0.2rem 0.4rem;
+  .deconstruction-item.strong-preterite-group,
+  .deconstruction-item.future-root-group,
+  .deconstruction-item.nonfinite-irregular-group {
+    padding: 1rem 0;
   }
 }

--- a/src/components/learning/NarrativeIntroduction.jsx
+++ b/src/components/learning/NarrativeIntroduction.jsx
@@ -1376,28 +1376,29 @@ function NarrativeIntroduction({ tense, exampleVerbs = [], onBack, onContinue })
         </div>
 
         {/* RIGHT: story + deconstruction */}
-        <div className="vo-right vo-noscroll ni-right-panel" style={{ justifyContent: 'flex-start', overflowY: 'auto', paddingTop: 48 }}>
-          <div className="vo-options-label">ANÁLISIS ─────</div>
+        <div className="vo-right vo-noscroll ni-right-panel">
           <div className="ni-content-inner">
             {tenseStoryData ? (
               <>
-                <div className="story-placeholder">
-                  <h3>{tenseStoryData.title}</h3>
+                <div className="ni-section-header">CONTEXTO</div>
+                <div className="ni-story-block">
+                  <div className="ni-story-title">{tenseStoryData.title}</div>
                   {renderStorySentences()}
                 </div>
-                <div className="deconstruction-placeholder">
+                <div className="ni-section-header">ANÁLISIS</div>
+                <div className="ni-analysis-block">
                   <div className="deconstruction-list">
                     {renderDeconstructionContent()}
                   </div>
                 </div>
               </>
             ) : (
-              <div className="story-placeholder">
-                <p style={{ color: INK2 }}>Introducción para "{tenseName}" no implementada aún.</p>
+              <div className="ni-story-block">
+                <p className="ni-not-implemented">Introducción para "{tenseName}" no implementada aún.</p>
               </div>
             )}
             <button className="ni-continue-btn" onClick={handleAnimatedContinue}>
-              continuar <span style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '0.8em' }}>→</span>
+              continuar <span className="ni-continue-arrow">→</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
… sistema VERB/OS

- Reemplaza cajas pesadas con borde (story-placeholder, deconstruction-placeholder) por secciones limpias con section headers en-flow (patrón monospace + línea horizontal)
- Elimina pseudo-labels estilo terminal ("DATA_SET //", "ANALYSIS //", "STRONG_PRET //", etc.)
- Título de narrativa: italic/light en muted, integrado al flujo sin caja
- Items de conjugación: border-bottom sutil (#1f1d18) en lugar de border-box pesado
- Grupos especiales (pretéritos fuertes, raíces futuro, yo-irregulares): micro-label en-flow en lugar de pseudo-element absoluto
- Consistencia total con el sistema de colores VERB/OS: #1f1d18 para bordes, #2a2823 para elementos muted, #ff4d1c para accent