### PR TITLE
fix(mobile): paradigm table rows must use min-width:max-content to enable horizontal scroll

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -843,7 +843,10 @@
 
   .ni-paradigm-table { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr)); }
+  .ni-paradigm-row {
+    min-width: max-content;
+    grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr));
+  }
   .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
   .ni-paradigm-lemma { font-size: 0.62rem; padding: 0.5rem 0.35rem; }
   .ni-paradigm-cell { font-size: 0.72rem; padding: 0.5rem 0.15rem; }
@@ -853,7 +856,10 @@
 
 @media (max-width: 360px) {
   .ni-paradigm-header,
-  .ni-paradigm-row { grid-template-columns: 3rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr)); }
+  .ni-paradigm-row {
+    min-width: max-content;
+    grid-template-columns: 3rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr));
+  }
   .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }
   .ni-paradigm-cell { font-size: 0.68rem; padding: 0.4rem 0.1rem; }
 }


### PR DESCRIPTION
## El problema real (por qué los fixes anteriores no alcanzaban)

Los rows del paradigm table son elementos `block`. Su `border-box` siempre es 100% del ancho de la tabla padre, sin importar cuánto desborde el contenido del grid interno.

`overflow-x: auto` en la tabla detecta overflow comparando el `border-box` de sus hijos con el propio padding-box. Como los rows siempre tienen `border-box = 100%` del contenedor, la tabla **nunca ve overflow** y nunca muestra scrollbar. El texto del grid desborda con `overflow: visible`, pisando celdas adyacentes.

## Fix

`min-width: max-content` hace que el `border-box` del row se expanda al tamaño real del contenido cuando el grid necesita más espacio. La tabla entonces **sí detecta** ese overflow y muestra scrollbar horizontal.

- Font size estándar (16px): max-content ≈ 292px < 335px disponibles → no hace falta scroll, columnas distribuyen espacio normalmente
- iOS Large Text (20px): max-content ≈ 365px > 335px → tabla scrollea ✓

## Test plan

- [ ] iPhone 375px, font size estándar: tabla muestra 6 columnas, ninguna celda pisa a la siguiente
- [ ] iPhone con "Texto más grande" en Accesibilidad activado: tabla scrollea horizontalmente, sin contenido que se pise
- [ ] Dialecto rioplatense (5 pronombres): tabla muestra exactamente 5 columnas

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_