### PR TITLE
feat(ui): rediseño del login/sync y menús del drill al estilo VERB/OS

### DIFF
--- a/src/components/auth/AccountButton.css
+++ b/src/components/auth/AccountButton.css
@@ -1,177 +1,170 @@
 /* ============================================
-   Account Button — Brutalist Design System
+   Account Button — nativo VERB/OS vo-header
+   Diseñado para vivir en el header de 44px con
+   fondo #0c0c0c, fuente JetBrains Mono 10px.
    ============================================ */
 
-/* --- Container --- */
 .acct-container {
   position: relative;
-  display: inline-block;
-}
-
-/* --- Login button (unauthenticated) --- */
-.acct-login-btn {
   display: inline-flex;
   align-items: center;
-  background: transparent;
-  color: var(--text, #fff);
-  border: 1px solid var(--border, #333);
-  border-radius: 0;
-  padding: 6px 14px;
-  font-family: var(--font-mono, monospace);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: transform 80ms, box-shadow 80ms;
 }
 
-.acct-login-btn:hover {
-  transform: translate(-2px, -2px);
-  box-shadow: 2px 2px 0 var(--text, #fff);
-  border-color: var(--text, #fff);
-}
-
-.acct-login-btn:active {
-  transform: translate(0, 0);
-  box-shadow: none;
-}
-
-/* --- Trigger button (authenticated) --- */
-.acct-trigger {
+/* ─────────────────────────────────────────
+   Botón de login (no autenticado)
+   Vive en el vo-header — usa sus mismos tokens
+   ───────────────────────────────────────── */
+.acct-login-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   background: transparent;
-  border: 1px solid var(--border, #333);
-  border-radius: 0;
-  padding: 4px 8px;
+  /* Borde sutil pero visible sobre el fondo oscuro #0c0c0c */
+  border: 1px solid #2a2823;
+  padding: 5px 11px;
   cursor: pointer;
-  transition: border-color 120ms, box-shadow 80ms;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #6e6a60;
+  transition: color 120ms, border-color 120ms;
+  white-space: nowrap;
+}
+
+.acct-login-btn:hover {
+  color: #f4f1ea;
+  border-color: #6e6a60;
+}
+
+.acct-login-label {
+  /* texto principal */
+}
+
+.acct-login-arrow {
+  color: #ff4d1c;
+  font-size: 11px;
+  line-height: 1;
+}
+
+/* ─────────────────────────────────────────
+   Trigger button (autenticado)
+   Muestra: [inicial] nombre · estado
+   ───────────────────────────────────────── */
+.acct-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 5px 8px;
+  cursor: pointer;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #6e6a60;
+  transition: color 120ms, border-color 120ms;
+  white-space: nowrap;
 }
 
 .acct-trigger:hover,
 .acct-trigger--open {
-  border-color: var(--text, #fff);
-  box-shadow: 2px 2px 0 var(--text, #fff);
+  color: #f4f1ea;
+  border-color: #2a2823;
 }
 
-.acct-trigger:active {
-  box-shadow: none;
-  transform: translate(1px, 1px);
-}
-
-.acct-avatar {
-  width: 28px;
-  height: 28px;
-  background: var(--text, #fff);
-  color: var(--bg, #000);
-  display: flex;
+/* Cuadrado con la inicial — visible y con propósito */
+.acct-initial {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-mono, monospace);
+  width: 20px;
+  height: 20px;
+  background: #f4f1ea;
+  color: #0c0c0c;
   font-weight: 800;
-  font-size: 0.85rem;
+  font-size: 9px;
+  letter-spacing: 0;
   flex-shrink: 0;
 }
 
-/* --- Sync badge (next to avatar) --- */
-.acct-sync-badge {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.6rem;
+/* Nombre del usuario */
+.acct-name {
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #6e6a60;
+  font-size: 10px;
+}
+
+.acct-trigger:hover .acct-name,
+.acct-trigger--open .acct-name {
+  color: #f4f1ea;
+}
+
+/* Badge de estado sync */
+.acct-status {
+  font-size: 9px;
+  letter-spacing: 0.1em;
   font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 1px 5px;
-  border: 1px solid;
+  padding: 1px 4px;
+  border: 1px solid currentColor;
+  flex-shrink: 0;
 }
 
-.acct-sync-badge--ok {
-  color: var(--accent-success, #0f0);
-  border-color: var(--accent-success, #0f0);
-}
-
-.acct-sync-badge--syncing {
-  color: var(--text, #fff);
-  border-color: var(--text, #fff);
-  animation: acct-blink 1s steps(2) infinite;
-}
-
-.acct-sync-badge--error {
-  color: var(--accent-error, #f00);
-  border-color: var(--accent-error, #f00);
-}
-
-.acct-sync-badge--offline {
-  color: var(--muted, #888);
-  border-color: var(--muted, #888);
-  border-style: dashed;
-}
-
-.acct-sync-badge--local {
-  color: var(--muted, #888);
-  border-color: var(--muted, #888);
-}
-
-.acct-sync-badge--stale {
-  color: var(--accent-warning, #fa0);
-  border-color: var(--accent-warning, #fa0);
-}
-
-.acct-sync-badge--unknown {
-  color: var(--muted-2, #555);
-  border-color: var(--muted-2, #555);
-}
+.acct-status--ok      { color: #5ee6a5; }
+.acct-status--syncing { color: #f4f1ea; animation: acct-blink 1s steps(2) infinite; }
+.acct-status--error   { color: #ff6b6b; }
+.acct-status--offline { color: #6e6a60; border-style: dashed; }
+.acct-status--local   { color: #6e6a60; border-style: dashed; }
+.acct-status--stale   { color: #faad14; }
+.acct-status--unknown { color: #2a2823; }
 
 @keyframes acct-blink {
   50% { opacity: 0.3; }
 }
 
-/* --- Dropdown --- */
+/* ─────────────────────────────────────────
+   Dropdown
+   ───────────────────────────────────────── */
 .acct-dropdown {
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
   z-index: 1100;
-  min-width: 280px;
-  max-width: 340px;
-  background: var(--bg, #000);
-  border: 1px solid var(--text, #fff);
-  box-shadow: 4px 4px 0 var(--text, #fff);
-  animation: acct-dropdown-in 120ms ease-out;
+  min-width: 256px;
+  background: #0c0c0c;
+  border: 1px solid #2a2823;
+  box-shadow: 4px 4px 0 #1f1d18;
+  animation: acct-in 100ms ease-out;
 }
 
-@keyframes acct-dropdown-in {
-  from {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+@keyframes acct-in {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-/* Header */
+/* Header del dropdown */
 .acct-dropdown__header {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border, #333);
+  gap: 10px;
+  padding: 12px 14px;
 }
 
 .acct-dropdown__avatar {
-  width: 36px;
-  height: 36px;
-  background: var(--text, #fff);
-  color: var(--bg, #000);
+  width: 30px;
+  height: 30px;
+  background: #f4f1ea;
+  color: #0c0c0c;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-mono, monospace);
+  font-family: 'JetBrains Mono', monospace;
   font-weight: 800;
-  font-size: 1rem;
+  font-size: 0.9rem;
   flex-shrink: 0;
 }
 
@@ -181,18 +174,20 @@
 }
 
 .acct-dropdown__name {
-  color: var(--text, #fff);
+  color: #f4f1ea;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
   font-weight: 600;
-  font-size: 0.9rem;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-bottom: 2px;
 }
 
 .acct-dropdown__email {
-  color: var(--muted, #888);
-  font-size: 0.75rem;
-  font-family: var(--font-mono, monospace);
+  color: #6e6a60;
+  font-size: 0.68rem;
+  font-family: 'JetBrains Mono', monospace;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -201,103 +196,93 @@
 /* Divider */
 .acct-dropdown__divider {
   height: 1px;
-  background: var(--border, #333);
+  background: #1f1d18;
 }
 
-/* Sections */
+/* Section */
 .acct-dropdown__section {
-  padding: 12px 16px;
+  padding: 10px 14px;
+}
+
+.acct-dropdown__section--menu {
+  padding: 4px 0;
 }
 
 .acct-dropdown__section-label {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.65rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.58rem;
   font-weight: 700;
-  color: var(--muted, #888);
-  letter-spacing: 0.12em;
+  color: #2a2823;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   margin-bottom: 8px;
 }
 
-/* Sync status */
-.acct-dropdown__sync-status {
-  margin-bottom: 10px;
+/* Sync grid */
+.acct-dropdown__sync-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+  margin-bottom: 8px;
 }
 
-.acct-dropdown__sync-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 3px 0;
+.acct-dropdown__sync-key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  color: #6e6a60;
+  white-space: nowrap;
+  padding: 2px 0;
 }
 
-.acct-dropdown__sync-label {
-  font-size: 0.8rem;
-  color: var(--muted, #888);
-}
-
-.acct-dropdown__sync-value {
-  font-family: var(--font-mono, monospace);
-  font-size: 0.8rem;
+.acct-dropdown__sync-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
   font-weight: 600;
-  color: var(--text, #fff);
+  color: #f4f1ea;
+  padding: 2px 0;
 }
 
-.acct-dropdown__sync-value.ok {
-  color: var(--accent-success, #0f0);
-}
-
-.acct-dropdown__sync-value.syncing {
-  color: var(--text, #fff);
-  animation: acct-blink 1s steps(2) infinite;
-}
-
-.acct-dropdown__sync-value.error {
-  color: var(--accent-error, #f00);
-}
-
-.acct-dropdown__sync-value.offline {
-  color: var(--accent-warning, #fa0);
-}
+.acct-dropdown__sync-val.ok       { color: #5ee6a5; }
+.acct-dropdown__sync-val.syncing  { color: #f4f1ea; animation: acct-blink 1s steps(2) infinite; }
+.acct-dropdown__sync-val.error    { color: #ff6b6b; }
+.acct-dropdown__sync-val.offline  { color: #faad14; }
 
 .acct-dropdown__sync-error {
-  margin-top: 6px;
-  padding: 6px 8px;
-  font-family: var(--font-mono, monospace);
-  font-size: 0.7rem;
-  color: var(--accent-error, #f00);
-  border: 1px solid var(--accent-error, #f00);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  color: #ff6b6b;
+  border: 1px solid #ff6b6b;
+  padding: 5px 7px;
+  margin-bottom: 8px;
   word-break: break-word;
 }
 
-/* Action button */
-.acct-dropdown__action-btn {
+/* Sync button */
+.acct-dropdown__sync-btn {
+  display: block;
   width: 100%;
-  padding: 8px;
+  padding: 8px 10px;
   background: transparent;
-  color: var(--text, #fff);
-  border: 1px solid var(--border, #333);
-  font-family: var(--font-mono, monospace);
-  font-size: 0.7rem;
+  color: #6e6a60;
+  border: 1px solid #2a2823;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
   font-weight: 700;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: border-color 120ms, background 120ms;
+  transition: color 100ms, border-color 100ms;
+  text-align: center;
 }
 
-.acct-dropdown__action-btn:hover:not(:disabled) {
-  border-color: var(--text, #fff);
-  background: rgba(255, 255, 255, 0.05);
+.acct-dropdown__sync-btn:hover:not(:disabled) {
+  color: #f4f1ea;
+  border-color: #6e6a60;
 }
 
-.acct-dropdown__action-btn:active:not(:disabled) {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.acct-dropdown__action-btn:disabled {
-  color: var(--muted-2, #555);
-  border-color: var(--muted-2, #555);
+.acct-dropdown__sync-btn:disabled {
+  color: #2a2823;
+  border-color: #1f1d18;
   cursor: not-allowed;
 }
 
@@ -307,56 +292,57 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding: 10px 16px;
+  padding: 9px 14px;
   background: none;
   border: none;
-  color: var(--text, #fff);
-  font-size: 0.85rem;
+  color: #6e6a60;
+  font-size: 0.78rem;
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.04em;
   text-align: left;
   cursor: pointer;
-  transition: background 100ms;
+  transition: color 80ms, background 80ms;
+}
+
+.acct-dropdown__menu-item svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  opacity: 0.5;
 }
 
 .acct-dropdown__menu-item:hover {
-  background: rgba(255, 255, 255, 0.06);
+  color: #f4f1ea;
+  background: rgba(255,255,255, 0.03);
 }
 
-.acct-dropdown__menu-icon {
-  font-size: 1rem;
-  width: 20px;
-  text-align: center;
-  color: var(--muted, #888);
+.acct-dropdown__menu-item:hover svg {
+  opacity: 0.8;
 }
 
 .acct-dropdown__menu-item--danger {
-  color: var(--accent-error, #f00);
-  padding: 12px 16px;
+  color: #2a2823;
+  padding: 10px 14px 12px;
 }
 
 .acct-dropdown__menu-item--danger:hover {
-  background: rgba(255, 0, 0, 0.08);
+  color: #ff6b6b;
+  background: rgba(255, 107, 107, 0.05);
 }
 
-/* --- Responsive --- */
+/* ─────────────────────────────────────────
+   Responsive
+   ───────────────────────────────────────── */
 @media (max-width: 480px) {
+  .acct-name { display: none; }
+
   .acct-login-btn {
-    padding: 5px 10px;
-    font-size: 0.7rem;
-  }
-
-  .acct-avatar {
-    width: 24px;
-    height: 24px;
-    font-size: 0.75rem;
-  }
-
-  .acct-sync-badge {
-    font-size: 0.55rem;
-    padding: 0 4px;
+    padding: 5px 9px;
+    font-size: 9px;
   }
 
   .acct-dropdown {
-    min-width: 260px;
-    right: -8px;
+    min-width: 230px;
+    right: -4px;
   }
 }

--- a/src/components/auth/AccountButton.jsx
+++ b/src/components/auth/AccountButton.jsx
@@ -6,28 +6,19 @@ import AccountManagementModal from './AccountManagementModal.jsx'
 import DeviceManagerModal from './DeviceManagerModal.jsx'
 import './AccountButton.css'
 
-function SyncBadge({ syncStatus }) {
-  const { isSyncing, lastSyncTime, syncError, isOnline, syncEnabled, isLocalSync } = syncStatus
-
-  if (isSyncing) {
-    return <span className="acct-sync-badge acct-sync-badge--syncing">SYNC...</span>
-  }
-  if (syncError) {
-    return <span className="acct-sync-badge acct-sync-badge--error">ERROR</span>
-  }
-  if (!isOnline) {
-    return <span className="acct-sync-badge acct-sync-badge--offline">OFFLINE</span>
-  }
-  if (isLocalSync || !syncEnabled) {
-    return <span className="acct-sync-badge acct-sync-badge--local">LOCAL</span>
-  }
+function syncStateLabel(syncStatus) {
+  const { isSyncing, syncError, isOnline, isLocalSync, syncEnabled, lastSyncTime } = syncStatus
+  if (isSyncing)  return { text: 'SYNC...', cls: 'syncing' }
+  if (syncError)  return { text: 'ERROR',   cls: 'error' }
+  if (!isOnline)  return { text: 'OFFLINE', cls: 'offline' }
+  if (isLocalSync || !syncEnabled) return { text: 'LOCAL', cls: 'local' }
   if (lastSyncTime) {
     const mins = Math.floor((Date.now() - lastSyncTime.getTime()) / 60000)
-    if (mins < 1) return <span className="acct-sync-badge acct-sync-badge--ok">OK</span>
-    if (mins < 60) return <span className="acct-sync-badge acct-sync-badge--ok">{mins}m</span>
-    return <span className="acct-sync-badge acct-sync-badge--stale">{Math.floor(mins / 60)}h</span>
+    if (mins < 1)  return { text: 'OK',        cls: 'ok' }
+    if (mins < 60) return { text: `${mins}m`,   cls: 'ok' }
+    return           { text: `${Math.floor(mins/60)}h`, cls: 'stale' }
   }
-  return <span className="acct-sync-badge acct-sync-badge--unknown">--</span>
+  return { text: '--', cls: 'unknown' }
 }
 
 function formatLastSync(lastSyncTime) {
@@ -70,14 +61,12 @@ export default function AccountButton() {
     }
 
     window.addEventListener('account-updated', handleAccountUpdated)
-
     return () => {
       cleanup?.()
       window.removeEventListener('account-updated', handleAccountUpdated)
     }
   }, [])
 
-  // Close dropdown on click outside
   useEffect(() => {
     if (!showDropdown) return
     const handleClickOutside = (e) => {
@@ -92,19 +81,9 @@ export default function AccountButton() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [showDropdown])
 
-  const handleLogin = () => {
-    setShowAuthModal(true)
-    setShowDropdown(false)
-  }
-
-  const handleLogout = async () => {
-    await authService.logout()
-    setShowDropdown(false)
-  }
-
-  const handleAuthSuccess = () => {
-    setShowAuthModal(false)
-  }
+  const handleLogin = () => { setShowAuthModal(true); setShowDropdown(false) }
+  const handleLogout = async () => { await authService.logout(); setShowDropdown(false) }
+  const handleAuthSuccess = () => setShowAuthModal(false)
 
   const handleSync = () => {
     window.dispatchEvent(new CustomEvent('trigger-sync'))
@@ -113,22 +92,26 @@ export default function AccountButton() {
   }
 
   const getDisplayName = () => {
-    if (account?.name) return account.name
+    if (account?.name) return account.name.split(' ')[0]
     if (account?.email) return account.email.split('@')[0]
-    return 'Usuario'
+    return 'cuenta'
   }
 
   const getInitial = () => getDisplayName().charAt(0).toUpperCase()
 
+  const sync = syncStateLabel(syncStatus)
+
+  /* ─── Unauthenticated ─── */
   if (!isAuthenticated) {
     return (
       <>
         <button
           onClick={handleLogin}
           className="acct-login-btn"
-          title="Iniciar sesión para sincronizar entre dispositivos"
+          title="Iniciá sesión para sincronizar tu progreso entre dispositivos"
         >
-          INICIAR SESIÓN
+          <span className="acct-login-label">SINCRONIZAR</span>
+          <span className="acct-login-arrow">→</span>
         </button>
 
         <AuthModal
@@ -140,23 +123,26 @@ export default function AccountButton() {
     )
   }
 
+  /* ─── Authenticated ─── */
   return (
     <div className="acct-container">
       <button
         ref={buttonRef}
         onClick={() => setShowDropdown(!showDropdown)}
-        className={`acct-trigger ${showDropdown ? 'acct-trigger--open' : ''}`}
-        title={getDisplayName()}
+        className={`acct-trigger${showDropdown ? ' acct-trigger--open' : ''}`}
+        title={`${getDisplayName()} — sync: ${sync.text}`}
       >
-        <span className="acct-avatar">{getInitial()}</span>
-        <SyncBadge syncStatus={syncStatus} />
+        <span className="acct-initial">{getInitial()}</span>
+        <span className="acct-name">{getDisplayName()}</span>
+        <span className={`acct-status acct-status--${sync.cls}`}>{sync.text}</span>
       </button>
 
       {showDropdown && (
         <div className="acct-dropdown" ref={dropdownRef}>
-          {/* User info header */}
+
+          {/* User header */}
           <div className="acct-dropdown__header">
-            <div className="acct-dropdown__avatar">{getInitial()}</div>
+            <span className="acct-dropdown__avatar">{getInitial()}</span>
             <div className="acct-dropdown__user-info">
               <div className="acct-dropdown__name">{getDisplayName()}</div>
               <div className="acct-dropdown__email">{account?.email}</div>
@@ -165,61 +151,57 @@ export default function AccountButton() {
 
           <div className="acct-dropdown__divider" />
 
-          {/* Sync status section */}
+          {/* Sync section */}
           <div className="acct-dropdown__section">
             <div className="acct-dropdown__section-label">SINCRONIZACIÓN</div>
-            <div className="acct-dropdown__sync-status">
-              <div className="acct-dropdown__sync-row">
-                <span className="acct-dropdown__sync-label">Estado</span>
-                <span className={`acct-dropdown__sync-value ${
-                  syncStatus.isSyncing ? 'syncing' :
-                  syncStatus.syncError ? 'error' :
-                  !syncStatus.isOnline ? 'offline' : 'ok'
-                }`}>
-                  {syncStatus.isSyncing ? 'Sincronizando...' :
-                   syncStatus.syncError ? 'Error' :
-                   !syncStatus.isOnline ? 'Sin conexión' :
-                   syncStatus.isLocalSync ? 'Solo local' : 'Conectado'}
-                </span>
-              </div>
-              <div className="acct-dropdown__sync-row">
-                <span className="acct-dropdown__sync-label">Última sync</span>
-                <span className="acct-dropdown__sync-value">
-                  {formatLastSync(syncStatus.lastSyncTime)}
-                </span>
-              </div>
-              {syncStatus.syncError && (
-                <div className="acct-dropdown__sync-error">
-                  {syncStatus.syncError}
-                </div>
-              )}
+            <div className="acct-dropdown__sync-grid">
+              <span className="acct-dropdown__sync-key">Estado</span>
+              <span className={`acct-dropdown__sync-val ${sync.cls}`}>
+                {syncStatus.isSyncing ? 'Sincronizando' :
+                 syncStatus.syncError ? 'Error' :
+                 !syncStatus.isOnline ? 'Sin conexión' :
+                 syncStatus.isLocalSync ? 'Solo local' : 'Conectado'}
+              </span>
+              <span className="acct-dropdown__sync-key">Última sync</span>
+              <span className="acct-dropdown__sync-val">
+                {formatLastSync(syncStatus.lastSyncTime)}
+              </span>
             </div>
+            {syncStatus.syncError && (
+              <div className="acct-dropdown__sync-error">{syncStatus.syncError}</div>
+            )}
             <button
-              className="acct-dropdown__action-btn"
+              className="acct-dropdown__sync-btn"
               onClick={handleSync}
               disabled={syncStatus.isSyncing || syncTriggered}
             >
               {syncStatus.isSyncing ? 'SINCRONIZANDO...' :
-               syncTriggered ? 'ENVIADO' : 'SINCRONIZAR AHORA'}
+               syncTriggered ? 'ENVIADO ✓' : 'SINCRONIZAR AHORA'}
             </button>
           </div>
 
           <div className="acct-dropdown__divider" />
 
-          {/* Account actions */}
-          <div className="acct-dropdown__section">
+          {/* Menu items */}
+          <div className="acct-dropdown__section acct-dropdown__section--menu">
             <button
               className="acct-dropdown__menu-item"
               onClick={() => { setShowDropdown(false); setShowAccountModal(true) }}
             >
-              <span className="acct-dropdown__menu-icon">&#9881;</span>
+              <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <circle cx="8" cy="5" r="3" stroke="currentColor" strokeWidth="1.3"/>
+                <path d="M2 14c0-3.3 2.7-5 6-5s6 1.7 6 5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+              </svg>
               Gestionar cuenta
             </button>
             <button
               className="acct-dropdown__menu-item"
               onClick={() => { setShowDropdown(false); setShowDeviceModal(true) }}
             >
-              <span className="acct-dropdown__menu-icon">&#9744;</span>
+              <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <rect x="1" y="3" width="9" height="7" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+                <rect x="10" y="6" width="5" height="7" rx="1" stroke="currentColor" strokeWidth="1.3"/>
+              </svg>
               Mis dispositivos
             </button>
           </div>

--- a/src/components/auth/AuthModal.css
+++ b/src/components/auth/AuthModal.css
@@ -1,197 +1,150 @@
 /* ============================================
-   Auth Modal — Brutalist Dark Theme
+   Auth Modal — VERB/OS Design System
    ============================================ */
 
 .auth-modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.85);
+  inset: 0;
+  background: rgba(0, 0, 0, 0.88);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 9999;
   padding: 20px;
-  animation: overlay-fade-in 0.2s ease forwards;
+  animation: overlay-fade-in 0.15s ease forwards;
 }
 
 @keyframes overlay-fade-in {
   from { opacity: 0; }
-  to { opacity: 1; }
+  to   { opacity: 1; }
 }
 
 .auth-modal {
   background: var(--bg, #000);
-  border: 1px solid var(--text, #fff);
-  box-shadow: 6px 6px 0 var(--text, #fff);
-  max-width: 440px;
+  border: 1px solid var(--border, #333);
+  box-shadow: 4px 4px 0 var(--border, #333);
+  max-width: 400px;
   width: 100%;
   max-height: 90vh;
   overflow-y: auto;
-  animation: modal-enter 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: modal-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 @keyframes modal-enter {
-  from {
-    opacity: 0;
-    transform: translateY(16px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
+/* Header */
 .auth-modal-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 24px;
+  padding: 16px 20px;
   border-bottom: 1px solid var(--border, #333);
+}
+
+.auth-modal-title-group {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.auth-modal-tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--muted-2, #555);
+  text-transform: uppercase;
 }
 
 .auth-modal-header h2 {
   margin: 0;
   font-family: var(--font-mono, monospace);
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   color: var(--text, #fff);
 }
 
 .close-btn {
   background: transparent;
   border: 1px solid var(--border, #333);
-  color: var(--text, #fff);
-  width: 28px;
-  height: 28px;
-  font-size: 1rem;
+  color: var(--muted, #888);
+  width: 26px;
+  height: 26px;
+  font-size: 0.8rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  transition: color 100ms, border-color 100ms;
+  flex-shrink: 0;
 }
 
 .close-btn:hover {
   border-color: var(--text, #fff);
-  transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  color: var(--text, #fff);
 }
 
-.close-btn:active {
-  transform: translate(0, 0);
-  box-shadow: none;
-}
-
+/* Content */
 .auth-modal-content {
-  padding: 24px;
+  padding: 20px;
 }
 
 .auth-description {
-  margin: 0 0 24px 0;
+  margin: 0 0 18px 0;
   color: var(--muted, #888);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   line-height: 1.5;
   text-align: center;
   font-family: var(--font-mono, monospace);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
 }
 
-.auth-form {
-  margin-bottom: 24px;
-}
-
-.form-group {
-  margin-bottom: 20px;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 6px;
-  color: var(--muted, #888);
-  font-weight: 600;
-  font-size: 0.75rem;
-  font-family: var(--font-mono, monospace);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.form-group input {
+/* Google button */
+.google-login-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   width: 100%;
   padding: 12px 16px;
-  border: 1px solid var(--border, #333);
   background: transparent;
   color: var(--text, #fff);
-  font-size: 0.95rem;
-  font-family: var(--font-ui, sans-serif);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-  box-sizing: border-box;
-}
-
-.form-group input:focus {
-  outline: none;
-  border-color: var(--text, #fff);
-  box-shadow: 3px 3px 0 var(--text, #fff);
-}
-
-.form-group input::placeholder {
-  color: var(--muted-2, #555);
-}
-
-.error-message {
-  background: transparent;
-  border: 1px solid var(--accent-error, #f00);
-  color: var(--accent-error, #f00);
-  padding: 10px 14px;
-  margin-bottom: 20px;
+  border: 1px solid var(--border, #333);
   font-size: 0.8rem;
-  font-family: var(--font-mono, monospace);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.auth-submit-btn {
-  width: 100%;
-  padding: 14px 20px;
-  background: var(--text, #fff);
-  color: var(--bg, #000);
-  border: 1px solid var(--text, #fff);
-  font-size: 0.85rem;
-  font-weight: 700;
+  font-weight: 600;
   font-family: var(--font-mono, monospace);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-  margin-bottom: 20px;
-  box-shadow: 4px 4px 0 var(--accent-orange, #ff5722);
+  transition: border-color 100ms, color 100ms;
+  margin-bottom: 18px;
 }
 
-.auth-submit-btn:hover:not(:disabled) {
-  transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange, #ff5722);
+.google-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
-.auth-submit-btn:active:not(:disabled) {
-  transform: translate(0, 0);
-  box-shadow: none;
+.google-login-btn:hover:not(:disabled) {
+  border-color: var(--text, #fff);
 }
 
-.auth-submit-btn:disabled {
-  opacity: 0.4;
+.google-login-btn:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
-  box-shadow: none;
 }
 
+/* Divider */
 .auth-divider {
   position: relative;
   text-align: center;
-  margin: 24px 0;
+  margin: 0 0 18px 0;
 }
 
 .auth-divider::before {
@@ -206,56 +159,108 @@
 
 .auth-divider span {
   background: var(--bg, #000);
-  color: var(--muted, #888);
-  padding: 0 16px;
-  font-size: 0.75rem;
+  color: var(--muted-2, #555);
+  padding: 0 12px;
+  font-size: 0.7rem;
   font-family: var(--font-mono, monospace);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   position: relative;
 }
 
-.google-login-btn {
-  width: 100%;
-  padding: 14px 20px;
-  background: transparent;
-  color: var(--text, #fff);
-  border: 1px solid var(--border, #333);
-  font-size: 0.85rem;
-  font-weight: 600;
+/* Form */
+.auth-form {
+  margin-bottom: 16px;
+}
+
+.form-group {
+  margin-bottom: 14px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted, #888);
+  font-weight: 700;
+  font-size: 0.65rem;
   font-family: var(--font-mono, monospace);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
-  margin-bottom: 24px;
+  letter-spacing: 0.1em;
 }
 
-.google-login-btn:hover:not(:disabled) {
+.form-optional {
+  color: var(--muted-2, #555);
+  font-weight: 400;
+  text-transform: lowercase;
+  letter-spacing: 0;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border, #333);
+  background: transparent;
+  color: var(--text, #fff);
+  font-size: 0.9rem;
+  font-family: var(--font-mono, monospace);
+  transition: border-color 100ms;
+  box-sizing: border-box;
+  caret-color: var(--accent-orange, #ff5722);
+}
+
+.form-group input:focus {
+  outline: none;
   border-color: var(--text, #fff);
-  transform: translate(-2px, -2px);
-  box-shadow: 4px 4px 0 var(--text, #fff);
 }
 
-.google-login-btn:active:not(:disabled) {
-  transform: translate(0, 0);
-  box-shadow: none;
+.form-group input::placeholder {
+  color: var(--muted-2, #555);
 }
 
-.google-login-btn:disabled {
-  opacity: 0.4;
+.error-message {
+  border: 1px solid var(--accent-error, #f00);
+  color: var(--accent-error, #f00);
+  padding: 8px 12px;
+  margin-bottom: 14px;
+  font-size: 0.72rem;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.04em;
+}
+
+/* Submit */
+.auth-submit-btn {
+  width: 100%;
+  padding: 13px 16px;
+  background: var(--text, #fff);
+  color: var(--bg, #000);
+  border: none;
+  font-size: 0.78rem;
+  font-weight: 700;
+  font-family: var(--font-mono, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  transition: opacity 120ms;
+}
+
+.auth-submit-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.auth-submit-btn:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
+/* Switch mode */
 .auth-switch {
   text-align: center;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
 .auth-switch p {
   margin: 0;
   color: var(--muted, #888);
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   font-family: var(--font-mono, monospace);
 }
 
@@ -265,82 +270,61 @@
   color: var(--text, #fff);
   cursor: pointer;
   text-decoration: underline;
-  text-underline-offset: 3px;
+  text-underline-offset: 2px;
   font-size: inherit;
   font-family: inherit;
   padding: 0;
-  margin: 0;
-  transition: opacity 0.15s ease;
+  transition: opacity 100ms;
 }
 
-.link-btn:hover {
-  opacity: 0.7;
-}
+.link-btn:hover { opacity: 0.7; }
 
+/* Benefits */
 .auth-benefits {
-  background: transparent;
-  padding: 16px;
   border: 1px solid var(--border, #333);
+  padding: 12px 14px;
 }
 
-.auth-benefits h4 {
-  margin: 0 0 12px 0;
-  color: var(--muted, #888);
-  font-size: 0.75rem;
+.auth-benefits__label {
   font-family: var(--font-mono, monospace);
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--muted-2, #555);
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  margin-bottom: 8px;
 }
 
 .auth-benefits ul {
   margin: 0;
-  padding-left: 0;
+  padding: 0;
   list-style: none;
 }
 
 .auth-benefits li {
   color: var(--muted, #888);
-  font-size: 0.8rem;
-  margin-bottom: 8px;
-  padding-left: 0;
-  line-height: 1.4;
+  font-size: 0.75rem;
+  font-family: var(--font-mono, monospace);
+  padding: 3px 0;
+  padding-left: 14px;
+  position: relative;
 }
 
-.auth-benefits li:last-child {
-  margin-bottom: 0;
+.auth-benefits li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--muted-2, #555);
 }
 
-/* Mobile responsive */
+/* Mobile */
 @media (max-width: 600px) {
-  .auth-modal-overlay {
-    padding: 10px;
-  }
-
-  .auth-modal {
-    max-height: 95vh;
-  }
-
-  .auth-modal-header {
-    padding: 16px 20px;
-  }
-
-  .auth-modal-content {
-    padding: 20px;
-  }
-
-  .form-group input {
-    padding: 10px 12px;
-  }
-
-  .auth-submit-btn,
-  .google-login-btn {
-    padding: 12px 16px;
-  }
+  .auth-modal-overlay { padding: 10px; }
+  .auth-modal-header { padding: 14px 16px; }
+  .auth-modal-content { padding: 16px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .auth-modal-overlay,
-  .auth-modal {
-    animation: none;
-  }
+  .auth-modal { animation: none; }
 }

--- a/src/components/auth/AuthModal.jsx
+++ b/src/components/auth/AuthModal.jsx
@@ -17,19 +17,15 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
     authService.initializeGoogleAuth()
   }, [])
 
-  // Listen for auth events
   useEffect(() => {
     const handleAuthLogin = () => {
-      console.log('🔵 AuthModal: Received auth-login event')
       setLoading(false)
       onSuccess?.()
       onClose()
-      // Reset form
       setFormData({ email: '', password: '', name: '' })
     }
 
     const handleGoogleError = (event) => {
-      console.log('🔴 AuthModal: Received google-auth-error event:', event.detail)
       setLoading(false)
       setError(event.detail.error || 'Error con Google OAuth')
     }
@@ -44,11 +40,8 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
   }, [onSuccess, onClose])
 
   const handleInputChange = useCallback((e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    })
-    setError('') // Clear error when user types
+    setFormData({ ...formData, [e.target.name]: e.target.value })
+    setError('')
   }, [formData])
 
   const handleSubmit = useCallback(async (e) => {
@@ -58,23 +51,14 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
 
     try {
       if (mode === 'register') {
-        await authService.register(
-          formData.email,
-          formData.password,
-          formData.name || null
-        )
+        await authService.register(formData.email, formData.password, formData.name || null)
       } else {
-        await authService.login(
-          formData.email,
-          formData.password
-        )
+        await authService.login(formData.email, formData.password)
       }
 
       authService.emitLoginEvent()
       onSuccess?.()
       onClose()
-
-      // Reset form
       setFormData({ email: '', password: '', name: '' })
     } catch (err) {
       setError(err.message)
@@ -89,26 +73,19 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
 
     try {
       if (!authService.isGoogleAvailable()) {
-        setError('Google OAuth no está configurado. Usa email y contraseña.')
+        setError('Google OAuth no está configurado. Usá email y contraseña.')
         setLoading(false)
         return
       }
 
-      console.log('🔵 Iniciando Google Sign-In...')
       const result = await authService.triggerGoogleSignIn()
 
       if (!result) {
-        setError('Google OAuth no está disponible. Prueba con email y contraseña.')
+        setError('Google OAuth no está disponible. Probá con email y contraseña.')
         setLoading(false)
-        return
       }
-
-      // Keep loading state, will be handled by event listeners
-      console.log('🔵 Google Sign-In triggered successfully')
-
-    } catch (error) {
-      console.error('🔴 Google login error:', error)
-      setError('Error con Google OAuth. Prueba con email y contraseña.')
+    } catch (err) {
+      setError('Error con Google OAuth. Probá con email y contraseña.')
       setLoading(false)
     }
   }
@@ -124,8 +101,11 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
     <div className="auth-modal-overlay" onClick={onClose}>
       <div className="auth-modal" onClick={(e) => e.stopPropagation()}>
         <div className="auth-modal-header">
-          <h2>{mode === 'login' ? '🔐 Iniciar Sesión' : '📝 Crear Cuenta'}</h2>
-          <button className="close-btn" onClick={onClose}>✕</button>
+          <div className="auth-modal-title-group">
+            <span className="auth-modal-tag">VERB/OS</span>
+            <h2>{mode === 'login' ? 'INICIAR SESIÓN' : 'CREAR CUENTA'}</h2>
+          </div>
+          <button className="close-btn" onClick={onClose} aria-label="Cerrar">✕</button>
         </div>
 
         <div className="auth-modal-content">
@@ -136,10 +116,30 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
             }
           </p>
 
+          <button
+            type="button"
+            onClick={handleGoogleLogin}
+            className="google-login-btn"
+            disabled={loading || !authService.isGoogleAvailable()}
+            title={!authService.isGoogleAvailable() ? 'Google OAuth no configurado' : ''}
+          >
+            <svg className="google-icon" viewBox="0 0 18 18" aria-hidden="true">
+              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+              <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/>
+              <path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+            </svg>
+            {authService.isGoogleAvailable() ? 'Continuar con Google' : 'Google OAuth (no configurado)'}
+          </button>
+
+          <div className="auth-divider">
+            <span>o</span>
+          </div>
+
           <form onSubmit={handleSubmit} className="auth-form">
             {mode === 'register' && (
               <div className="form-group">
-                <label htmlFor="name">Nombre (opcional)</label>
+                <label htmlFor="name">NOMBRE <span className="form-optional">(opcional)</span></label>
                 <input
                   type="text"
                   id="name"
@@ -147,12 +147,13 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
                   value={formData.name}
                   onChange={handleInputChange}
                   placeholder="Tu nombre"
+                  autoComplete="name"
                 />
               </div>
             )}
 
             <div className="form-group">
-              <label htmlFor="email">Email</label>
+              <label htmlFor="email">EMAIL</label>
               <input
                 type="email"
                 id="email"
@@ -161,11 +162,12 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
                 onChange={handleInputChange}
                 placeholder="tu@email.com"
                 required
+                autoComplete="email"
               />
             </div>
 
             <div className="form-group">
-              <label htmlFor="password">Contraseña</label>
+              <label htmlFor="password">CONTRASEÑA</label>
               <input
                 type="password"
                 id="password"
@@ -175,13 +177,12 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
                 placeholder="Mínimo 6 caracteres"
                 minLength={6}
                 required
+                autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
               />
             </div>
 
             {error && (
-              <div className="error-message">
-                ⚠️ {error}
-              </div>
+              <div className="error-message">{error}</div>
             )}
 
             <button
@@ -189,49 +190,30 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
               className="auth-submit-btn"
               disabled={loading}
             >
-              {loading ? '⏳ Procesando...' : (mode === 'login' ? '🔓 Iniciar Sesión' : '🎯 Crear Cuenta')}
+              {loading ? 'PROCESANDO...' : (mode === 'login' ? 'INICIAR SESIÓN' : 'CREAR CUENTA')}
             </button>
           </form>
-
-          <div className="auth-divider">
-            <span>o</span>
-          </div>
-
-          <button
-            type="button"
-            onClick={handleGoogleLogin}
-            className="google-login-btn"
-            disabled={loading || !authService.isGoogleAvailable()}
-            title={!authService.isGoogleAvailable() ? 'Google OAuth no configurado' : ''}
-          >
-            🌐 {authService.isGoogleAvailable() ? 'Continuar con Google' : 'Google OAuth (no configurado)'}
-          </button>
 
           <div className="auth-switch">
             {mode === 'login' ? (
               <p>
-                ¿No tenés cuenta?{' '}
-                <button type="button" onClick={switchMode} className="link-btn">
-                  Creá una acá
-                </button>
+                ¿Sin cuenta?{' '}
+                <button type="button" onClick={switchMode} className="link-btn">Creá una acá</button>
               </p>
             ) : (
               <p>
                 ¿Ya tenés cuenta?{' '}
-                <button type="button" onClick={switchMode} className="link-btn">
-                  Iniciá sesión
-                </button>
+                <button type="button" onClick={switchMode} className="link-btn">Iniciá sesión</button>
               </p>
             )}
           </div>
 
           <div className="auth-benefits">
-            <h4>✨ Beneficios de tener cuenta:</h4>
+            <div className="auth-benefits__label">POR QUÉ CREAR CUENTA</div>
             <ul>
-              <li>📱 Sincronización entre dispositivos</li>
-              <li>☁️ Backup automático de tu progreso</li>
-              <li>📊 Historial completo de aprendizaje</li>
-              <li>🎯 Recomendaciones personalizadas</li>
+              <li>Sincronización entre dispositivos</li>
+              <li>Backup automático de progreso</li>
+              <li>Historial completo de aprendizaje</li>
             </ul>
           </div>
         </div>

--- a/src/components/drill/DrillVerbos.css
+++ b/src/components/drill/DrillVerbos.css
@@ -1096,6 +1096,7 @@
   color: var(--vd-accent);
 }
 
+/* Legacy .setting-group overrides (still used by SettingsPanel) */
 .verbos-drill .quick-switch-panel .setting-group {
   margin-bottom: 14px;
 }
@@ -1108,6 +1109,190 @@
   color: var(--vd-ink);
   font-family: var(--vd-mono);
   font-size: 11px;
+}
+
+/* ── QuickSwitch panel — VERB/OS native layout ── */
+.verbos-drill .vd-qs-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 20px 24px 0;
+}
+
+.verbos-drill .vd-qs-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+  gap: 0;
+  border-bottom: 1px solid var(--vd-line);
+  min-height: 42px;
+}
+
+.verbos-drill .vd-qs-row:first-child {
+  border-top: 1px solid var(--vd-line);
+}
+
+.verbos-drill .vd-qs-label {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  padding: 0 12px 0 0;
+  flex-shrink: 0;
+}
+
+.verbos-drill .vd-qs-select {
+  width: 100%;
+  padding: 11px 10px;
+  border: none;
+  border-left: 1px solid var(--vd-line);
+  background: transparent;
+  color: var(--vd-ink);
+  font-family: var(--vd-mono);
+  font-size: 11px;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%236e6a60' stroke-width='1.2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}
+
+.verbos-drill .vd-qs-select:focus {
+  outline: none;
+  background-color: rgba(255,77,28,0.04);
+  color: var(--vd-ink);
+  border-left-color: var(--vd-accent);
+}
+
+.verbos-drill .vd-qs-select option {
+  background: #111;
+  color: var(--vd-ink);
+}
+
+.verbos-drill .vd-qs-hint {
+  font-family: var(--vd-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  color: var(--vd-ink2);
+  padding: 8px 24px 0;
+}
+
+.verbos-drill .vd-qs-actions {
+  display: flex;
+  gap: 8px;
+  padding: 16px 24px;
+}
+
+/* ── Games panel — VERB/OS native layout ── */
+.verbos-drill .vd-games-panel {
+  padding: 20px 24px;
+}
+
+.verbos-drill .vd-games-label {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+  margin-bottom: 14px;
+}
+
+.verbos-drill .vd-games-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--vd-line);
+  margin-bottom: 16px;
+}
+
+.verbos-drill .vd-game-btn {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 14px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--vd-line);
+  cursor: pointer;
+  text-align: left;
+  transition: background 100ms;
+}
+
+.verbos-drill .vd-game-btn:last-child {
+  border-bottom: none;
+}
+
+.verbos-drill .vd-game-btn:hover {
+  background: rgba(255,255,255,0.03);
+}
+
+.verbos-drill .vd-game-btn--active {
+  background: rgba(255,77,28,0.06);
+}
+
+.verbos-drill .vd-game-img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  flex-shrink: 0;
+  opacity: 0.7;
+  filter: saturate(0.6);
+}
+
+.verbos-drill .vd-game-btn--active .vd-game-img {
+  opacity: 1;
+  filter: none;
+}
+
+.verbos-drill .vd-game-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.verbos-drill .vd-game-name {
+  font-family: var(--vd-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--vd-ink2);
+}
+
+.verbos-drill .vd-game-btn--active .vd-game-name {
+  color: var(--vd-accent);
+}
+
+.verbos-drill .vd-game-desc {
+  font-family: var(--vd-mono);
+  font-size: 9.5px;
+  color: var(--vd-ink3);
+  letter-spacing: 0.04em;
+}
+
+.verbos-drill .vd-game-state {
+  font-family: var(--vd-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  border: 1px solid var(--vd-line);
+  padding: 2px 6px;
+  color: var(--vd-ink3);
+  flex-shrink: 0;
+}
+
+.verbos-drill .vd-game-btn--active .vd-game-state {
+  border-color: var(--vd-accent);
+  color: var(--vd-accent);
 }
 
 /* Loading fallback for panels */
@@ -1130,6 +1315,7 @@
 /* These appear after DrillHeader and before main-content */
 .verbos-drill > div.quick-switch-panel,
 .verbos-drill > div.games-panel,
+.verbos-drill > div.vd-games-panel,
 .verbos-drill > div.pronunciation-panel-safe,
 .verbos-drill > div.pronunciation-panel-v2 {
   position: absolute;

--- a/src/components/drill/GamesPanel.jsx
+++ b/src/components/drill/GamesPanel.jsx
@@ -1,95 +1,79 @@
 import React from 'react'
 
+const GAME_MODES = [
+  {
+    id: 'resistance',
+    icon: '/zombie.png',
+    label: 'SUPERVIVENCIA',
+    desc: 'Modo contrarreloj',
+    isActive: (s) => s.resistanceActive,
+    toggle: (settings, onClose) => {
+      if (settings.resistanceActive) {
+        settings.set({ resistanceActive: false, resistanceMsLeft: 0, resistanceStartTs: null })
+      } else {
+        const level = settings.level || 'A1'
+        const baseMs = level==='C2'?15000: level==='C1'?16000: level==='B2'?17000: level==='B1'?18000: level==='A2'?18000:20000
+        settings.set({ resistanceActive: true, resistanceMsLeft: baseMs, resistanceStartTs: Date.now() })
+      }
+      onClose()
+    },
+    needsRegen: false
+  },
+  {
+    id: 'reverse',
+    icon: '/sobrev.png',
+    label: 'INVERSO',
+    desc: 'Forma → pronombre',
+    isActive: (s) => s.reverseActive,
+    toggle: (settings, onClose, onRegen) => {
+      const active = !!settings.reverseActive
+      settings.set({ reverseActive: !active, doubleActive: false })
+      onClose()
+      if (!active) setTimeout(onRegen, 100)
+    },
+    needsRegen: true
+  },
+  {
+    id: 'double',
+    icon: '/verbosverbos.png',
+    label: 'DOS × DOS',
+    desc: 'Dos verbos a la vez',
+    isActive: (s) => s.doubleActive,
+    toggle: (settings, onClose, onRegen) => {
+      const active = !!settings.doubleActive
+      settings.set({ doubleActive: !active, reverseActive: false })
+      onClose()
+      if (!active) setTimeout(onRegen, 100)
+    },
+    needsRegen: true
+  }
+]
+
 function GamesPanel({ settings, onClose, onRegenerateItem }) {
-  const handleResistanceToggle = () => {
-    if (settings.resistanceActive) {
-      // Deactivate
-      settings.set({ resistanceActive: false, resistanceMsLeft: 0, resistanceStartTs: null })
-    } else {
-      const level = settings.level || 'A1'
-      // Supervivencia: A1 20s, A2 18s, B1 18s, B2 17s, C1 16s, C2 15s
-      const baseMs = level==='C2'?15000: level==='C1'?16000: level==='B2'?17000: level==='B1'?18000: level==='A2'?18000:20000
-      settings.set({ resistanceActive: true, resistanceMsLeft: baseMs, resistanceStartTs: Date.now() })
-    }
-    onClose()
-  }
-
-  const handleReverseToggle = () => {
-    // Toggle reverse mode
-    const active = !!settings.reverseActive
-    settings.set({ reverseActive: !active, doubleActive: false })
-    onClose()
-    
-    // CRÍTICO: Si se activa el modo reverso, regenerar inmediatamente
-    if (!active) {
-      setTimeout(() => {
-        onRegenerateItem()
-      }, 100)
-    }
-  }
-
-  const handleDoubleToggle = () => {
-    // Toggle double mode
-    const active = !!settings.doubleActive
-    settings.set({ doubleActive: !active, reverseActive: false })
-    onClose()
-    
-    // CRÍTICO: Si se activa el modo doble, regenerar inmediatamente
-    if (!active) {
-      setTimeout(() => {
-        onRegenerateItem()
-      }, 100)
-    }
-  }
-
-  const handleKeyDown = (e, callback) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      callback()
-    }
-  }
-
   return (
-    <div className="games-panel quick-switch-panel" aria-label="Juegos">
-      <div className="options-grid">
-        <div 
-          className="option-card compact" 
-          onClick={handleResistanceToggle} 
-          aria-label="Survivor"
-          role="button"
-          tabIndex="0"
-          onKeyDown={(e) => handleKeyDown(e, handleResistanceToggle)}
-        >
-          <img src="/zombie.png" alt="Survivor" className="game-icon" />
-          <p className="conjugation-example">Modo supervivencia</p>
-        </div>
-        
-        <div 
-          className="option-card compact" 
-          onClick={handleReverseToggle} 
-          aria-label="Reverso"
-          role="button"
-          tabIndex="0"
-          onKeyDown={(e) => handleKeyDown(e, handleReverseToggle)}
-        >
-          <img src="/sobrev.png" alt="Reverso" className="game-icon" />
-          <p className="conjugation-example">Invertí la consigna</p>
-        </div>
-        
-        <div 
-          className="option-card compact" 
-          onClick={handleDoubleToggle} 
-          aria-label="Dos juntos dos"
-          role="button"
-          tabIndex="0"
-          onKeyDown={(e) => handleKeyDown(e, handleDoubleToggle)}
-        >
-          <img src="/verbosverbos.png" alt="De a dos" className="game-icon" />
-          <p className="conjugation-example">Dos juntos dos</p>
-        </div>
+    <div className="vd-games-panel quick-switch-panel">
+      <div className="vd-games-label">MODOS DE JUEGO</div>
+      <div className="vd-games-list">
+        {GAME_MODES.map((mode) => {
+          const active = mode.isActive(settings)
+          return (
+            <button
+              key={mode.id}
+              className={`vd-game-btn${active ? ' vd-game-btn--active' : ''}`}
+              onClick={() => mode.toggle(settings, onClose, onRegenerateItem)}
+              aria-pressed={active}
+            >
+              <img src={mode.icon} alt="" className="vd-game-img" aria-hidden="true" />
+              <span className="vd-game-info">
+                <span className="vd-game-name">{mode.label}</span>
+                <span className="vd-game-desc">{mode.desc}</span>
+              </span>
+              <span className="vd-game-state">{active ? 'ON' : 'OFF'}</span>
+            </button>
+          )
+        })}
       </div>
-      
-      <div style={{ textAlign: 'center' }}>
+      <div className="vd-qs-actions">
         <button className="btn btn-secondary" onClick={onClose}>Cerrar</button>
       </div>
     </div>

--- a/src/components/drill/QuickSwitchPanel.jsx
+++ b/src/components/drill/QuickSwitchPanel.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { getTensesForMood, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
 
-function QuickSwitchPanel({ 
-  settings, 
-  onApply, 
+function QuickSwitchPanel({
+  settings,
+  onApply,
   onClose,
   getAvailableMoodsForLevel,
   getAvailableTensesForLevelAndMood,
@@ -18,40 +18,11 @@ function QuickSwitchPanel({
 
   const applyDialectLocally = (dialect) => {
     const variantUpdates = {
-      rioplatense: {
-        useVoseo: true,
-        useTuteo: false,
-        useVosotros: false,
-        strict: true,
-        region: 'rioplatense',
-        practicePronoun: 'all'
-      },
-      peninsular: {
-        useTuteo: true,
-        useVoseo: false,
-        useVosotros: true,
-        strict: true,
-        region: 'peninsular',
-        practicePronoun: 'both'
-      },
-      both: {
-        useTuteo: true,
-        useVoseo: true,
-        useVosotros: true,
-        strict: false,
-        region: 'la_general',
-        practicePronoun: 'all'
-      },
-      la_general: {
-        useTuteo: true,
-        useVoseo: false,
-        useVosotros: false,
-        strict: true,
-        region: 'la_general',
-        practicePronoun: 'both'
-      }
+      rioplatense: { useVoseo: true, useTuteo: false, useVosotros: false, strict: true, region: 'rioplatense', practicePronoun: 'all' },
+      peninsular:  { useTuteo: true, useVoseo: false, useVosotros: true,  strict: true, region: 'peninsular',  practicePronoun: 'both' },
+      both:        { useTuteo: true, useVoseo: true,  useVosotros: true,  strict: false, region: 'la_general', practicePronoun: 'all' },
+      la_general:  { useTuteo: true, useVoseo: false, useVosotros: false, strict: true, region: 'la_general',  practicePronoun: 'both' }
     }
-
     settings.set(variantUpdates[dialect] || variantUpdates.la_general)
   }
 
@@ -64,18 +35,12 @@ function QuickSwitchPanel({
   }
 
   const handleMoodChange = (mood) => {
-    // Reset tense when mood changes, and ensure practice mode goes back to mixed
-    settings.set({
-      specificMood: mood || null,
-      specificTense: null,
-      practiceMode: 'mixed' // Reset to mixed mode until both mood and tense are selected
-    })
+    settings.set({ specificMood: mood || null, specificTense: null, practiceMode: 'mixed' })
   }
 
   const handleTenseChange = (tense) => {
     settings.set({
       specificTense: tense || null,
-      // Reset to mixed mode if tense is cleared
       practiceMode: (settings.specificMood && tense) ? 'specific' : 'mixed'
     })
   }
@@ -85,11 +50,9 @@ function QuickSwitchPanel({
   }
 
   const handleApply = () => {
-    // Only set practice mode to specific when BOTH mood and tense are selected
     if (settings.specificMood && settings.specificTense) {
       settings.set({ practiceMode: 'specific' })
     } else {
-      // Ensure we stay in mixed mode if selection is incomplete
       settings.set({ practiceMode: 'mixed' })
     }
     onApply()
@@ -97,82 +60,83 @@ function QuickSwitchPanel({
 
   return (
     <div className="quick-switch-panel">
-      <div className="setting-group">
-        <label htmlFor="variant-select">Variantes:</label>
-        <select
-          id="variant-select"
-          className="setting-select"
-          value={getDialectValue()}
-          onChange={(e) => handleDialectChange(e.target.value)}
-        >
-          <option value="rioplatense">Vos</option>
-          <option value="la_general">Tú</option>
-          <option value="peninsular">Tú y vosotros</option>
-          <option value="both">Todos</option>
-        </select>
-      </div>
+      <div className="vd-qs-body">
 
-      <div className="setting-group">
-        <label htmlFor="mood-select">Modo verbal:</label>
-        <select
-          id="mood-select"
-          className="setting-select"
-          value={settings.specificMood || ''}
-          onChange={(e) => handleMoodChange(e.target.value)}
-        >
-          <option value="">Seleccioná modo...</option>
-          {(settings.level ? getAvailableMoodsForLevel(settings.level) : ['indicative','subjunctive','imperative','conditional','nonfinite']).map(m => (
-            <option key={m} value={m}>{getMoodLabel(m)}</option>
-          ))}
-        </select>
-      </div>
-
-      {settings.specificMood && (
-        <div className="setting-group">
-          <label htmlFor="tense-select">Tiempo verbal:</label>
+        <div className="vd-qs-row">
+          <label className="vd-qs-label" htmlFor="qs-variant">VARIANTE</label>
           <select
-            id="tense-select"
-            className="setting-select"
-            value={settings.specificTense || ''}
-            onChange={(e) => handleTenseChange(e.target.value)}
+            id="qs-variant"
+            className="vd-qs-select"
+            value={getDialectValue()}
+            onChange={(e) => handleDialectChange(e.target.value)}
           >
-            <option value="">Seleccioná tiempo...</option>
-            {(settings.level
-              ? getAvailableTensesForLevelAndMood(settings.level, settings.specificMood)
-              : getTensesForMood(settings.specificMood)
-            ).map(t => (
-              <option key={t} value={t}>{getTenseLabel(t)}</option>
+            <option value="rioplatense">Vos (Río de la Plata)</option>
+            <option value="la_general">Tú (América Latina)</option>
+            <option value="peninsular">Tú y vosotros (España)</option>
+            <option value="both">Todos</option>
+          </select>
+        </div>
+
+        <div className="vd-qs-row">
+          <label className="vd-qs-label" htmlFor="qs-mood">MODO VERBAL</label>
+          <select
+            id="qs-mood"
+            className="vd-qs-select"
+            value={settings.specificMood || ''}
+            onChange={(e) => handleMoodChange(e.target.value)}
+          >
+            <option value="">Todos los modos</option>
+            {(settings.level ? getAvailableMoodsForLevel(settings.level) : ['indicative','subjunctive','imperative','conditional','nonfinite']).map(m => (
+              <option key={m} value={m}>{getMoodLabel(m)}</option>
             ))}
           </select>
         </div>
-      )}
 
-      <div className="setting-group">
-        <label htmlFor="verb-type-select">Tipo de verbos:</label>
-        <select
-          id="verb-type-select"
-          className="setting-select"
-          value={settings.verbType}
-          onChange={(e) => handleVerbTypeChange(e.target.value)}
-        >
-          <option value="all">Todos</option>
-          <option value="regular">Regulares</option>
-          <option value="irregular">Irregulares</option>
-        </select>
-      </div>
-
-      <div className="setting-group">
-        {settings.specificMood && !settings.specificTense && (
-          <div className="validation-message">
-            Seleccioná un tiempo verbal para practicar modo específico
+        {settings.specificMood && (
+          <div className="vd-qs-row">
+            <label className="vd-qs-label" htmlFor="qs-tense">TIEMPO</label>
+            <select
+              id="qs-tense"
+              className="vd-qs-select"
+              value={settings.specificTense || ''}
+              onChange={(e) => handleTenseChange(e.target.value)}
+            >
+              <option value="">Seleccioná tiempo...</option>
+              {(settings.level
+                ? getAvailableTensesForLevelAndMood(settings.level, settings.specificMood)
+                : getTensesForMood(settings.specificMood)
+              ).map(t => (
+                <option key={t} value={t}>{getTenseLabel(t)}</option>
+              ))}
+            </select>
           </div>
         )}
-        <button className="btn" onClick={handleApply}>
-          Aplicar
-        </button>
-        <button className="btn btn-secondary" onClick={onClose}>
-          Cerrar
-        </button>
+
+        <div className="vd-qs-row">
+          <label className="vd-qs-label" htmlFor="qs-verbtype">VERBOS</label>
+          <select
+            id="qs-verbtype"
+            className="vd-qs-select"
+            value={settings.verbType}
+            onChange={(e) => handleVerbTypeChange(e.target.value)}
+          >
+            <option value="all">Todos</option>
+            <option value="regular">Solo regulares</option>
+            <option value="irregular">Solo irregulares</option>
+          </select>
+        </div>
+
+      </div>
+
+      {settings.specificMood && !settings.specificTense && (
+        <div className="vd-qs-hint">
+          Seleccioná un tiempo para practicar modo específico
+        </div>
+      )}
+
+      <div className="vd-qs-actions">
+        <button className="btn" onClick={handleApply}>Aplicar</button>
+        <button className="btn btn-secondary" onClick={onClose}>Cerrar</button>
       </div>
     </div>
   )


### PR DESCRIPTION
AccountButton: el botón sin sesión ahora muestra "SINCRONIZAR →" con flecha naranja como call-to-action explícito. Con sesión: muestra [inicial] + nombre + badge de estado (OK/2m/ERROR) en lugar del cuadradito misterioso anterior. Todo usa los tokens hardcodeados del sistema (#0c0c0c, #1f1d18, JetBrains Mono, 10px) para quedar nativo en el vo-header de 44px en lugar de las variables globales que no estaban calibradas para ese contexto.

AuthModal: eliminados todos los emojis. Google OAuth sube al tope del formulario. Header con tag "VERB/OS" + título en mono uppercase. La sección de beneficios usa labels pequeñas con flecha →.

QuickSwitchPanel: layout de grilla (label 90px | select) separados por bordes finos, selects con chevron SVG custom, sin grupos verticales.

GamesPanel: reemplaza las option-card con vd-game-btn — filas con icon, nombre, descripción y badge ON/OFF. El modo activo resalta en naranja.

DrillVerbos.css: estilos nativos para .vd-qs-row, .vd-qs-label, .vd-qs-select, .vd-game-btn y variantes de estado.