### PR TITLE
fix: mobile layout for learning module intro page

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -843,8 +843,10 @@
 
   .ni-paradigm-table { overflow-x: auto; }
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 5rem repeat(auto-fill, minmax(3rem, 1fr)); }
-  .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.4rem 0.25rem; }
-  .ni-paradigm-lemma { font-size: 0.65rem; padding: 0.6rem 0.5rem; }
-  .ni-paradigm-cell { font-size: 0.75rem; padding: 0.6rem 0.25rem; }
+  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(auto-fill, minmax(2.2rem, 1fr)); }
+  .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
+  .ni-paradigm-lemma { font-size: 0.62rem; padding: 0.5rem 0.35rem; }
+  .ni-paradigm-cell { font-size: 0.72rem; padding: 0.5rem 0.15rem; }
+  /* Hide repeated stem — lemma column already shows the verb; only colored ending matters */
+  .ni-form-stem { display: none; }
 }

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -481,6 +481,8 @@
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
     overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
   }
 
   .vo-left {
@@ -488,6 +490,8 @@
     border-bottom: 1px solid #1f1d18;
     padding: 28px 20px 24px 20px;
     min-height: 220px;
+    max-height: 42vh;
+    overflow: hidden;
   }
 
   .vo-watermark { font-size: clamp(80px, 28vw, 160px); }
@@ -496,6 +500,8 @@
     padding: 20px 20px 20px 20px;
     justify-content: flex-start;
     overflow-y: auto;
+    min-height: 0;
+    -webkit-overflow-scrolling: touch;
   }
 
   .vo-options-label { top: 8px; left: 20px; }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Critical grid fix**: Added `min-height: 0` to `.vo-right` — without it, CSS grid cannot shrink the `1fr` panel below its content height, so the layout breaks instead of scrolling internally on mobile
- **Paradigm table**: Reduced column widths (`3.5rem + minmax(2.2rem,1fr)`) and hide the repeated stem in each cell at ≤480px; the lemma column already names the verb, so showing only the highlighted ending is sufficient and fits narrow screens
- **iOS Safari scroll**: Added `-webkit-overflow-scrolling: touch` and `touch-action: pan-y` to the scroll containers inside the `position: fixed; overflow: hidden` shell
- **Left panel cap**: Added `max-height: 42vh; overflow: hidden` to `.vo-left` to prevent long tense names from squeezing the right panel on short phones (iPhone SE)

## Test plan

- [ ] Open DevTools → Responsive → 375px width; navigate to any tense intro page — right panel should scroll and "continuar" button should be reachable
- [ ] Check with a long tense name (subjuntivo → imperfecto de subjuntivo) — left panel stays within 42vh
- [ ] Check paradigm table at 375px and 320px — no horizontal overflow, only colored endings shown per cell
- [ ] Test on iOS Safari (or simulator) — scroll should work without freezing

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_