### PR TITLE
fix(mobile): tabla de paradigma — columnas exactas con --pronoun-count

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -713,7 +713,7 @@
 .ni-paradigm-header,
 .ni-paradigm-row {
   display: grid;
-  grid-template-columns: 7rem repeat(auto-fill, minmax(4rem, 1fr));
+  grid-template-columns: 7rem repeat(var(--pronoun-count, 6), minmax(4rem, 1fr));
   align-items: center;
   border-bottom: 1px solid #1f1d18;
 }
@@ -843,7 +843,7 @@
 
   .ni-paradigm-table { overflow-x: auto; }
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(auto-fill, minmax(2.2rem, 1fr)); }
+  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), 1fr); }
   .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
   .ni-paradigm-lemma { font-size: 0.62rem; padding: 0.5rem 0.35rem; }
   .ni-paradigm-cell { font-size: 0.72rem; padding: 0.5rem 0.15rem; }
@@ -853,7 +853,7 @@
 
 @media (max-width: 360px) {
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3rem repeat(auto-fill, minmax(2rem, 1fr)); }
+  .ni-paradigm-row { grid-template-columns: 3rem repeat(var(--pronoun-count, 6), 1fr); }
   .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }
   .ni-paradigm-cell { font-size: 0.68rem; padding: 0.4rem 0.1rem; }
 }


### PR DESCRIPTION
## Problema

En móvil, el pronombre ELLOS (última columna de la tabla de TERMINACIONES) saltaba a una nueva fila rompiendo completamente la tabla. Las formas `hablan`, `comen`, `viven` aparecían sueltas debajo de cada fila.

## Causa raíz

`repeat(auto-fill, minmax(2.2rem, 1fr))` calcula el número de columnas dividiendo el espacio disponible entre el tamaño mínimo en `rem`. Si el sistema tiene accesibilidad de fuente aumentada (iOS/Android), `rem` es mayor → caben menos columnas que pronombres → ELLOS desborda a la siguiente fila.

## Fix

El JSX ya calculaba el número exacto de pronombres y lo exponía como variable CSS `--pronoun-count` en el elemento tabla, pero el CSS la ignoraba. Ahora se usa en los 3 breakpoints:

```css
/* Antes */
grid-template-columns: Xrem repeat(auto-fill, minmax(Yrem, 1fr));

/* Después */
grid-template-columns: Xrem repeat(var(--pronoun-count, 6), 1fr);
```

Garantiza exactamente el número correcto de columnas sin importar el tamaño de fuente del sistema. Funciona para 5 pronombres (voseo rioplatense) y 6 (estándar).

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_