### PR TITLE
fix: prevent crash and truncated flow after drill controlado

### DIFF
--- a/src/components/learning/IrregularRootDrill.jsx
+++ b/src/components/learning/IrregularRootDrill.jsx
@@ -79,6 +79,8 @@ function IrregularRootDrill({
   const [showPronunciation, setShowPronunciation] = useState(false)
   const [showAccentKeypad, setShowAccentKeypad] = useState(false)
   const pronunciationPanelRef = useRef(null)
+  const handleFinishRef = useRef(handleFinish)
+  handleFinishRef.current = handleFinish
 
   const mode = useMemo(() => {
     if (selectedFamilies.includes(ROOT_FAMILY_ID) && (tense?.tense === 'fut' || tense?.tense === 'cond')) {
@@ -118,18 +120,17 @@ function IrregularRootDrill({
 
   useEffect(() => {
     if (!timeLeft || timeLeft <= 0) return
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (!prev || prev <= 1) {
-          clearInterval(timer)
-          handleFinish()
-          return 0
-        }
-        return prev - 1
-      })
+    const timer = setTimeout(() => {
+      setTimeLeft(prev => (prev && prev > 1) ? prev - 1 : 0)
     }, 1000)
-    return () => clearInterval(timer)
+    return () => clearTimeout(timer)
   }, [timeLeft])
+
+  useEffect(() => {
+    if (timeLeft === 0) {
+      handleFinishRef.current(stats)
+    }
+  }, [timeLeft, stats])
 
   const currentQuestion = questions[index] || null
   const tenseLabel = tense ? TENSE_LABELS[tense.tense] || formatMoodTense(tense.mood, tense.tense) : ''

--- a/src/components/learning/LearnTenseFlow.jsx
+++ b/src/components/learning/LearnTenseFlow.jsx
@@ -532,8 +532,8 @@ function LearnTenseFlowContainer({ onHome, onGoToProgress }) {
   };
 
   const handleMechanicalPhaseComplete = () => {
-    logger.debug('Mechanical phase complete, finishing session.');
-    handleFinish();
+    logger.debug('Mechanical phase complete, showing session summary.');
+    setCurrentStep('session-complete');
   };
 
   if (exampleVerbsLoading) {
@@ -695,6 +695,24 @@ function LearnTenseFlowContainer({ onHome, onGoToProgress }) {
     );
   }
 
+
+  if (currentStep === 'session-complete') {
+    return (
+      <div className="learning-menu-layout" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '70vh', gap: '1.5rem', textAlign: 'center' }}>
+        <div style={{ fontSize: '2.5rem', fontWeight: 900, color: '#ff4d1c' }}>✓</div>
+        <h2 style={{ margin: 0, fontFamily: 'Inter Tight, sans-serif', fontSize: '1.75rem', fontWeight: 900, fontStyle: 'italic' }}>¡Sesión completada!</h2>
+        <p style={{ margin: 0, opacity: 0.6, fontSize: '0.9rem', letterSpacing: '0.05em', textTransform: 'uppercase', fontFamily: 'JetBrains Mono, monospace' }}>
+          Practicaste con éxito. Buen trabajo.
+        </p>
+        <button
+          onClick={handleFinish}
+          style={{ marginTop: '0.5rem', padding: '0.75rem 2rem', cursor: 'pointer', background: '#ff4d1c', color: '#0c0c0c', border: 'none', borderRadius: 4, fontSize: '0.95rem', fontWeight: 700, fontFamily: 'JetBrains Mono, monospace', letterSpacing: '0.1em', textTransform: 'uppercase' }}
+        >
+          Volver al inicio →
+        </button>
+      </div>
+    );
+  }
 
   // Step 1: Tense Selection
   if (currentStep === 'tense-selection') {

--- a/src/lib/learning/learningConfig.js
+++ b/src/lib/learning/learningConfig.js
@@ -199,6 +199,7 @@ export const LEARNING_FLOW_STEPS = [
   'guided_drill_ir',
   'recap',
   'practice',
+  'session-complete',
 ];
 
 /**


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Crash fix**: `handleMechanicalPhaseComplete` was calling `handleFinish()` directly inside a `setTimeout` callback, which synchronously triggered `onHome()` → `router.navigate()` → `setCurrentMode()` while also setting multiple state fields on `LearnTenseFlowContainer`. This race in React's reconciliation triggered the ErrorBoundary ("Se produjo un error en la UI").
- **Flow fix**: After the drill, the user now lands on a "¡Sesión completada!" screen instead of being abruptly sent home. They click "Volver al inicio" to navigate cleanly.
- **Timer anti-pattern fix**: `IrregularRootDrill` was calling `handleFinish()` inside a `setTimeLeft` state updater — React requires state updaters to be pure. Fixed by separating countdown state mutation (`setTimeout`) from the finish side-effect (a dedicated `useEffect` on `timeLeft === 0` using a ref).

## Test plan

- [ ] Navigate to learning module → Participios irregulares (irregular)
- [ ] Complete all three guided drill stages (NonfiniteGuidedDrill ar/er/ir)
- [ ] Complete the recap step
- [ ] Complete the IrregularRootDrill (answer all 12 participle questions)
- [ ] Verify "¡Sesión completada!" screen appears (no ErrorBoundary)
- [ ] Click "Volver al inicio" → returns to tense selection cleanly
- [ ] Repeat with a regular tense (e.g., presente regular) to confirm no regressions
- [ ] Let the timer expire mid-drill (set duration low) → verify session-complete screen appears

https://claude.ai/code/session_01L7hV9CdDssTPowFPKJmtZ4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7hV9CdDssTPowFPKJmtZ4)_