### PR TITLE
fix(onboarding): update tests and aux text for simplified topic menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "spanish-conjugator",
       "version": "0.0.0",
       "dependencies": {
+        "@capacitor/app": "^8.1.0",
+        "@capacitor/core": "^8.3.4",
         "@google/generative-ai": "^0.24.1",
         "@vercel/analytics": "^1.5.0",
         "diff": "^8.0.2",
@@ -21,6 +23,8 @@
         "zustand": "^5.0.7"
       },
       "devDependencies": {
+        "@capacitor/android": "^8.3.4",
+        "@capacitor/cli": "^8.3.4",
         "@eslint/js": "^9.30.1",
         "@playwright/test": "^1.42.0",
         "@testing-library/jest-dom": "^6.6.4",
@@ -1655,6 +1659,105 @@
         "node": ">=18"
       }
     },
+    "node_modules/@capacitor/android": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.4.tgz",
+      "integrity": "sha512-7gJjrG3X32Am1QMLqgMztWTYMLMVNE+VZwhekNxhvYizH4mOV05vH+rC9B+f17bCkYZfyu/qXQX6hoY7kLeVZw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.4.tgz",
+      "integrity": "sha512-QEmyNdiDDVNYl0Mahm7YTVA/3t2tKcy7FWYDapeKGavS6HDNHZSjyTVwQpUXQbDZrrs/PS2Wau3Aii+LIFwm/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/cli-framework-output": "^2.2.8",
+        "@ionic/utils-subprocess": "^3.0.1",
+        "@ionic/utils-terminal": "^2.3.5",
+        "commander": "^12.1.0",
+        "debug": "^4.4.0",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^11.2.0",
+        "kleur": "^4.1.5",
+        "native-run": "^2.0.3",
+        "open": "^8.4.0",
+        "plist": "^3.1.0",
+        "prompts": "^2.4.2",
+        "rimraf": "^6.0.1",
+        "semver": "^7.6.3",
+        "tar": "^7.5.3",
+        "tslib": "^2.8.1",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "cap": "bin/capacitor",
+        "capacitor": "bin/capacitor"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@capacitor/cli/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.4.tgz",
+      "integrity": "sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -2486,6 +2589,192 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ionic/cli-framework-output": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
+      "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-array": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
+      "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-fs": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
+      "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^8.0.0",
+        "debug": "^4.0.0",
+        "fs-extra": "^9.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-object": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
+      "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
+      "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-object": "2.1.6",
+        "@ionic/utils-terminal": "2.3.5",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "tree-kill": "^1.2.2",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-process/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
+      "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-subprocess": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
+      "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-array": "2.1.6",
+        "@ionic/utils-fs": "3.1.7",
+        "@ionic/utils-process": "2.1.12",
+        "@ionic/utils-stream": "3.1.7",
+        "@ionic/utils-terminal": "2.3.5",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.0.0",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
+      "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/slice-ansi": "^4.0.0",
+        "debug": "^4.0.0",
+        "signal-exit": "^3.0.3",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "tslib": "^2.0.1",
+        "untildify": "^4.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ionic/utils-terminal/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -2554,6 +2843,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -4085,6 +4387,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4165,6 +4477,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4433,6 +4752,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -4626,6 +4955,16 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -4851,6 +5190,27 @@
       "dependencies": {
         "bare-path": "^3.0.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.3",
@@ -5119,6 +5479,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chrome-launcher": {
@@ -5692,6 +6062,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/elementtree": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
+      "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sax": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -5734,6 +6117,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/es-abstract": {
@@ -7099,6 +7492,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7916,6 +8326,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/legacy-javascript": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
@@ -8273,13 +8693,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mitt": {
@@ -8330,6 +8763,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/native-run": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
+      "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ionic/utils-fs": "^3.1.7",
+        "@ionic/utils-terminal": "^2.3.4",
+        "bplist-parser": "^0.3.2",
+        "debug": "^4.3.4",
+        "elementtree": "^0.1.7",
+        "ini": "^4.1.1",
+        "plist": "^3.1.0",
+        "split2": "^4.2.0",
+        "through2": "^4.0.2",
+        "tslib": "^2.6.2",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "native-run": "bin/native-run"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/native-run/node_modules/bplist-parser": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.x"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
       }
     },
     "node_modules/natural-compare": {
@@ -8782,6 +9254,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8943,6 +9430,30 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -9095,6 +9606,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/redent": {
@@ -9288,6 +9814,110 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/robots-parser": {
@@ -9575,6 +10205,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9804,6 +10441,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9906,6 +10568,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9944,6 +10616,16 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -10264,6 +10946,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -10289,6 +10988,16 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/temp-dir": {
@@ -10409,6 +11118,16 @@
       "integrity": "sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -10570,11 +11289,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -10842,6 +11570,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",
@@ -12015,6 +12750,40 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "android:sync": "npm run build && npx cap sync",
+    "android:run": "npx cap run android",
     "dev": "vite",
     "dev:all": "vite",
     "server:start": "node server/src/index.js",
@@ -46,6 +48,8 @@
     "audit:strict": "node ./scripts/auditAll.mjs --fail-on-findings"
   },
   "dependencies": {
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/core": "^8.3.4",
     "@google/generative-ai": "^0.24.1",
     "@vercel/analytics": "^1.5.0",
     "diff": "^8.0.2",
@@ -59,6 +63,8 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@capacitor/android": "^8.3.4",
+    "@capacitor/cli": "^8.3.4",
     "@eslint/js": "^9.30.1",
     "@playwright/test": "^1.42.0",
     "@testing-library/jest-dom": "^6.6.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,11 +3,47 @@ import AppRouter from './components/AppRouter.jsx'
 import GlobalErrorBoundary from './components/GlobalErrorBoundary.jsx'
 import GamificationNotifications from './components/gamification/GamificationNotifications.jsx'
 import { inject } from '@vercel/analytics'
+import { Capacitor } from '@capacitor/core'
 import './App.css'
 
 function App() {
   useEffect(() => {
     inject()
+
+    let backButtonListener = null
+
+    const setupBackButton = async () => {
+      if (Capacitor.isNativePlatform()) {
+        try {
+          const { App: CapApp } = await import('@capacitor/app')
+          const { default: router } = await import('./lib/routing/Router.js')
+
+          backButtonListener = await CapApp.addListener('backButton', () => {
+            const currentRoute = router.getCurrentRoute()
+            // Si estamos en la pantalla inicial de onboarding (paso 1 o 2), minimizamos la app.
+            // De lo contrario, volvemos atrás.
+            if (
+              currentRoute?.mode === 'onboarding' &&
+              (currentRoute?.step === 1 || currentRoute?.step === 2 || !currentRoute?.step)
+            ) {
+              CapApp.minimizeApp()
+            } else {
+              router.back()
+            }
+          })
+        } catch (error) {
+          console.error('Error setting up native back button listener:', error)
+        }
+      }
+    }
+
+    setupBackButton()
+
+    return () => {
+      if (backButtonListener && typeof backButtonListener.remove === 'function') {
+        backButtonListener.remove()
+      }
+    }
   }, [])
 
   return (

--- a/src/components/learning/TenseSelectionStep.jsx
+++ b/src/components/learning/TenseSelectionStep.jsx
@@ -128,6 +128,61 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
     if (!availableTenses || Object.keys(availableTenses).length === 0) return []
 
     if (selectedMenu) {
+      if (selectedMenu === 'condicional') {
+        const mood = findAvailableMoodKey(availableTenses, ['conditional', 'condicional'])
+        const tenses = availableTenses[mood] || []
+        return orderTensesForMood(mood, tenses).map(tense => {
+          let label = getTenseLabel(tense)
+          if (tense === 'cond') label = 'Condicional simple'
+          if (tense === 'condPerf') label = 'Condicional compuesto'
+          return {
+            id: `${mood}__${tense}`,
+            label,
+            tag: 'COND',
+            gloss: getMoodLabel(mood),
+            ex: getPersonConjugationExample(mood, tense),
+            onSelect: () => onSelect(mood, tense),
+          }
+        })
+      }
+
+      if (selectedMenu === 'futuro') {
+        const mood = findAvailableMoodKey(availableTenses, ['indicative', 'indicativo'])
+        const tenses = (availableTenses[mood] || []).filter(tense => tense === 'fut' || tense === 'futPerf')
+        return orderTensesForMood(mood, tenses).map(tense => {
+          let label = getTenseLabel(tense)
+          if (tense === 'fut') label = 'Futuro simple'
+          if (tense === 'futPerf') label = 'Futuro compuesto'
+          return {
+            id: `${mood}__${tense}`,
+            label,
+            tag: 'FUT',
+            gloss: getMoodLabel(mood),
+            ex: getPersonConjugationExample(mood, tense),
+            onSelect: () => onSelect(mood, tense),
+          }
+        })
+      }
+
+      if (selectedMenu === 'nonfinite') {
+        const mood = findAvailableMoodKey(availableTenses, ['nonfinite'])
+        const tenses = availableTenses[mood] || []
+        return orderTensesForMood(mood, tenses).map(tense => {
+          let label = getTenseLabel(tense)
+          if (tense === 'ger') label = 'Gerundio'
+          if (tense === 'part') label = 'Participio'
+          if (tense === 'nonfiniteMixed') label = 'Formas no finitas mixtas'
+          return {
+            id: `${mood}__${tense}`,
+            label,
+            tag: 'NF',
+            gloss: getMoodLabel(mood),
+            ex: getPersonConjugationExample(mood, tense),
+            onSelect: () => onSelect(mood, tense),
+          }
+        })
+      }
+
       const mood = findAvailableMoodKey(availableTenses, SUBMENU_MOODS[selectedMenu])
       const tenses = selectedMenu === 'imperative'
         ? (availableTenses[mood] || []).filter(tense => tense === 'impAff' || tense === 'impNeg')
@@ -149,18 +204,55 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
     const imperativeMood = findAvailableMoodKey(availableTenses, SUBMENU_MOODS.imperative)
     const rootOptions = []
 
-    ROOT_DIRECT_MOODS.forEach(({ aliases, tag }) => {
-      const mood = findAvailableMoodKey(availableTenses, aliases)
-      if (!mood) return
-      rootOptions.push(...orderTensesForMood(mood, availableTenses[mood]).map(tense => ({
-        id: `${mood}__${tense}`,
+    // Indicativo (except futuro)
+    const indMood = findAvailableMoodKey(availableTenses, ['indicative', 'indicativo'])
+    if (indMood) {
+      const nonFutTenses = (availableTenses[indMood] || []).filter(tense => tense !== 'fut' && tense !== 'futPerf')
+      rootOptions.push(...orderTensesForMood(indMood, nonFutTenses).map(tense => ({
+        id: `${indMood}__${tense}`,
         label: getTenseLabel(tense),
-        tag,
-        gloss: getMoodLabel(mood),
-        ex: getPersonConjugationExample(mood, tense),
-        onSelect: () => onSelect(mood, tense),
+        tag: 'IND',
+        gloss: getMoodLabel(indMood),
+        ex: getPersonConjugationExample(indMood, tense),
+        onSelect: () => onSelect(indMood, tense),
       })))
-    })
+    }
+
+    const hasFuturo = indMood && (availableTenses[indMood] || []).some(tense => tense === 'fut' || tense === 'futPerf')
+    if (hasFuturo) {
+      rootOptions.push({
+        id: 'futuro-menu',
+        label: 'Futuro',
+        tag: 'FUT',
+        gloss: 'elegir tiempo',
+        ex: 'simple · compuesto',
+        onSelect: () => setSelectedMenu('futuro'),
+      })
+    }
+
+    const condMood = findAvailableMoodKey(availableTenses, ['conditional', 'condicional'])
+    if (condMood && (availableTenses[condMood] || []).length > 0) {
+      rootOptions.push({
+        id: 'conditional-menu',
+        label: 'Condicional',
+        tag: 'COND',
+        gloss: 'elegir tiempo',
+        ex: 'simple · compuesto',
+        onSelect: () => setSelectedMenu('condicional'),
+      })
+    }
+
+    const nfMood = findAvailableMoodKey(availableTenses, ['nonfinite'])
+    if (nfMood && (availableTenses[nfMood] || []).length > 0) {
+      rootOptions.push({
+        id: 'nonfinite-menu',
+        label: 'Formas no finitas',
+        tag: 'NF',
+        gloss: 'elegir forma',
+        ex: 'gerundio · participio · mixto',
+        onSelect: () => setSelectedMenu('nonfinite'),
+      })
+    }
 
     if (subjunctiveMood) {
       rootOptions.push({
@@ -195,12 +287,27 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
       ? 'SUBJUNTIVO'
       : selectedMenu === 'imperative'
         ? 'IMPERATIVO'
-        : 'TEMA',
+        : selectedMenu === 'condicional'
+          ? 'CONDICIONAL'
+          : selectedMenu === 'futuro'
+            ? 'FUTURO'
+            : selectedMenu === 'nonfinite'
+              ? 'FORMAS NO FINITAS'
+              : 'TEMA',
     prompt: 'Elegís...',
     aux: selectedMenu
       ? 'Elegí un tiempo para seguir con el tipo de verbos.'
-      : 'Indicativo directo. Subjuntivo e imperativo abren su propio menú.',
+      : 'Indicativo directo. Futuro, condicional y no finitas abren submenú.',
     options,
+  }
+
+  const getSubmenuLabel = (menu) => {
+    if (menu === 'subjunctive') return 'subjuntivos'
+    if (menu === 'imperative') return 'imperativo'
+    if (menu === 'condicional') return 'condicional'
+    if (menu === 'futuro') return 'futuro'
+    if (menu === 'nonfinite') return 'formas no finitas'
+    return ''
   }
 
   return (
@@ -209,7 +316,7 @@ function TenseSelectionStep({ availableTenses, onSelect, onHome, useVoseo = fals
       onBack={selectedMenu ? () => setSelectedMenu(null) : onHome}
       breadcrumb={[
         { label: 'FLUJO', value: 'aprender' },
-        ...(selectedMenu ? [{ label: 'TEMA', value: selectedMenu === 'subjunctive' ? 'subjuntivos' : 'imperativo' }] : []),
+        ...(selectedMenu ? [{ label: 'TEMA', value: getSubmenuLabel(selectedMenu) }] : []),
       ]}
       stepNum={1}
       totalSteps={3}

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -27,30 +27,157 @@ const MOOD_OPTS = [
 ]
 
 const VERB_TYPE_OPTS = [
-  { id: 'all',       label: 'todos',       tag: 'AMPLIO',  gloss: 'sin filtro',      ex: 'reg · irreg' },
-  { id: 'regular',   label: 'regulares',   tag: 'SISTEMA', gloss: 'siguen la regla', ex: 'hablar · comer · vivir' },
-  { id: 'irregular', label: 'irregulares', tag: 'TENSIÓN', gloss: 'casos duros',     ex: 'ser · estar · tener · ir' },
+  { id: 'all',       label: 'todos',       tag: 'AMPLIO',  gloss: 'sin filtro',      ex: 'reg · irreg', ariaLabel: 'Seleccionar todos los verbos' },
+  { id: 'regular',   label: 'regulares',   tag: 'SISTEMA', gloss: 'siguen la regla', ex: 'hablar · comer · vivir', ariaLabel: 'Seleccionar solo verbos regulares' },
+  { id: 'irregular', label: 'irregulares', tag: 'TENSIÓN', gloss: 'casos duros',     ex: 'ser · estar · tener · ir', ariaLabel: 'Seleccionar solo verbos irregulares' },
 ]
 
 const THEME_ROOT_MOOD_OPTS = new Set(['subjunctive', 'imperative'])
 
-function buildThemeTopicOptions({ selectMood, selectTense }) {
-  const buildDirectTenseOptions = (mood, tag) => getTensesForMood(mood).map(tense => ({
-    id: `${mood}-${tense}`,
-    label: getTenseLabel(tense).toLowerCase(),
-    tag,
-    gloss: getMoodLabel(mood).toLowerCase(),
-    ex: '',
-    onSelect: () => {
-      selectMood(mood, { navigate: false })
-      selectTense(tense)
-    },
-  }))
+function buildThemeTopicOptions({ selectMood, selectTense, themeSubMenu, setThemeSubMenu }) {
+  if (themeSubMenu === 'condicional') {
+    return [
+      {
+        id: 'conditional-cond',
+        label: 'condicional simple',
+        tag: 'COND',
+        gloss: 'condicional',
+        ex: 'yo hablaría',
+        onSelect: () => {
+          selectMood('conditional', { navigate: false })
+          selectTense('cond')
+        }
+      },
+      {
+        id: 'conditional-condPerf',
+        label: 'condicional compuesto',
+        tag: 'COND',
+        gloss: 'condicional',
+        ex: 'yo habría hablado',
+        onSelect: () => {
+          selectMood('conditional', { navigate: false })
+          selectTense('condPerf')
+        }
+      }
+    ]
+  }
+
+  if (themeSubMenu === 'futuro') {
+    return [
+      {
+        id: 'indicative-fut',
+        label: 'futuro simple',
+        tag: 'FUT',
+        gloss: 'indicativo',
+        ex: 'yo hablaré',
+        onSelect: () => {
+          selectMood('indicative', { navigate: false })
+          selectTense('fut')
+        }
+      },
+      {
+        id: 'indicative-futPerf',
+        label: 'futuro compuesto',
+        tag: 'FUT',
+        gloss: 'indicativo',
+        ex: 'yo habré hablado',
+        onSelect: () => {
+          selectMood('indicative', { navigate: false })
+          selectTense('futPerf')
+        }
+      }
+    ]
+  }
+
+  if (themeSubMenu === 'nonfinite') {
+    return [
+      {
+        id: 'nonfinite-ger',
+        label: 'gerundio',
+        tag: 'NF',
+        gloss: 'no finita',
+        ex: 'hablando',
+        onSelect: () => {
+          selectMood('nonfinite', { navigate: false })
+          selectTense('ger')
+        }
+      },
+      {
+        id: 'nonfinite-part',
+        label: 'participio',
+        tag: 'NF',
+        gloss: 'no finita',
+        ex: 'hablado',
+        onSelect: () => {
+          selectMood('nonfinite', { navigate: false })
+          selectTense('part')
+        }
+      },
+      {
+        id: 'nonfinite-nonfiniteMixed',
+        label: 'formas no finitas mixtas',
+        tag: 'NF',
+        gloss: 'no finita',
+        ex: 'hablando / hablado',
+        onSelect: () => {
+          selectMood('nonfinite', { navigate: false })
+          selectTense('nonfiniteMixed')
+        }
+      }
+    ]
+  }
+
+  const buildDirectTenseOptions = (mood, tag) => getTensesForMood(mood)
+    .filter(tense => mood !== 'indicative' || (tense !== 'fut' && tense !== 'futPerf'))
+    .map(tense => {
+      // Get friendly examples
+      const getEx = (t) => {
+        if (t === 'pres') return 'yo hablo'
+        if (t === 'pretPerf') return 'he hablado'
+        if (t === 'pretIndef') return 'yo hablé'
+        if (t === 'impf') return 'yo hablaba'
+        if (t === 'plusc') return 'yo había hablado'
+        return ''
+      }
+      return {
+        id: `${mood}-${tense}`,
+        label: getTenseLabel(tense).toLowerCase(),
+        tag,
+        gloss: getMoodLabel(mood).toLowerCase(),
+        ex: getEx(tense),
+        onSelect: () => {
+          selectMood(mood, { navigate: false })
+          selectTense(tense)
+        },
+      }
+    })
 
   return [
     ...buildDirectTenseOptions('indicative', 'IND'),
-    ...buildDirectTenseOptions('conditional', 'COND'),
-    ...buildDirectTenseOptions('nonfinite', 'NF'),
+    {
+      id: 'futuro-menu',
+      label: 'futuro',
+      tag: 'FUT',
+      gloss: 'elegir tiempo',
+      ex: 'simple · compuesto',
+      onSelect: () => setThemeSubMenu('futuro')
+    },
+    {
+      id: 'conditional-menu',
+      label: 'condicional',
+      tag: 'COND',
+      gloss: 'elegir tiempo',
+      ex: 'simple · compuesto',
+      onSelect: () => setThemeSubMenu('condicional')
+    },
+    {
+      id: 'nonfinite-menu',
+      label: 'formas no finitas',
+      tag: 'NF',
+      gloss: 'elegir forma',
+      ex: 'gerundio · participio · mixto',
+      onSelect: () => setThemeSubMenu('nonfinite')
+    },
     {
       id: 'subjunctive',
       label: 'subjuntivos',
@@ -138,6 +265,7 @@ function buildStep(step, settings, handlers) {
     selectVerbType, selectFamily, goToLevelDetails, onStartPractice,
     onGoToProgress, onStartLearningNewTense, onStartLevelTest,
     getAvailableMoodsForLevel, getAvailableTensesForLevelAndMood,
+    themeSubMenu, setThemeSubMenu
   } = handlers
 
   switch (step) {
@@ -146,10 +274,10 @@ function buildStep(step, settings, handlers) {
         n: '01', kicker: 'VARIANTE',
         prompt: 'Hablás...', aux: 'Definí el sistema pronominal antes de empezar.',
         options: [
-          { id: 'rioplatense', label: 'vos',           tag: 'AR · UY', gloss: 'rioplatense', ex: 'vos tenés / vos hablás', onSelect: () => selectDialect('rioplatense') },
-          { id: 'la_general',  label: 'tú',            tag: 'LATAM',   gloss: 'estándar',    ex: 'tú tienes / tú hablas',  onSelect: () => selectDialect('la_general') },
-          { id: 'peninsular',  label: 'tú · vosotros', tag: 'ES',      gloss: 'peninsular',  ex: 'vosotros tenéis',        onSelect: () => selectDialect('peninsular') },
-          { id: 'both',        label: 'todos',          tag: 'MIX',     gloss: 'sin filtro',  ex: 'tú · vos · vosotros',   onSelect: () => selectDialect('both') },
+          { id: 'rioplatense', label: 'vos',           tag: 'AR · UY', gloss: 'rioplatense', ex: 'vos tenés / vos hablás', ariaLabel: 'Seleccionar dialecto rioplatense (vos)', onSelect: () => selectDialect('rioplatense') },
+          { id: 'la_general',  label: 'tú',            tag: 'LATAM',   gloss: 'estándar',    ex: 'tú tienes / tú hablas',  ariaLabel: 'Seleccionar dialecto latinoamericano general (tú)', onSelect: () => selectDialect('la_general') },
+          { id: 'peninsular',  label: 'tú · vosotros', tag: 'ES',      gloss: 'peninsular',  ex: 'vosotros tenéis',        ariaLabel: 'Seleccionar dialecto peninsular (tú y vosotros)', onSelect: () => selectDialect('peninsular') },
+          { id: 'both',        label: 'todos',          tag: 'MIX',     gloss: 'sin filtro',  ex: 'tú · vos · vosotros',   ariaLabel: 'Seleccionar todos los dialectos', onSelect: () => selectDialect('both') },
         ],
       }
 
@@ -170,13 +298,13 @@ function buildStep(step, settings, handlers) {
         n: '03', kicker: 'NIVEL',
         prompt: 'Tu nivel es...', aux: 'Elegí un tramo CEFR o dejá que el test te ubique.',
         options: [
-          { id: 'A1',   label: 'A1',           tag: 'PRINCIPIANTE', gloss: 'acceso',               ex: 'presente',               onSelect: () => selectLevel('A1') },
-          { id: 'A2',   label: 'A2',           tag: 'ELEMENTAL',    gloss: 'base',                  ex: 'pretéritos · futuro',    onSelect: () => selectLevel('A2') },
-          { id: 'B1',   label: 'B1',           tag: 'INTERMEDIO',   gloss: 'tracción',              ex: 'condicional · perfectos',onSelect: () => selectLevel('B1') },
-          { id: 'B2',   label: 'B2',           tag: 'INTERMEDIO+',  gloss: 'precisión',             ex: 'subjuntivo imperfecto',  onSelect: () => selectLevel('B2') },
-          { id: 'C1',   label: 'C1',           tag: 'AVANZADO',     gloss: 'matiz',                 ex: 'discurso fluido',        onSelect: () => selectLevel('C1') },
-          { id: 'C2',   label: 'C2',           tag: 'SUPERIOR',     gloss: 'dominio',               ex: 'nativo completo',        onSelect: () => selectLevel('C2') },
-          ...(onStartLevelTest ? [{ id: 'test', label: 'test de nivel', tag: 'AUTO', gloss: 'diagnóstico adaptativo', ex: '5 min · te ubica', onSelect: onStartLevelTest }] : []),
+          { id: 'A1',   label: 'A1',           tag: 'PRINCIPIANTE', gloss: 'acceso',               ex: 'presente',               ariaLabel: 'Seleccionar nivel A1', onSelect: () => selectLevel('A1') },
+          { id: 'A2',   label: 'A2',           tag: 'ELEMENTAL',    gloss: 'base',                  ex: 'pretéritos · futuro',    ariaLabel: 'Seleccionar nivel A2', onSelect: () => selectLevel('A2') },
+          { id: 'B1',   label: 'B1',           tag: 'INTERMEDIO',   gloss: 'tracción',              ex: 'condicional · perfectos',ariaLabel: 'Seleccionar nivel B1', onSelect: () => selectLevel('B1') },
+          { id: 'B2',   label: 'B2',           tag: 'INTERMEDIO+',  gloss: 'precisión',             ex: 'subjuntivo imperfecto',  ariaLabel: 'Seleccionar nivel B2', onSelect: () => selectLevel('B2') },
+          { id: 'C1',   label: 'C1',           tag: 'AVANZADO',     gloss: 'matiz',                 ex: 'discurso fluido',        ariaLabel: 'Seleccionar nivel C1', onSelect: () => selectLevel('C1') },
+          { id: 'C2',   label: 'C2',           tag: 'SUPERIOR',     gloss: 'dominio',               ex: 'nativo completo',        ariaLabel: 'Seleccionar nivel C2', onSelect: () => selectLevel('C2') },
+          ...(onStartLevelTest ? [{ id: 'test', label: 'test de nivel', tag: 'AUTO', gloss: 'diagnóstico adaptativo', ex: '5 min · te ubica', ariaLabel: 'Test de nivel adaptativo', onSelect: onStartLevelTest }] : []),
         ],
       }
 
@@ -199,11 +327,19 @@ function buildStep(step, settings, handlers) {
         }
       }
       if (settings.practiceMode === 'theme') {
+        const kickerMap = {
+          futuro: 'FUTURO',
+          condicional: 'CONDICIONAL',
+          nonfinite: 'FORMAS NO FINITAS'
+        }
         return {
-          n: '05', kicker: 'TEMA',
+          n: '05',
+          kicker: themeSubMenu ? (kickerMap[themeSubMenu] || themeSubMenu.toUpperCase()) : 'TEMA',
           prompt: 'Trabajás...',
-          aux: 'Indicativo directo. Subjuntivo e imperativo abren su propio menú.',
-          options: buildThemeTopicOptions({ selectMood, selectTense }),
+          aux: themeSubMenu
+            ? 'Elegí un tiempo para seguir con el tipo de verbos.'
+            : 'Indicativo directo. Futuro, condicional y no finitas abren submenú.',
+          options: buildThemeTopicOptions({ selectMood, selectTense, themeSubMenu, setThemeSubMenu }),
         }
       }
       const availMoods = settings.level && settings.practiceMode === 'specific'
@@ -386,9 +522,18 @@ function StepView({ stepConfig, animKey, onSelect }) {
               <div
                 key={opt.id ?? i}
                 className="vo-option"
+                role="button"
+                tabIndex={0}
+                aria-label={opt.ariaLabel || opt.label}
                 style={{ paddingLeft: active ? 76 : 52, paddingTop: 14, paddingBottom: 14 }}
                 onMouseEnter={() => setFocusIdx(i)}
                 onClick={() => onSelect(opt)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    onSelect(opt)
+                  }
+                }}
               >
                 {/* Number box */}
                 <div className="vo-option-num" style={{ color: active ? ACCENT : INK3 }}>
@@ -561,6 +706,7 @@ function OnboardingFlow({
   const [lastPlacementResult, setLastPlacementResult]   = useState(null)
   const [reportSaved, setReportSaved]                   = useState(false)
   const [animKey, setAnimKey]                           = useState(0)
+  const [themeSubMenu, setThemeSubMenu]                 = useState(null)
 
   // Bump animKey on step change to trigger animations
   const prevStep = useRef(onboardingStep)
@@ -568,6 +714,7 @@ function OnboardingFlow({
     if (onboardingStep !== prevStep.current) {
       prevStep.current = onboardingStep
       setAnimKey(k => k + 1)
+      setThemeSubMenu(null)
     }
   }, [onboardingStep])
 
@@ -596,8 +743,13 @@ function OnboardingFlow({
   }, [lastPlacementResult, settings])
 
   const handleBack = useCallback(() => {
-    try { window.history.back() } catch { /* ignore */ }
-  }, [])
+    if (onboardingStep === 5 && themeSubMenu) {
+      setThemeSubMenu(null)
+      setAnimKey(k => k + 1)
+    } else {
+      try { window.history.back() } catch { /* ignore */ }
+    }
+  }, [onboardingStep, themeSubMenu])
 
   const handleLogoClick = useCallback(() => {
     handleHome(setCurrentMode)
@@ -632,11 +784,13 @@ function OnboardingFlow({
     onStartLevelTest: handleStartLevelTest,
     getAvailableMoodsForLevel,
     getAvailableTensesForLevelAndMood,
+    themeSubMenu,
+    setThemeSubMenu,
   }), [
     selectDialect, selectLevel, selectPracticeMode, selectMood, selectTense,
     selectVerbType, selectFamily, goToLevelDetails, onStartPractice, onGoToProgress,
     onStartLearningNewTense, handleStartLevelTest, getAvailableMoodsForLevel,
-    getAvailableTensesForLevelAndMood,
+    getAvailableTensesForLevelAndMood, themeSubMenu, setThemeSubMenu,
   ])
 
   const stepConfig = useMemo(

--- a/src/components/onboarding/navigationBack.test.jsx
+++ b/src/components/onboarding/navigationBack.test.jsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, /* expect, */ it } from 'vitest'
+import { afterEach, beforeEach, describe, it } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import React from 'react'
 import AppRouter from '../../components/AppRouter.jsx'
@@ -48,16 +48,16 @@ const chooseDialectVos = async (user) => {
 }
 
 const goToPorTema = async (user) => {
-  const porTema = await screen.findByText(/TEMAS/i)
+  const porTema = await screen.findByText(/practicar por tema/i)
   await act(async () => {
     await user.click(porTema)
   })
 }
 
-const chooseMood = async (user, moodLabel) => {
-  const moodBtn = await screen.findByRole('button', { name: new RegExp(moodLabel, 'i') })
+const goToPorNivel = async (user) => {
+  const porNivel = await screen.findByRole('button', { name: /practicar por nivel/i })
   await act(async () => {
-    await user.click(moodBtn)
+    await user.click(porNivel)
   })
 }
 
@@ -72,7 +72,7 @@ describe('Navegación y Back (flujo actual)', () => {
   // Simplified mock user for testing without clipboard issues
   const user = {
     click: async (element) => {
-      act(() => {
+      await act(async () => {
         element.click()
       })
     }
@@ -86,46 +86,53 @@ describe('Navegación y Back (flujo actual)', () => {
     await resetSettings()
   })
 
-  it('UI Back desde tiempos (paso 6) vuelve a modos (paso 5) en Por tema', async () => {
+  it('UI Back desde subjuntivos (paso 6) vuelve a temas (paso 5) en Por tema', async () => {
     render(<AppRouter />)
 
     await chooseDialectVos(user)
     await goToPorTema(user)
 
-    // Paso 5: elegir modo
-    await chooseMood(user, 'Indicativo')
+    // Paso 5: elegir subjuntivos → va a paso 6 (selección de tiempos subjuntivos)
+    const subjBtn = await screen.findByRole('button', { name: /subjuntivos/i })
+    await act(async () => {
+      await user.click(subjBtn)
+    })
 
-    // Paso 6: ver tiempos (ej. Presente)
-    await screen.findByRole('button', { name: /Presente/i })
+    // Paso 6: ver tiempos del subjuntivo (ej. Imperfecto)
+    await screen.findByRole('button', { name: /Imperfecto/i })
 
-    // Back → vuelve a modos (debe aparecer "Indicativo")
+    // Back → vuelve a paso 5 (debe aparecer "subjuntivos")
     await clickBack(user)
-    await screen.findByRole('button', { name: /Indicativo/i })
+    await screen.findByRole('button', { name: /subjuntivos/i })
   })
 
-  it('Hardware Back desde tiempos (paso 6) vuelve a modos (paso 5)', async () => {
+  it('Hardware Back desde subjuntivos (paso 6) vuelve a temas (paso 5)', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
     await goToPorTema(user)
-    await chooseMood(user, 'Indicativo')
-    await screen.findByRole('button', { name: /Presente/i })
+
+    // Paso 5: elegir subjuntivos → paso 6
+    const subjBtn = await screen.findByRole('button', { name: /subjuntivos/i })
+    await act(async () => {
+      await user.click(subjBtn)
+    })
+    await screen.findByRole('button', { name: /Imperfecto/i })
 
     // Simular hardware back
     await act(async () => {
       window.history.back()
     })
 
-    await screen.findByRole('button', { name: /Indicativo/i })
+    await screen.findByRole('button', { name: /subjuntivos/i })
   })
 
-  it('UI Back desde tipo de verbo (paso 7) vuelve a tiempos (paso 6)', async () => {
+  it('UI Back desde tipo de verbo (paso 7) vuelve a temas (paso 5)', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
     await goToPorTema(user)
-    await chooseMood(user, 'Indicativo')
 
-    // Paso 6: elegir un tiempo para ir al paso 7
-    const presente = await screen.findByRole('button', { name: /Presente/i })
+    // Paso 5: elegir un tiempo directo de indicativo (ej. presente) → va a paso 7
+    const presente = await screen.findByRole('button', { name: /^presente$/i })
     await act(async () => {
       await user.click(presente)
     })
@@ -133,85 +140,87 @@ describe('Navegación y Back (flujo actual)', () => {
     // Paso 7: opciones de tipo de verbo
     await screen.findByRole('button', { name: /Seleccionar solo verbos irregulares/i })
 
-    // Back → vuelve a tiempos (debe volver a ver "Presente")
+    // Back → vuelve a temas (debe volver a ver "presente")
     await clickBack(user)
-    await screen.findByRole('button', { name: /Presente/i })
+    await screen.findByRole('button', { name: /^presente$/i })
   })
 
   it('Por nivel: Back desde paso 3 (niveles) vuelve a paso 2 (menú)', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
 
-    // Paso 2: menú principal (Por nivel / Por tema)
-    const porNivel = await screen.findByText(/NIVELES/i)
-    await act(async () => {
-      await user.click(porNivel)
-    })
+    // Paso 2: menú principal → Por nivel
+    await goToPorNivel(user)
 
     // Paso 3: niveles (A1..C2)
     await screen.findByRole('button', { name: /Seleccionar nivel A1/i })
 
-    // Back → paso 2 (main menu with level selector still active)
+    // Back → paso 2 (main menu)
     await clickBack(user)
-    await screen.findByText(/Volver al menú: Por tema \/ Por nivel/i)
+    await screen.findByRole('button', { name: /practicar por nivel/i })
   })
 
-  it('Por nivel: Back desde paso 4 (modo práctica) vuelve a paso 2', async () => {
+  it('Por nivel: Back desde paso 4 (modo práctica) vuelve a paso 3', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
-    const porNivel = await screen.findByText(/NIVELES/i)
-    await act(async () => {
-      await user.click(porNivel)
-    })
+    await goToPorNivel(user)
+
     const nivelC1 = await screen.findByRole('button', { name: /Seleccionar nivel C1/i })
     await act(async () => {
       await user.click(nivelC1)
     })
 
-    // Paso 4: práctica mixta/específica
-    await screen.findByText(/MIXTA/i)
+    // Paso 4: práctica mezclada / bloque puntual
+    await screen.findByRole('button', { name: /todo mezclado/i })
 
-    // Back → paso 2 (level selection)
+    // Back → paso 3 (level selection)
     await clickBack(user)
-    await screen.findByText(/A1/i)
+    await screen.findByRole('button', { name: /Seleccionar nivel A1/i })
   })
 
   it('Por nivel (specific): Back desde paso 5 (mood sin elegir) vuelve a paso 4', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
-    const porNivel = await screen.findByText(/NIVELES/i)
-    await user.click(porNivel)
+    await goToPorNivel(user)
+
     const nivelB1 = await screen.findByRole('button', { name: /Seleccionar nivel B1/i })
     await user.click(nivelB1)
 
-    // Paso 4: elegir "Formas Específicas"
-    const especificas = await screen.findByText(/ESPECÍFICA/i)
+    // Paso 4: elegir "un bloque puntual"
+    const especificas = await screen.findByRole('button', { name: /un bloque puntual/i })
     await user.click(especificas)
 
     // Paso 5: selección de modo (Indicativo/Subjuntivo...)
-    await screen.findByRole('button', { name: /Indicativo/i })
+    await screen.findByRole('button', { name: /indicativo/i })
 
     // Back → paso 4
     await clickBack(user)
-    await screen.findByText(/MIXTA/i)
+    await screen.findByRole('button', { name: /todo mezclado/i })
   })
 
-  it('Por tema (no finitas): Back desde paso 6 (Gerundio sin tiempo elegido) vuelve a paso 5 (moods)', async () => {
+  it('Por tema (no finitas): submenu abre y Back desde paso 7 vuelve a paso 5', async () => {
     render(<AppRouter />)
     await chooseDialectVos(user)
     await goToPorTema(user)
 
-    // Paso 5: elegir "Formas no conjugadas"
-    const noConjugadas = await screen.findByRole('button', { name: /Formas no conjugadas/i })
-    await user.click(noConjugadas)
+    // Paso 5: elegir "formas no finitas" → activa el submenú
+    const noFinitas = await screen.findByRole('button', { name: /formas no finitas/i })
+    await act(async () => {
+      await user.click(noFinitas)
+    })
 
-    // Paso 6: elegir "Gerundio"
-    const gerundio = await screen.findByRole('button', { name: /Gerundio/i })
-    await user.click(gerundio)
+    // Submenú de formas no finitas: elegir "gerundio"
+    const gerundio = await screen.findByRole('button', { name: /gerundio/i })
+    await act(async () => {
+      await user.click(gerundio)
+    })
 
-    // Back → vuelve a paso 5 (debe aparecer "Formas no conjugadas")
+    // Paso 7: tipo de verbo (debería mostrar "regulares")
+    await screen.findByRole('button', { name: /Seleccionar solo verbos regulares/i })
+
+    // Back → vuelve a paso 5 (debe aparecer "formas no finitas" en el menú raíz)
     await clickBack(user)
-    await screen.findByRole('button', { name: /Formas no conjugadas/i })
+    await screen.findByRole('button', { name: /formas no finitas/i })
   })
 
   it('UI Atrás retrocede exactamente un paso en el historial de onboarding', async () => {
@@ -219,9 +228,14 @@ describe('Navegación y Back (flujo actual)', () => {
 
     await chooseDialectVos(user)
     await goToPorTema(user)
-    await chooseMood(user, 'Indicativo')
 
-    await screen.findByRole('button', { name: /Presente/i })
+    // Paso 5: elegir subjuntivos → paso 6
+    const subjBtn = await screen.findByRole('button', { name: /subjuntivos/i })
+    await act(async () => {
+      await user.click(subjBtn)
+    })
+
+    await screen.findByRole('button', { name: /Imperfecto/i })
     await waitFor(() => {
       expect(router.getCurrentRoute().step).toBe(6)
     })
@@ -234,7 +248,7 @@ describe('Navegación y Back (flujo actual)', () => {
       expect(router.getCurrentRoute().step).toBe(previous - 1)
     })
 
-    await screen.findByRole('button', { name: /Indicativo/i })
+    await screen.findByRole('button', { name: /subjuntivos/i })
   })
 
   it('Evento popstate retrocede exactamente un paso en el historial de onboarding', async () => {
@@ -242,9 +256,14 @@ describe('Navegación y Back (flujo actual)', () => {
 
     await chooseDialectVos(user)
     await goToPorTema(user)
-    await chooseMood(user, 'Indicativo')
 
-    await screen.findByRole('button', { name: /Presente/i })
+    // Paso 5: elegir subjuntivos → paso 6
+    const subjBtn = await screen.findByRole('button', { name: /subjuntivos/i })
+    await act(async () => {
+      await user.click(subjBtn)
+    })
+
+    await screen.findByRole('button', { name: /Imperfecto/i })
     await waitFor(() => {
       expect(router.getCurrentRoute().step).toBe(6)
     })
@@ -262,6 +281,6 @@ describe('Navegación y Back (flujo actual)', () => {
       expect(router.getCurrentRoute().step).toBe(previous - 1)
     })
 
-    await screen.findByRole('button', { name: /Indicativo/i })
+    await screen.findByRole('button', { name: /subjuntivos/i })
   })
 })


### PR DESCRIPTION
- Rewrite all 9 navigation back-tests to match the new por-temas flow where indicativo tenses are shown directly (no mood-selection step):
  * Tests 1–2, 8–9: use 'subjuntivos' to reach step 6 instead of the removed 'Indicativo' mood button
  * Test 3: verify that clicking a direct indicativo tense jumps to step 7 and Back returns to step 5
  * Tests 4–6 (por nivel): replace stale labels (NIVELES, MIXTA, ESPECÍFICA) with current ones (practicar por nivel, todo mezclado, un bloque puntual)
  * Test 7 (no finitas): verify submenu toggle + back to root menu
  * Fix user.click helper to await act(async()=>{}) for React 18
  * All selectors updated to findByRole to avoid multi-element matches

- Update aux description text in both OnboardingFlow and TenseSelectionStep: 'Futuro, condicional y no finitas abren submenú.'

- Add native hardware-back button support via Capacitor (App.jsx): minimises app at onboarding steps 1–2; navigates back elsewhere