### PR TITLE
fix(mobile): paradigm table columns — pronoun count + min-content sizing

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -841,9 +841,9 @@
     padding: 1rem 0;
   }
 
-  .ni-paradigm-table { overflow-x: auto; }
+  .ni-paradigm-table { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), 1fr); }
+  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr)); }
   .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
   .ni-paradigm-lemma { font-size: 0.62rem; padding: 0.5rem 0.35rem; }
   .ni-paradigm-cell { font-size: 0.72rem; padding: 0.5rem 0.15rem; }
@@ -853,7 +853,7 @@
 
 @media (max-width: 360px) {
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3rem repeat(var(--pronoun-count, 6), 1fr); }
+  .ni-paradigm-row { grid-template-columns: 3rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr)); }
   .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }
   .ni-paradigm-cell { font-size: 0.68rem; padding: 0.4rem 0.1rem; }
 }


### PR DESCRIPTION
## Summary

- Replace `repeat(auto-fill, minmax(Xrem, 1fr))` with `repeat(var(--pronoun-count), minmax(min-content, 1fr))` in the paradigm table at mobile breakpoints (≤480px, ≤360px) and base rule
- `var(--pronoun-count)` (already set in JSX) guarantees exactly the right number of columns regardless of system font size — fixes the ELLOS pronoun wrapping to a new row on accessibility font sizes
- `minmax(min-content, 1fr)` ensures columns never shrink below their content width; the table scrolls horizontally instead of text visually overflowing into adjacent cells (the "hablamos habláis" merged-cell bug)
- Also includes compact left-panel styles scoped to `.verbos-onboarding--intro` and `min-height: 0` on `.vo-right` to prevent the double-scroll bug

## Test plan

- [ ] Open learning module intro page on 375px DevTools viewport (Chrome/Safari)
- [ ] Verify TERMINACIONES table shows all 6 pronoun columns (YO TÚ ÉL/ELLA NOS. VOS. ELL.) with each in its own cell
- [ ] Verify no cell content bleeds into an adjacent cell
- [ ] Test with iOS Large Text accessibility setting enabled — table should scroll horizontally if needed
- [ ] Test rioplatense dialect (5 pronouns) — table shows exactly 5 columns
- [ ] Verify left panel shows tense name fully without clipping (especially long names like "pretérito imperfecto de subjuntivo")
- [ ] Verify "continuar" button is reachable via scroll in the right panel

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_