### PR TITLE
fix: mobile layout and contrast issues in learning module

### DIFF
--- a/src/components/learning/LearningDrill.css
+++ b/src/components/learning/LearningDrill.css
@@ -565,7 +565,8 @@
   .ld-main {
     padding: 12px;
     gap: 12px;
-    justify-content: center;
+    justify-content: flex-start;
+    overflow-y: auto;
   }
 
   .ld-verb-focal {

--- a/src/components/learning/LearningStepView.jsx
+++ b/src/components/learning/LearningStepView.jsx
@@ -131,7 +131,7 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
                 onClick={() => onSelect(opt)}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(opt) }}
               >
-                <div className="vo-option-num" style={{ color: active || selected ? ACCENT : INK3 }}>
+                <div className="vo-option-num" style={{ color: active || selected ? ACCENT : INK2 }}>
                   <span
                     className="vo-option-num-box"
                     style={{
@@ -156,7 +156,7 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
                   {opt.label}
                 </div>
 
-                <div className="vo-option-tag" style={{ color: active || selected ? ACCENT : INK3 }}>
+                <div className="vo-option-tag" style={{ color: active || selected ? ACCENT : INK2 }}>
                   {selected && !active ? '← confirmar' : opt.tag}
                 </div>
 

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -22,7 +22,7 @@
   font-size: 10px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #2a2823;
+  color: #6e6a60;
   margin-bottom: 20px;
 }
 
@@ -849,11 +849,11 @@
   .narrative-introduction .vo-right {
     min-height: 0;
     padding: 14px 20px 12px;
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .narrative-introduction .ni-right-panel {
-    overflow: hidden;
+    overflow-y: auto;
   }
 
   .narrative-introduction .ni-content-inner {

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -88,7 +88,7 @@
   font-size: 9.5px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #2a2823;
+  color: #6e6a60;
   z-index: 50;
 }
 
@@ -281,7 +281,7 @@
 }
 
 .vo-meta-item { display: flex; flex-direction: column; gap: 4px; }
-.vo-meta-key { color: #2a2823; }
+.vo-meta-key { color: #6e6a60; }
 .vo-meta-val { color: #f4f1ea; }
 .vo-meta-ex { font-style: italic; text-transform: none; letter-spacing: 0.04em; }
 
@@ -479,7 +479,7 @@
 @media (max-width: 680px) {
   .vo-step {
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
@@ -489,7 +489,7 @@
     border-right: none;
     border-bottom: 1px solid #1f1d18;
     padding: 28px 20px 24px 20px;
-    min-height: 220px;
+    min-height: 0;
   }
 
   .vo-watermark { font-size: clamp(80px, 28vw, 160px); }
@@ -497,9 +497,8 @@
   .vo-right {
     padding: 20px 20px 20px 20px;
     justify-content: flex-start;
-    overflow-y: auto;
+    overflow-y: visible;
     min-height: 0;
-    -webkit-overflow-scrolling: touch;
   }
 
   .vo-options-label { top: 8px; left: 20px; }


### PR DESCRIPTION
## Summary

- **Scroll desbloqueado en pasos de selección**: El grid mobile de `.vo-step` usaba `auto 1fr` haciendo que las opciones quedaran en un panel de altura fija con scrollbar oculto. Cambiado a `auto auto` para que ambos paneles tengan altura natural y el padre (`.vo-step`) sea el scroll container.
- **Botón "continuar" accesible en NarrativeIntroduction**: El CSS de 680px tenía `overflow: hidden` en `.vo-right` y `.ni-right-panel`, bloqueando completamente el scroll y dejando el botón inaccesible. Cambiado a `overflow-y: auto`.
- **Contraste de colores corregido**: Textos usando `#2a2823` (~1.3:1 de contraste sobre fondo negro) en footer, labels "TAG/TIPO/EJEMPLO", headers de sección en NarrativeIntro, y números/tags de opciones inactivas en LearningStepView — todos cambiados a `#6e6a60`.
- **Drill card en pantallas pequeñas**: `.ld-main` en mobile ahora tiene `overflow-y: auto` y `justify-content: flex-start` para evitar que el contenido quede cortado en landscape o teléfonos muy pequeños.

## Test plan

- [ ] Abrir módulo de aprendizaje en mobile (≤680px) y seleccionar "gerundios irregulares" — todas las opciones visibles, scroll funciona
- [ ] Avanzar a NarrativeIntroduction — contenido de historia y formas deconstruidas visibles, botón "continuar →" alcanzable con scroll
- [ ] Verificar que el texto del footer, labels "TAG/TIPO/EJEMPLO" y números de opción inactivos son legibles
- [ ] Verificar que el layout desktop no tiene regresiones (los cambios de layout son todos dentro de `@media (max-width: 680px)`)
- [ ] Práctica de drill: tarjeta visible sin recortes en pantallas pequeñas o landscape

https://claude.ai/code/session_018H7GBy8GXgsGemjqGvc9W5

---
_Generated by [Claude Code](https://claude.ai/code/session_018H7GBy8GXgsGemjqGvc9W5)_