### PR TITLE
[codex] Simplify topic tense menus

### DIFF
--- a/src/components/learning/TenseSelectionStep.jsx
+++ b/src/components/learning/TenseSelectionStep.jsx
@@ -1,12 +1,45 @@
 import React, { useEffect, useState, useMemo } from 'react'
 import LearningStepView from './LearningStepView.jsx'
-import { MOOD_LABELS, formatMoodTense, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
+import { getTensesForMood, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
 import { getVerbForms } from '../../lib/core/verbDataService.js'
 
 const REFERENCE_LEMMAS = ['hablar', 'comer', 'vivir']
+const SUBMENU_MOODS = {
+  subjunctive: ['subjunctive', 'subjuntivo'],
+  imperative: ['imperative', 'imperativo'],
+}
+const ROOT_DIRECT_MOODS = [
+  { aliases: ['indicative', 'indicativo'], tag: 'IND' },
+  { aliases: ['conditional', 'condicional'], tag: 'COND' },
+  { aliases: ['nonfinite'], tag: 'NF' },
+]
+
+function findAvailableMoodKey(availableTenses, moodAliases) {
+  return moodAliases.find(mood => Array.isArray(availableTenses?.[mood]) && availableTenses[mood].length > 0)
+}
+
+function orderTensesForMood(mood, tenses) {
+  const canonicalMood = mood === 'indicativo'
+    ? 'indicative'
+    : mood === 'subjuntivo'
+      ? 'subjunctive'
+      : mood === 'imperativo'
+        ? 'imperative'
+        : mood
+  const order = getTensesForMood(canonicalMood)
+  return [...(tenses || [])].sort((a, b) => {
+    const ai = order.indexOf(a)
+    const bi = order.indexOf(b)
+    if (ai === -1 && bi === -1) return a.localeCompare(b)
+    if (ai === -1) return 1
+    if (bi === -1) return -1
+    return ai - bi
+  })
+}
 
 function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = false, region }) {
   const [referenceForms, setReferenceForms] = useState(new Map())
+  const [selectedMenu, setSelectedMenu] = useState(null)
 
   useEffect(() => {
     async function loadReferenceForms() {
@@ -87,36 +120,97 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
     return parts.join(', ')
   }
 
+  useEffect(() => {
+    setSelectedMenu(null)
+  }, [availableTenses])
+
   const options = useMemo(() => {
     if (!availableTenses || Object.keys(availableTenses).length === 0) return []
-    return Object.entries(availableTenses).flatMap(([mood, tenses]) =>
-      tenses.map(tense => ({
+
+    if (selectedMenu) {
+      const mood = findAvailableMoodKey(availableTenses, SUBMENU_MOODS[selectedMenu])
+      const tenses = selectedMenu === 'imperative'
+        ? (availableTenses[mood] || []).filter(tense => tense === 'impAff' || tense === 'impNeg')
+        : (availableTenses[mood] || [])
+
+      return orderTensesForMood(mood, tenses).map(tense => ({
         id: `${mood}__${tense}`,
-        label: formatMoodTense(mood, tense),
-        tag: (getMoodLabel ? getMoodLabel(mood) : MOOD_LABELS[mood] || mood).toUpperCase().slice(0, 4),
-        gloss: MOOD_LABELS[mood] || mood,
+        label: selectedMenu === 'imperative'
+          ? `Imperativo ${getTenseLabel(tense).toLowerCase()}`
+          : getTenseLabel(tense),
+        tag: selectedMenu === 'imperative' ? 'IMP' : 'SUB',
+        gloss: getMoodLabel(mood),
         ex: getPersonConjugationExample(mood, tense),
         onSelect: () => onSelect(mood, tense),
       }))
-    )
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [availableTenses, useVoseo, referenceForms])
+    }
+
+    const subjunctiveMood = findAvailableMoodKey(availableTenses, SUBMENU_MOODS.subjunctive)
+    const imperativeMood = findAvailableMoodKey(availableTenses, SUBMENU_MOODS.imperative)
+    const rootOptions = []
+
+    ROOT_DIRECT_MOODS.forEach(({ aliases, tag }) => {
+      const mood = findAvailableMoodKey(availableTenses, aliases)
+      if (!mood) return
+      rootOptions.push(...orderTensesForMood(mood, availableTenses[mood]).map(tense => ({
+        id: `${mood}__${tense}`,
+        label: getTenseLabel(tense),
+        tag,
+        gloss: getMoodLabel(mood),
+        ex: getPersonConjugationExample(mood, tense),
+        onSelect: () => onSelect(mood, tense),
+      })))
+    })
+
+    if (subjunctiveMood) {
+      rootOptions.push({
+        id: 'subjunctive-menu',
+        label: 'subjuntivos',
+        tag: 'SUB',
+        gloss: 'elegir tiempo',
+        ex: 'presente · imperfecto',
+        onSelect: () => setSelectedMenu('subjunctive'),
+      })
+    }
+
+    if (imperativeMood) {
+      rootOptions.push({
+        id: 'imperative-menu',
+        label: 'imperativo',
+        tag: 'IMP',
+        gloss: 'afirmativo o negativo',
+        ex: 'habla · no hables',
+        onSelect: () => setSelectedMenu('imperative'),
+      })
+    }
+
+    return rootOptions
+  }, [availableTenses, useVoseo, referenceForms, selectedMenu])
 
   if (!availableTenses || Object.keys(availableTenses).length === 0) return null
 
   const stepConfig = {
     n: '01',
-    kicker: 'TIEMPO VERBAL',
+    kicker: selectedMenu === 'subjunctive'
+      ? 'SUBJUNTIVO'
+      : selectedMenu === 'imperative'
+        ? 'IMPERATIVO'
+        : 'TEMA',
     prompt: 'Elegís...',
-    aux: 'Un tiempo por vez. Después definís el tipo de verbos.',
+    aux: selectedMenu
+      ? 'Elegí un tiempo para seguir con el tipo de verbos.'
+      : 'Indicativo directo. Subjuntivo e imperativo abren su propio menú.',
     options,
   }
 
   return (
     <LearningStepView
       stepConfig={stepConfig}
-      onBack={onHome}
-      breadcrumb={[{ label: 'FLUJO', value: 'aprender' }]}
+      onBack={selectedMenu ? () => setSelectedMenu(null) : onHome}
+      breadcrumb={[
+        { label: 'FLUJO', value: 'aprender' },
+        ...(selectedMenu ? [{ label: 'TEMA', value: selectedMenu === 'subjunctive' ? 'subjuntivos' : 'imperativo' }] : []),
+      ]}
       stepNum={1}
       totalSteps={3}
     />

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -32,6 +32,44 @@ const VERB_TYPE_OPTS = [
   { id: 'irregular', label: 'irregulares', tag: 'TENSIÓN', gloss: 'casos duros',     ex: 'ser · estar · tener · ir' },
 ]
 
+const THEME_ROOT_MOOD_OPTS = new Set(['subjunctive', 'imperative'])
+
+function buildThemeTopicOptions({ selectMood, selectTense }) {
+  const buildDirectTenseOptions = (mood, tag) => getTensesForMood(mood).map(tense => ({
+    id: `${mood}-${tense}`,
+    label: getTenseLabel(tense).toLowerCase(),
+    tag,
+    gloss: getMoodLabel(mood).toLowerCase(),
+    ex: '',
+    onSelect: () => {
+      selectMood(mood, { navigate: false })
+      selectTense(tense)
+    },
+  }))
+
+  return [
+    ...buildDirectTenseOptions('indicative', 'IND'),
+    ...buildDirectTenseOptions('conditional', 'COND'),
+    ...buildDirectTenseOptions('nonfinite', 'NF'),
+    {
+      id: 'subjunctive',
+      label: 'subjuntivos',
+      tag: 'SUB',
+      gloss: 'elegir tiempo',
+      ex: 'presente · imperfecto',
+      onSelect: () => selectMood('subjunctive'),
+    },
+    {
+      id: 'imperative',
+      label: 'imperativo',
+      tag: 'IMP',
+      gloss: 'afirmativo o negativo',
+      ex: 'habla · no hables',
+      onSelect: () => selectMood('imperative'),
+    },
+  ]
+}
+
 const FALLBACK_FAMILIES = [
   { id: 'G_VERBS',   name: 'Irregulares en YO',  description: 'tener, poner, salir, conocer, vencer' },
   { id: 'UIR_Y',     name: '-uir (inserción y)',  description: 'construir, huir' },
@@ -160,6 +198,14 @@ function buildStep(step, settings, handlers) {
           options: VERB_TYPE_OPTS.map(o => ({ ...o, onSelect: () => selectVerbType(o.id, onStartPractice) })),
         }
       }
+      if (settings.practiceMode === 'theme') {
+        return {
+          n: '05', kicker: 'TEMA',
+          prompt: 'Trabajás...',
+          aux: 'Indicativo directo. Subjuntivo e imperativo abren su propio menú.',
+          options: buildThemeTopicOptions({ selectMood, selectTense }),
+        }
+      }
       const availMoods = settings.level && settings.practiceMode === 'specific'
         ? getAvailableMoodsForLevel(settings.level).map(id => MOOD_OPTS.find(m => m.id === id)).filter(Boolean)
         : MOOD_OPTS
@@ -179,14 +225,18 @@ function buildStep(step, settings, handlers) {
         }
       }
       if (!settings.specificMood) return null
+      if (settings.practiceMode === 'theme' && !THEME_ROOT_MOOD_OPTS.has(settings.specificMood)) return null
       const tenses = settings.level
         ? getAvailableTensesForLevelAndMood(settings.level, settings.specificMood)
         : getTensesForMood(settings.specificMood)
+      const visibleTenses = settings.practiceMode === 'theme' && settings.specificMood === 'imperative'
+        ? tenses.filter(tense => tense === 'impAff' || tense === 'impNeg')
+        : tenses
       const moodTag = getMoodLabel(settings.specificMood).toUpperCase().slice(0, 3)
       return {
         n: '06', kicker: 'TIEMPO',
         prompt: 'Atacás...', aux: 'Recorte exacto del drill.',
-        options: tenses.map(t => ({
+        options: visibleTenses.map(t => ({
           id: t,
           label: getTenseLabel(t),
           tag: moodTag,

--- a/src/hooks/useOnboardingFlow.js
+++ b/src/hooks/useOnboardingFlow.js
@@ -559,13 +559,17 @@ export function useOnboardingFlow() {
     }
   }, [setOnboardingStep, settings])
 
-  const selectMood = useCallback((mood) => {
+  const selectMood = useCallback((mood, options = {}) => {
     if (import.meta.env.DEV) {
       console.log('ACTION: selectMood', mood);
     }
     closeTopPanelsAndFeatures()
     // For theme-based practice (cameFromTema=true), keep the flag set
     settings.set({ specificMood: mood })
+
+    if (options.navigate === false) {
+      return
+    }
     
     const currentSettings = useSettings.getState()
     if (currentSettings.practiceMode === 'theme') {


### PR DESCRIPTION
## Summary

- Simplifies topic practice onboarding so indicative tenses are selected directly from the first topic menu.
- Adds nested submenu choices only for Subjuntivos and Imperativo.
- Mirrors the same topic menu structure in the learning module tense selection.

## Impact

The topic onboarding flow no longer asks users to choose a broad verbal mode before choosing common indicative tenses. Imperative practice is narrowed to affirmative and negative choices.

## Validation

- `npx eslint src/components/onboarding/OnboardingFlow.jsx src/components/learning/TenseSelectionStep.jsx src/hooks/useOnboardingFlow.js`
- `npx vitest run src/components/learning/TenseSelectionStep.test.jsx src/hooks/useOnboardingFlow.test.js`
- `npm run build`

Note: full `npm run lint` still fails on unrelated pre-existing files, including `.claude/worktrees` and generated/build artifacts.