### PR TITLE
fix(learning): white text on orange highlight boxes in intro screens

### DIFF
--- a/src/components/learning/IrregularRootDrill.css
+++ b/src/components/learning/IrregularRootDrill.css
@@ -17,8 +17,8 @@
 .ird-hint-block .root-line { display:flex; justify-content:space-between; align-items:center; gap:16px; }
 .ird-hint-block .hint-label { color:#2a2823; }
 .ird-hint-block .hint-value { color:#f4f1ea; font-weight:700; }
-.ird-hint-block .root-highlight { color:#0c0c0c; background:#ff4d1c; font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
-.ird-hint-block .nonfinite-highlight { color:#0c0c0c; background:#ff4d1c; font-weight:700; padding:2px 8px; }
+.ird-hint-block .root-highlight { color:#ffffff; background:#ff4d1c; font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
+.ird-hint-block .nonfinite-highlight { color:#ffffff; background:#ff4d1c; font-weight:700; padding:2px 8px; }
 .ird-hint-block .hint-note { color:#2a2823; font-size:10px; text-transform:none; font-style:italic; margin:0; }
 .ird-hint-block .hint-note.alternate { color:#6e6a60; }
 

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -116,7 +116,7 @@
 }
 
 .story-sentence .highlight {
-  color: #0c0c0c;
+  color: #ffffff;
   background: #ff4d1c;
   font-weight: 700;
   padding: 0.1em 0.35em;
@@ -194,14 +194,12 @@
   text-underline-offset: 2px;
 }
 
-/* Overrides inside orange backgrounds */
+/* Overrides inside orange backgrounds — keep white for underline consistency */
 .story-sentence .highlight .irreg-frag {
-  color: #ffffff !important;
   text-decoration-color: #ffffff;
 }
 
 .yo-form-highlight .irreg-frag {
-  color: #ffffff !important;
   text-decoration-color: #ffffff;
 }
 
@@ -308,7 +306,7 @@
 .future-root-highlight {
   font-size: 1.3rem;
   font-weight: 800;
-  color: #0c0c0c;
+  color: #ffffff;
   background: #ff4d1c;
   padding: 0.15rem 0.5rem;
   letter-spacing: 0.06em;
@@ -385,9 +383,9 @@
 
 .nonfinite-item .arrow { color: #6e6a60; font-weight: 700; }
 
-.nonfinite-highlight {
+.narrative-introduction .nonfinite-highlight {
   font-weight: 800;
-  color: #0c0c0c;
+  color: #ffffff;
   background: #ff4d1c;
   padding: 0.15rem 0.45rem;
   letter-spacing: 0.05em;
@@ -408,7 +406,7 @@
 .group-label-large { color: #f4f1ea; opacity: 0.45; font-weight: 800; }
 
 .stem-vowel-highlight-large {
-  color: #0c0c0c;
+  color: #ffffff;
   background: #ff4d1c;
   font-weight: 800;
   font-size: 1.05em;
@@ -524,7 +522,7 @@
 .irregular-yo-verb-complete .yo-form-highlight {
   font-size: 1.3rem;
   font-weight: 800;
-  color: #0c0c0c;
+  color: #ffffff;
   background: #ff4d1c;
   padding: 0.4rem 0.85rem;
   font-family: 'JetBrains Mono', monospace;


### PR DESCRIPTION
Orange-background highlight boxes (.nonfinite-highlight, .future-root-highlight, .stem-vowel-highlight-large, .yo-form-highlight, .story-sentence .highlight) used color:#0c0c0c, but a CSS cascade collision made text invisible.

NarrativeIntroduction.css and IrregularRootDrill.css both defined .nonfinite-highlight as an unscoped rule. Since IrregularRootDrill.css is imported second in LearnTenseFlow.jsx, its color:var(--accent-orange) silently overrode the text color, producing orange-on-orange → invisible.

Fixes:
- Scope .nonfinite-highlight with .narrative-introduction to prevent collision
- Change all text-on-orange-background from #0c0c0c to #ffffff across both files
- Affects all intro screens: gerundios, participios, futuros, pretéritos, yo-irregulares