### PR TITLE
feat(nav): agregar botón de back visible en onboarding y drill

### DIFF
--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useSettings } from '../../state/settings.js'
 import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
 import { ConfigSvg, AccentsSvg, MicSvg, DiceSvg, ChartSvg } from '../shared/DrillIcons.jsx'
+import router from '../../lib/routing/Router.js'
 
 const DIALECT_LABEL = {
   rioplatense: 'vos',
@@ -60,12 +61,23 @@ function DrillHeader({
 
   return (
     <header className="header">
-      {/* Left: VERB/OS logo → home */}
-      <div className="vd-logo" onClick={onHome} title="Ir al inicio">
-        <div className="vd-logo-dot" />
-        <span className="vd-logo-name">
-          VERB<span style={{ color: '#ff4d1c' }}>/</span>OS
-        </span>
+      {/* Left: back button + VERB/OS logo */}
+      <div className="vd-header-left">
+        <button
+          type="button"
+          className="vd-back-btn"
+          onClick={() => router.back()}
+          title="Volver"
+          aria-label="Volver"
+        >
+          ←
+        </button>
+        <div className="vd-logo" onClick={onHome} title="Ir al inicio">
+          <div className="vd-logo-dot" />
+          <span className="vd-logo-name">
+            VERB<span style={{ color: '#ff4d1c' }}>/</span>OS
+          </span>
+        </div>
       </div>
 
       {/* Center: practice context breadcrumb */}

--- a/src/components/drill/DrillVerbos.css
+++ b/src/components/drill/DrillVerbos.css
@@ -123,6 +123,32 @@
   gap: 0;
 }
 
+/* Header left group: back button + logo */
+.vd-header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.vd-back-btn {
+  background: none;
+  border: none;
+  color: var(--vd-ink2);
+  font-family: var(--vd-mono);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 2px;
+  line-height: 1;
+  transition: color 120ms ease;
+  display: flex;
+  align-items: center;
+}
+
+.vd-back-btn:hover {
+  color: var(--vd-accent);
+}
+
 /* VERB/OS logo in header */
 .vd-logo {
   display: flex;

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -96,6 +96,33 @@
 .vo-footer-hints span { white-space: nowrap; }
 .vo-footer-hints em { font-style: normal; color: #6e6a60; }
 
+.vo-header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.vo-back-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: #6e6a60;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 4px 0;
+  transition: color 120ms ease;
+  user-select: none;
+}
+
+.vo-back-btn:hover {
+  color: #ff4d1c;
+}
+
 .vo-logo {
   display: flex;
   align-items: center;

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -611,12 +611,19 @@ function OnboardingFlow({
 
       {/* Top header */}
       <header className="vo-header">
-        <div className="vo-logo" onClick={handleLogoClick} title="Ir al inicio">
-          <div className="vo-logo-dot" style={{ background: ACCENT }} />
-          <span className="vo-logo-name">
-            VERB<span style={{ color: ACCENT }}>/</span>OS
-          </span>
-          <span style={{ marginLeft: 8 }}>v0.1</span>
+        <div className="vo-header-left">
+          {onboardingStep > 1 && !showLevelTest && (
+            <button className="vo-back-btn" onClick={handleBack} aria-label="Volver al paso anterior">
+              ← VOLVER
+            </button>
+          )}
+          <div className="vo-logo" onClick={handleLogoClick} title="Ir al inicio">
+            <div className="vo-logo-dot" style={{ background: ACCENT }} />
+            <span className="vo-logo-name">
+              VERB<span style={{ color: ACCENT }}>/</span>OS
+            </span>
+            <span style={{ marginLeft: 8 }}>v0.1</span>
+          </div>
         </div>
 
         <div className="vo-breadcrumb" aria-label="Progreso de configuración">


### PR DESCRIPTION
Agrega navegación hacia atrás visual en las pantallas donde solo existían shortcuts de teclado (← / Esc) pero ningún botón clickeable en la UI.

- OnboardingFlow: botón "← VOLVER" aparece en el header desde el paso 2 en adelante; se oculta en el paso 1 y durante el placement test
- DrillHeader: botón "←" antes del logo VERB/OS llama a router.back() para volver a la pantalla anterior en el historial