### PR TITLE
fix(mobile): hide paradigm stems at ≤680px, not ≤480px

### DIFF
--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -850,8 +850,6 @@
   .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
   .ni-paradigm-lemma { font-size: 0.62rem; padding: 0.5rem 0.35rem; }
   .ni-paradigm-cell { font-size: 0.72rem; padding: 0.5rem 0.15rem; }
-  /* Hide repeated stem — lemma column already shows the verb; only colored ending matters */
-  .ni-form-stem { display: none; }
 }
 
 @media (max-width: 360px) {
@@ -868,6 +866,9 @@
 /* Scoped with .verbos-onboarding--intro so other learning steps keep min-height: 220px */
 
 @media (max-width: 680px) {
+  /* Hide stem on all single-column layouts — lemma column already shows the verb */
+  .ni-form-stem { display: none; }
+
   .verbos-onboarding--intro .vo-left {
     min-height: unset;
     padding: 16px 16px 12px 16px;


### PR DESCRIPTION
## Causa raíz

El screenshot confirma que las cells mostraban "hablo", "hablas", "hablamos" (stems visibles en gris), haciendo que la columna ELL. se cortara.

`.ni-form-stem { display: none }` existía **sólo en `@media (max-width: 480px)`**. Dispositivos con viewport entre 481–680px (layout de columna única activo pero stem-hiding inactivo) veían los stems, lo que hacía overflow la tabla.

## Fix — 2 líneas

Mover `.ni-form-stem { display: none }` del bloque `≤480px` al bloque `≤680px`, que coincide exactamente con el breakpoint del layout de columna única (`OnboardingFlow.css`).

| Viewport | Layout | Stems antes | Stems ahora |
|---|---|---|---|
| ≤480px | columna única | ocultos | ocultos |
| **481–680px** | **columna única** | **visibles — BUG** | **ocultos — fix** |
| >680px | dos columnas | visibles | visibles |

Con stems ocultos, las cells muestran sólo el ending ("-amos", "-áis"…) que caben en 46px por columna sin overflow.

https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo

---
_Generated by [Claude Code](https://claude.ai/code/session_017pvEyTWv4DBXQsLGzXvkCo)_