### PR TITLE
fix(mobile): arreglo layout pantalla intro learning module

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -850,3 +850,10 @@
   /* Hide repeated stem — lemma column already shows the verb; only colored ending matters */
   .ni-form-stem { display: none; }
 }
+
+@media (max-width: 360px) {
+  .ni-paradigm-header,
+  .ni-paradigm-row { grid-template-columns: 3rem repeat(auto-fill, minmax(2rem, 1fr)); }
+  .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }
+  .ni-paradigm-cell { font-size: 0.68rem; padding: 0.4rem 0.1rem; }
+}

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -857,3 +857,21 @@
   .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }
   .ni-paradigm-cell { font-size: 0.68rem; padding: 0.4rem 0.1rem; }
 }
+
+/* ── NarrativeIntroduction-specific mobile overrides ── */
+/* Scoped with .verbos-onboarding--intro so other learning steps keep min-height: 220px */
+
+@media (max-width: 680px) {
+  .verbos-onboarding--intro .vo-left {
+    min-height: unset;
+    padding: 16px 16px 12px 16px;
+  }
+  .verbos-onboarding--intro .vo-left-bottom { margin-top: 8px; }
+  .verbos-onboarding--intro .vo-prompt      { font-size: 17px; margin-bottom: 4px; }
+  .verbos-onboarding--intro .vo-aux         { margin-bottom: 8px; }
+  .verbos-onboarding--intro .vo-focal-word  { margin-bottom: 8px; }
+  .verbos-onboarding--intro .vo-meta        { padding-top: 8px; }
+  /* The global .vo-right rule adds padding-top: 36px for .vo-options-label in other steps;
+     NarrativeIntroduction has no such label, so reclaim that space */
+  .verbos-onboarding--intro .ni-right-panel { padding-top: 20px; }
+}

--- a/src/components/learning/NarrativeIntroduction.jsx
+++ b/src/components/learning/NarrativeIntroduction.jsx
@@ -1384,7 +1384,7 @@ function NarrativeIntroduction({ tense, exampleVerbs = [], onBack, onContinue })
   };
 
   return (
-    <div className={`verbos-onboarding${leaving ? ' ni-leaving' : ''}`}>
+    <div className={`verbos-onboarding verbos-onboarding--intro${leaving ? ' ni-leaving' : ''}`}>
       <div className="vo-grid" aria-hidden="true" />
       <div className="vo-vignette" aria-hidden="true" />
       {[{top:56,left:12},{top:56,right:12},{bottom:44,left:12},{bottom:44,right:12}].map((pos,i) => (

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -490,8 +490,6 @@
     border-bottom: 1px solid #1f1d18;
     padding: 28px 20px 24px 20px;
     min-height: 220px;
-    max-height: 42vh;
-    overflow: hidden;
   }
 
   .vo-watermark { font-size: clamp(80px, 28vw, 160px); }


### PR DESCRIPTION
## Qué arregla

La pantalla de introducción del módulo de aprendizaje (`NarrativeIntroduction`) se descompaginaba en móvil: ambos paneles (nombre del tiempo + terminaciones) se desplazaban juntos como un único bloque, el nombre del tiempo desaparecía al hacer scroll y el botón "continuar" quedaba fuera de alcance.

## Causa raíz

`grid-template-rows: auto 1fr` en `.vo-step` + `min-height: auto` (default) en `.vo-right` → el panel derecho no podía contraerse a su fila `1fr`, el grid desbordaba el contenedor y `overflow-y: auto` del step entero activaba scroll en ambos paneles a la vez.

## Cambios

### `OnboardingFlow.css`
- `min-height: 0` en `.vo-right` (fix crítico: permite al item del grid contraerse y hacer scroll interno)
- `-webkit-overflow-scrolling: touch` + `touch-action: pan-y` en `.vo-step` y `.vo-right` (iOS Safari)

### `NarrativeIntroduction.jsx`
- Añade clase `verbos-onboarding--intro` al div raíz para poder sobreescribir estilos sin afectar otras pantallas del módulo

### `NarrativeIntroduction.css`
- Bloque `@media (max-width: 680px)` con selectores `.verbos-onboarding--intro`:
  - Elimina `min-height: 220px` del panel izquierdo (sólo necesario en otras pantallas con menús)
  - Compacta padding/márgenes del panel izquierdo → altura natural ~150px en vez de 220px
  - Corrige `padding-top: 36px` del panel derecho (sobraba; es para `.vo-options-label` que no existe aquí)
- Tabla de terminaciones más estrecha en ≤480px (`3.5rem + minmax(2.2rem,1fr)`, stem oculto)
- Breakpoint adicional ≤360px para teléfonos muy pequeños

## Test

- DevTools → 375px (iPhone SE): panel izquierdo compacto, nombre del tiempo visible, "continuar" accesible con scroll
- Probar tense largo ("pretérito imperfecto de subjuntivo"): sin recorte del texto
- Probar tabla de terminaciones en 375px y 320px: sin overflow horizontal

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_