### PR TITLE
fix(learning): prevent top-clipping of intro panel on smaller/Windows…

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,200..700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+    <noscript>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,200..700&display=swap" />
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap" />
+    </noscript>
     <title>VerbOS - Conjugador de Verbos en Español</title>
   </head>
   <body>

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -1,4 +1,12 @@
 /* ── VERB/OS shell overrides for NarrativeIntroduction ── */
+.narrative-introduction .vo-right {
+  /* Override justify-content: center from OnboardingFlow.css.
+     When content overflows a centered flex container, browsers clip the top
+     and anchor scrolling to center — making the top of the panel unreachable.
+     flex-start ensures overflow-y: auto scrolls from the top as expected. */
+  justify-content: flex-start;
+}
+
 .ni-right-panel {
   gap: 0;
   justify-content: flex-start !important;


### PR DESCRIPTION
… screens

The right panel used justify-content: center from OnboardingFlow.css. When content overflows a centered flex container with overflow-y: auto, browsers clip the start of the overflow and anchor scrolling to center — making the top of the panel unreachable. This manifested on computers with smaller viewports, higher zoom levels, or Windows font rendering (which is ~3–5% larger than macOS), causing the TERMINACIONES table and CONTEXTO examples to be inaccessible.

Fix: override justify-content to flex-start specifically for the NarrativeIntroduction context so the panel always scrolls from the top.

Also add <noscript> font fallback links so Google Fonts load on networks where the onload JS trick is blocked, preventing layout shifts from mismatched system font metrics.