### PR TITLE
Rediseño: tema minimalista monocromo elegante (estilo impacto-directo)

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,200..700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
     <noscript>
       <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,200..700&display=swap" />
-      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap" />
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400..600&display=swap" />
     </noscript>
     <title>VerbOS - Conjugador de Verbos en Español</title>
   </head>

--- a/src/App.css
+++ b/src/App.css
@@ -78,11 +78,11 @@
 }
 
 .streak-tier-2 {
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 .streak-tier-3 {
-  color: #ffd166;
+  color: var(--accent-warning);
 }
 
 .streak-tier-4 {
@@ -238,7 +238,7 @@ body {
 .icon-btn:hover {
   border: 1px solid var(--border-active);
   background: rgba(255, 255, 255, 0.05);
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .icon-btn:hover img {
@@ -382,7 +382,7 @@ body {
 
 .onboarding h1 {
   font-size: 5rem;
-  font-weight: 900;
+  font-weight: 600;
   margin-bottom: 1rem;
   color: #ffffff;
   letter-spacing: -0.04em;
@@ -459,7 +459,7 @@ body {
   background: var(--text);
   border-color: var(--text);
   transform: translate(-4px, -4px);
-  box-shadow: 6px 6px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
   z-index: 10;
 }
 
@@ -579,7 +579,7 @@ body {
 
 .option-card h3 {
   font-size: 2.5rem;
-  font-weight: 900;
+  font-weight: 600;
   margin-bottom: 1rem;
   color: var(--text);
   display: flex;
@@ -644,7 +644,7 @@ body {
 
 .option-title {
   font-size: 2.5rem;
-  font-weight: 900;
+  font-weight: 600;
   margin-bottom: 0.75rem;
   line-height: 1;
   text-transform: uppercase;
@@ -718,7 +718,7 @@ body {
 
 .verb-lemma {
   font-size: 3rem;
-  font-weight: 900;
+  font-weight: 600;
   margin-bottom: 0.5rem;
   color: #ffffff;
   letter-spacing: -0.02em;
@@ -831,7 +831,7 @@ body {
   border-radius: 0;
   background: #000000;
   color: var(--text);
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 
@@ -863,7 +863,7 @@ body {
   color: #666;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 
@@ -885,7 +885,7 @@ body {
   letter-spacing: 0.05em;
   caret-color: #ffffff;
   box-shadow: none;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 .accent-keypad {
@@ -907,7 +907,7 @@ body {
   cursor: pointer;
   transition: all 0.1s ease;
   box-shadow: none;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 .accent-key:hover {
@@ -915,7 +915,7 @@ body {
   border-color: #ffffff;
   color: #000000;
   transform: translate(-2px, -2px);
-  box-shadow: 2px 2px 0 #ffffff;
+  box-shadow: var(--shadow-soft);
 }
 
 .accent-key:active {
@@ -932,7 +932,7 @@ body {
   margin-top: 0.4rem;
   color: #666;
   font-size: 0.8rem;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 .conjugation-input:focus {
@@ -940,7 +940,7 @@ body {
   border-color: #ffffff;
   background: #000000;
   transform: none;
-  box-shadow: 4px 4px 0 #ffffff;
+  box-shadow: var(--shadow-soft);
 }
 
 .conjugation-input::placeholder {
@@ -977,19 +977,19 @@ body {
   min-width: 140px;
   min-height: 48px;
   position: relative;
-  box-shadow: 4px 4px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn:hover {
   background: var(--text);
   color: var(--bg);
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn:active {
   transform: translate(2px, 2px);
-  box-shadow: 0px 0px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn:disabled {
@@ -1037,18 +1037,18 @@ body {
   background: transparent;
   color: var(--text);
   border: 2px solid var(--text);
-  box-shadow: 4px 4px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn-secondary:hover {
   background: var(--text);
   color: var(--bg);
   border-color: var(--text);
-  box-shadow: 6px 6px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn-secondary:active {
-  box-shadow: 0px 0px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 
@@ -1158,7 +1158,7 @@ body {
 
 .digit-clock {
   position: relative;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   font-size: 2rem;
@@ -1379,7 +1379,7 @@ body {
   margin-bottom: 2rem;
   max-width: 550px;
   width: 100%;
-  box-shadow: 6px 6px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 .settings-panel h3 {
@@ -1414,7 +1414,7 @@ body {
   font-weight: 600;
   font-family: var(--font-mono);
   transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 4px 4px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 .setting-select:focus {
@@ -1422,7 +1422,7 @@ body {
   border-color: var(--accent-orange);
   background: var(--bg);
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .setting-select option {
@@ -1450,7 +1450,7 @@ body {
   font-family: var(--font-mono);
   font-weight: 600;
   text-transform: uppercase;
-  box-shadow: 4px 4px 0px var(--text);
+  box-shadow: var(--shadow-soft);
 }
 
 .radio-group label:hover {
@@ -1458,7 +1458,7 @@ body {
   color: var(--bg);
   border-color: var(--text);
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0px var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .radio-group input[type="radio"] {
@@ -1762,18 +1762,18 @@ body {
     /* Improve contrast vs background on mobile */
     background: transparent !important;
     border: 2px solid var(--text) !important;
-    box-shadow: 4px 4px 0px var(--text) !important;
+    box-shadow: var(--shadow-soft);
   }
 
   .option-card:hover {
-    box-shadow: 6px 6px 0px var(--accent-orange) !important;
+    box-shadow: var(--shadow-soft);
     background: var(--text) !important;
     border-color: var(--text) !important;
   }
 
   /* Neo-Brutalist simplified swipe/click effect on touch */
   .option-card:active {
-    box-shadow: 0px 0px 0px var(--accent-orange) !important;
+    box-shadow: var(--shadow-soft);
     transform: translate(4px, 4px) !important;
   }
 
@@ -2109,7 +2109,7 @@ body {
 
 .digit-clock {
   position: relative;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   font-size: 2rem;
@@ -2237,12 +2237,12 @@ body {
 /* Shake animation when countdown reaches zero */
 .digit-clock.shake {
   animation: countdown-explosion 1.2s ease-in-out;
-  color: #ff0000 !important;
+  color: var(--accent-error) !important;
   text-shadow: 0 0 10px rgba(255, 0, 0, 0.8) !important;
 }
 
 .digit-clock.shake .digit {
-  color: #ff0000 !important;
+  color: var(--accent-error) !important;
   text-shadow: 0 0 10px rgba(255, 0, 0, 0.8) !important;
 }
 
@@ -3834,7 +3834,7 @@ body {
 .main-menu-onboarding .option-card:hover {
   background: #f2f2f2;
   border-color: #f2f2f2;
-  box-shadow: 10px 10px 0px rgba(255, 255, 255, 0.85);
+  box-shadow: var(--shadow-soft);
 }
 
 .main-menu-onboarding .option-card.compact {

--- a/src/components/SafeComponent.jsx
+++ b/src/components/SafeComponent.jsx
@@ -31,7 +31,7 @@ class SafeComponent extends Component {
           border: '1px solid #f87171',
           borderRadius: '8px',
           backgroundColor: '#fef2f2',
-          color: '#dc2626'
+          color: 'var(--accent-error)'
         }}>
           <h3 style={{ margin: '0 0 0.5rem 0' }}>
             ⚠️ Error en {this.props.name || 'componente'}
@@ -43,7 +43,7 @@ class SafeComponent extends Component {
             onClick={this.handleRetry}
             style={{
               padding: '0.5rem 1rem',
-              backgroundColor: '#dc2626',
+              backgroundColor: 'var(--accent-error)',
               color: 'white',
               border: 'none',
               borderRadius: '4px',

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -25,7 +25,7 @@
   background: #000;
   color: #fff;
   padding: 10px 14px;
-  box-shadow: 4px 4px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border: 1px solid #fff;
   font-size: 0.8rem;
   font-family: var(--font-mono, monospace);
@@ -39,13 +39,13 @@
 
 .toast:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
-.toast-info { border-left: 3px solid #5ee6a5; }
-.toast-success { border-left: 3px solid #5ee6a5; }
-.toast-error { border-left: 3px solid #ff0000; box-shadow: 4px 4px 0 #ff0000; }
-.toast-error:hover { box-shadow: 6px 6px 0 #ff0000; }
+.toast-info { border-left: 3px solid var(--accent-success); }
+.toast-success { border-left: 3px solid var(--accent-success); }
+.toast-error { border-left: 3px solid var(--accent-error); box-shadow: var(--shadow-soft); }
+.toast-error:hover { box-shadow: var(--shadow-soft); }
 
 @media (max-width: 640px) {
   .toast-container {

--- a/src/components/auth/AccountButton.css
+++ b/src/components/auth/AccountButton.css
@@ -1,7 +1,7 @@
 /* ============================================
    Account Button — nativo VERB/OS vo-header
    Diseñado para vivir en el header de 44px con
-   fondo #0c0c0c, fuente JetBrains Mono 10px.
+   fondo var(--bg), fuente mono 10px.
    ============================================ */
 
 .acct-container {
@@ -19,23 +19,23 @@
   align-items: center;
   gap: 6px;
   background: transparent;
-  /* Borde sutil pero visible sobre el fondo oscuro #0c0c0c */
-  border: 1px solid #2a2823;
+  /* Borde sutil pero visible sobre el fondo oscuro var(--bg) */
+  border: 1px solid var(--border-strong);
   padding: 5px 11px;
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   transition: color 120ms, border-color 120ms;
   white-space: nowrap;
 }
 
 .acct-login-btn:hover {
-  color: #f4f1ea;
-  border-color: #6e6a60;
+  color: var(--text);
+  border-color: var(--muted);
 }
 
 .acct-login-label {
@@ -43,7 +43,7 @@
 }
 
 .acct-login-arrow {
-  color: #ff4d1c;
+  color: var(--accent-primary);
   font-size: 11px;
   line-height: 1;
 }
@@ -60,19 +60,19 @@
   border: 1px solid transparent;
   padding: 5px 8px;
   cursor: pointer;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   transition: color 120ms, border-color 120ms;
   white-space: nowrap;
 }
 
 .acct-trigger:hover,
 .acct-trigger--open {
-  color: #f4f1ea;
-  border-color: #2a2823;
+  color: var(--text);
+  border-color: var(--border-strong);
 }
 
 /* Cuadrado con la inicial — visible y con propósito */
@@ -82,8 +82,8 @@
   justify-content: center;
   width: 20px;
   height: 20px;
-  background: #f4f1ea;
-  color: #0c0c0c;
+  background: var(--text);
+  color: var(--bg);
   font-weight: 800;
   font-size: 9px;
   letter-spacing: 0;
@@ -95,13 +95,13 @@
   max-width: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: #6e6a60;
+  color: var(--muted);
   font-size: 10px;
 }
 
 .acct-trigger:hover .acct-name,
 .acct-trigger--open .acct-name {
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 /* Badge de estado sync */
@@ -114,13 +114,13 @@
   flex-shrink: 0;
 }
 
-.acct-status--ok      { color: #5ee6a5; }
-.acct-status--syncing { color: #f4f1ea; animation: acct-blink 1s steps(2) infinite; }
-.acct-status--error   { color: #ff6b6b; }
-.acct-status--offline { color: #6e6a60; border-style: dashed; }
-.acct-status--local   { color: #6e6a60; border-style: dashed; }
+.acct-status--ok      { color: var(--accent-success); }
+.acct-status--syncing { color: var(--text); animation: acct-blink 1s steps(2) infinite; }
+.acct-status--error   { color: var(--accent-error); }
+.acct-status--offline { color: var(--muted); border-style: dashed; }
+.acct-status--local   { color: var(--muted); border-style: dashed; }
 .acct-status--stale   { color: #faad14; }
-.acct-status--unknown { color: #2a2823; }
+.acct-status--unknown { color: var(--border-strong); }
 
 @keyframes acct-blink {
   50% { opacity: 0.3; }
@@ -135,9 +135,9 @@
   right: 0;
   z-index: 1100;
   min-width: 256px;
-  background: #0c0c0c;
-  border: 1px solid #2a2823;
-  box-shadow: 4px 4px 0 #1f1d18;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-soft);
   animation: acct-in 100ms ease-out;
 }
 
@@ -157,12 +157,12 @@
 .acct-dropdown__avatar {
   width: 30px;
   height: 30px;
-  background: #f4f1ea;
-  color: #0c0c0c;
+  background: var(--text);
+  color: var(--bg);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-weight: 800;
   font-size: 0.9rem;
   flex-shrink: 0;
@@ -174,8 +174,8 @@
 }
 
 .acct-dropdown__name {
-  color: #f4f1ea;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--text);
+  font-family: var(--font-ui);
   font-size: 0.8rem;
   font-weight: 600;
   white-space: nowrap;
@@ -185,9 +185,9 @@
 }
 
 .acct-dropdown__email {
-  color: #6e6a60;
+  color: var(--muted);
   font-size: 0.68rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -196,7 +196,7 @@
 /* Divider */
 .acct-dropdown__divider {
   height: 1px;
-  background: #1f1d18;
+  background: var(--border);
 }
 
 /* Section */
@@ -209,10 +209,10 @@
 }
 
 .acct-dropdown__section-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.58rem;
   font-weight: 700;
-  color: #2a2823;
+  color: var(--border-strong);
   letter-spacing: 0.18em;
   text-transform: uppercase;
   margin-bottom: 8px;
@@ -227,31 +227,31 @@
 }
 
 .acct-dropdown__sync-key {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.68rem;
-  color: #6e6a60;
+  color: var(--muted);
   white-space: nowrap;
   padding: 2px 0;
 }
 
 .acct-dropdown__sync-val {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.68rem;
   font-weight: 600;
-  color: #f4f1ea;
+  color: var(--text);
   padding: 2px 0;
 }
 
-.acct-dropdown__sync-val.ok       { color: #5ee6a5; }
-.acct-dropdown__sync-val.syncing  { color: #f4f1ea; animation: acct-blink 1s steps(2) infinite; }
-.acct-dropdown__sync-val.error    { color: #ff6b6b; }
+.acct-dropdown__sync-val.ok       { color: var(--accent-success); }
+.acct-dropdown__sync-val.syncing  { color: var(--text); animation: acct-blink 1s steps(2) infinite; }
+.acct-dropdown__sync-val.error    { color: var(--accent-error); }
 .acct-dropdown__sync-val.offline  { color: #faad14; }
 
 .acct-dropdown__sync-error {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.62rem;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
   padding: 5px 7px;
   margin-bottom: 8px;
   word-break: break-word;
@@ -263,9 +263,9 @@
   width: 100%;
   padding: 8px 10px;
   background: transparent;
-  color: #6e6a60;
-  border: 1px solid #2a2823;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-ui);
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -276,13 +276,13 @@
 }
 
 .acct-dropdown__sync-btn:hover:not(:disabled) {
-  color: #f4f1ea;
-  border-color: #6e6a60;
+  color: var(--text);
+  border-color: var(--muted);
 }
 
 .acct-dropdown__sync-btn:disabled {
-  color: #2a2823;
-  border-color: #1f1d18;
+  color: var(--border-strong);
+  border-color: var(--border);
   cursor: not-allowed;
 }
 
@@ -295,9 +295,9 @@
   padding: 9px 14px;
   background: none;
   border: none;
-  color: #6e6a60;
+  color: var(--muted);
   font-size: 0.78rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   letter-spacing: 0.04em;
   text-align: left;
   cursor: pointer;
@@ -312,7 +312,7 @@
 }
 
 .acct-dropdown__menu-item:hover {
-  color: #f4f1ea;
+  color: var(--text);
   background: rgba(255,255,255, 0.03);
 }
 
@@ -321,12 +321,12 @@
 }
 
 .acct-dropdown__menu-item--danger {
-  color: #2a2823;
+  color: var(--border-strong);
   padding: 10px 14px 12px;
 }
 
 .acct-dropdown__menu-item--danger:hover {
-  color: #ff6b6b;
+  color: var(--accent-error);
   background: rgba(255, 107, 107, 0.05);
 }
 

--- a/src/components/auth/AccountManagementModal.css
+++ b/src/components/auth/AccountManagementModal.css
@@ -23,7 +23,7 @@
   max-height: 85vh;
   background: var(--bg, #000);
   border: 1px solid var(--text, #fff);
-  box-shadow: 6px 6px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
   padding: 24px;
   display: flex;
   flex-direction: column;
@@ -76,7 +76,7 @@
 .account-modal__close:hover {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .account-modal__close:active {
@@ -120,7 +120,7 @@
 
 .account-modal__input:focus {
   border-color: var(--text, #fff);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
   outline: none;
 }
 
@@ -157,7 +157,7 @@
 
 .account-modal__button.primary:hover:not(:disabled) {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--muted, #888);
+  box-shadow: var(--shadow-soft);
 }
 
 .account-modal__button.primary:active:not(:disabled) {
@@ -180,7 +180,7 @@
 .account-modal__button.secondary:hover {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .account-modal__button.secondary:active {

--- a/src/components/auth/AuthModal.css
+++ b/src/components/auth/AuthModal.css
@@ -22,7 +22,7 @@
 .auth-modal {
   background: var(--bg, #000);
   border: 1px solid var(--border, #333);
-  box-shadow: 4px 4px 0 var(--border, #333);
+  box-shadow: var(--shadow-soft);
   max-width: 400px;
   width: 100%;
   max-height: 90vh;
@@ -204,7 +204,7 @@
   font-family: var(--font-mono, monospace);
   transition: border-color 100ms;
   box-sizing: border-box;
-  caret-color: var(--accent-orange, #ff5722);
+  caret-color: var(--accent-orange, var(--accent-primary));
 }
 
 .form-group input:focus {

--- a/src/components/auth/DeviceManagerModal.css
+++ b/src/components/auth/DeviceManagerModal.css
@@ -23,7 +23,7 @@
   max-height: 85vh;
   background: var(--bg, #000);
   border: 1px solid var(--text, #fff);
-  box-shadow: 6px 6px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   animation: modal-enter 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
@@ -75,7 +75,7 @@
 .device-modal__close:hover {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .device-modal__close:active {
@@ -109,7 +109,7 @@
 
 .device-card--current {
   border-color: var(--text, #fff);
-  box-shadow: 2px 2px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .device-card__info h3 {
@@ -170,7 +170,7 @@
 
 .device-card__button.primary:hover:not(:disabled) {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--muted, #888);
+  box-shadow: var(--shadow-soft);
 }
 
 .device-card__button.primary:active:not(:disabled) {
@@ -186,7 +186,7 @@
 .device-card__button.secondary:hover {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .device-card__button.secondary:active {
@@ -203,7 +203,7 @@
 .device-card__button.danger:hover {
   background: rgba(255, 0, 0, 0.08);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--accent-error, #f00);
+  box-shadow: 0 0 0 2px var(--accent-error);
 }
 
 .device-card__button.danger:active {
@@ -236,7 +236,7 @@
 
 .device-card__input:focus {
   border-color: var(--text, #fff);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
   outline: none;
 }
 
@@ -271,7 +271,7 @@
 .device-modal__button:hover {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .device-modal__button:active {

--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -75,7 +75,7 @@ function DrillHeader({
         <div className="vd-logo" onClick={onHome} title="Ir al inicio">
           <div className="vd-logo-dot" />
           <span className="vd-logo-name">
-            VERB<span style={{ color: '#ff4d1c' }}>/</span>OS
+            VERB<span style={{ color: 'var(--accent-primary)' }}>/</span>OS
           </span>
         </div>
       </div>
@@ -88,7 +88,7 @@ function DrillHeader({
             <span>REPASO SRS</span>
           </span>
         ) : breadcrumb.length === 0 ? (
-          <span style={{ color: '#2a2823' }}>— · —</span>
+          <span style={{ color: 'var(--border-strong)' }}>— · —</span>
         ) : (
           breadcrumb.map((item, i) => (
             <React.Fragment key={i}>

--- a/src/components/drill/DrillMode.jsx
+++ b/src/components/drill/DrillMode.jsx
@@ -469,7 +469,7 @@ function DrillMode({
       {crosshairPositions.map((pos, i) => (
         <div key={i} className="vd-crosshair" style={pos} aria-hidden="true">
           <svg width="14" height="14" viewBox="0 0 14 14">
-            <path d="M0 7H14M7 0V14" stroke="#ff4d1c" strokeWidth="1" />
+            <path d="M0 7H14M7 0V14" stroke="var(--accent-primary)" strokeWidth="1" />
           </svg>
         </div>
       ))}
@@ -627,7 +627,7 @@ function DrillMode({
           <span><em>↵</em> verificar · continuar</span>
           <span><em>esc</em> limpiar</span>
         </div>
-        <div style={{ color: '#6e6a60' }}>PRÁCTICA</div>
+        <div style={{ color: 'var(--muted)' }}>PRÁCTICA</div>
         <div>SISTEMA · OK</div>
       </footer>
     </div>

--- a/src/components/drill/DrillVerbos.css
+++ b/src/components/drill/DrillVerbos.css
@@ -1,17 +1,15 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap');
-
-/* ── Design tokens (scoped) ── */
+/* ── Design tokens (scoped) — now inherit the global monochrome theme ── */
 .verbos-drill {
-  --vd-bg:       #0c0c0c;
-  --vd-ink:      #f4f1ea;
-  --vd-ink2:     #6e6a60;
-  --vd-ink3:     #2a2823;
-  --vd-line:     #1f1d18;
-  --vd-accent:   #ff4d1c;
-  --vd-green:    #5ee6a5;
-  --vd-red:      #ff6b6b;
-  --vd-font:     'Inter Tight', -apple-system, sans-serif;
-  --vd-mono:     'JetBrains Mono', monospace;
+  --vd-bg:       var(--bg);
+  --vd-ink:      var(--text);
+  --vd-ink2:     var(--muted);
+  --vd-ink3:     var(--border-strong);
+  --vd-line:     var(--border);
+  --vd-accent:   var(--accent-primary);
+  --vd-green:    var(--accent-success);
+  --vd-red:      var(--accent-error);
+  --vd-font:     var(--font-ui);
+  --vd-mono:     var(--font-ui);
 }
 
 /* ── Wrapper ── */
@@ -76,30 +74,10 @@
 }
 
 /* ── Background grid ── */
-.vd-grid {
-  position: fixed;
-  inset: 44px 0 32px 0;
-  background-image:
-    linear-gradient(var(--vd-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--vd-line) 1px, transparent 1px);
-  background-size: 64px 64px;
-  opacity: 0.55;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.vd-vignette {
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,0.55) 100%);
-  pointer-events: none;
-  z-index: 1;
-}
-
+.vd-grid,
+.vd-vignette,
 .vd-crosshair {
-  position: fixed;
-  pointer-events: none;
-  z-index: 2;
+  display: none;
 }
 
 /* ── Header ── */
@@ -233,7 +211,7 @@
 
 .verbos-drill .icon-btn.active {
   border-color: var(--vd-accent);
-  background: rgba(255, 77, 28, 0.1);
+  background: rgba(242, 242, 240, 0.1);
   color: var(--vd-accent);
 }
 
@@ -270,7 +248,7 @@
 }
 
 .verbos-drill .srs-badge-icon {
-  filter: invert(1) sepia(1) saturate(5) hue-rotate(320deg);
+  filter: invert(1);
   width: 12px;
   height: 12px;
 }
@@ -333,16 +311,16 @@
 
 /* ── Verb lemma — focal display ── */
 .verbos-drill .verb-lemma {
-  font-family: var(--vd-font);
-  font-weight: 900;
+  font-family: var(--font-display);
+  font-weight: 600;
   font-style: italic;
   font-size: clamp(52px, 10vw, 120px);
-  letter-spacing: -0.055em;
+  letter-spacing: -0.035em;
   line-height: 0.9;
   text-transform: lowercase;
   color: var(--vd-accent);
   margin-bottom: 20px;
-  animation: vdScanIn 0.4s cubic-bezier(0.7, 0, 0.2, 1) both;
+  animation: vdLiftIn 0.4s cubic-bezier(0.2, 0, 0.2, 1) both;
 }
 
 /* ── Conjugation context ── */
@@ -403,7 +381,7 @@
 .verbos-drill .conjugation-input:focus {
   outline: none;
   border-color: var(--vd-accent);
-  background: rgba(255, 77, 28, 0.04);
+  background: rgba(242, 242, 240, 0.04);
   box-shadow: none;
   transform: none;
 }
@@ -448,7 +426,7 @@
 .verbos-drill .accent-key:hover {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255, 77, 28, 0.08);
+  background: rgba(242, 242, 240, 0.08);
   transform: none;
   box-shadow: none;
 }
@@ -570,7 +548,7 @@
 .verbos-drill .tts-btn:hover {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-drill .tts-btn img {
@@ -581,7 +559,7 @@
 }
 
 .verbos-drill .tts-btn:hover img {
-  filter: invert(1) sepia(1) saturate(5) hue-rotate(320deg) brightness(1);
+  filter: invert(1);
 }
 
 /* ── Diff component ── */
@@ -837,7 +815,7 @@
 .verbos-drill .pron-target-word {
   font-family: var(--vd-font);
   font-size: clamp(32px, 6vw, 52px);
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   color: var(--vd-accent);
   letter-spacing: -0.04em;
@@ -871,7 +849,7 @@
 .verbos-drill .pron-listen-btn:hover {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-drill .pron-listen-btn img,
@@ -887,7 +865,7 @@
 }
 
 .verbos-drill .pron-listen-btn:hover img {
-  filter: invert(1) sepia(1) saturate(5) hue-rotate(320deg) brightness(1);
+  filter: invert(1);
 }
 
 /* Mic button */
@@ -924,19 +902,19 @@
 .verbos-drill .pron-mic-btn:hover:not(:disabled) {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-drill .pron-mic-btn.recording {
   border-color: var(--vd-accent);
-  background: rgba(255,77,28,0.12);
+  background: rgba(242, 242, 240,0.12);
   color: var(--vd-accent);
   animation: vdMicPulse 1.5s ease-in-out infinite;
 }
 
 @keyframes vdMicPulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255,77,28,0.3); }
-  50%       { box-shadow: 0 0 0 10px rgba(255,77,28,0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(242, 242, 240,0.3); }
+  50%       { box-shadow: 0 0 0 10px rgba(242, 242, 240,0); }
 }
 
 .verbos-drill .pron-mic-btn:disabled {
@@ -998,8 +976,8 @@
 
 .verbos-drill .pron-result.perfect   { border-color: var(--vd-green); }
 .verbos-drill .pron-result.excellent { border-color: var(--vd-green); }
-.verbos-drill .pron-result.good      { border-color: #9fda8a; }
-.verbos-drill .pron-result.needs-work{ border-color: #e0c05a; }
+.verbos-drill .pron-result.good      { border-color: var(--accent-success); }
+.verbos-drill .pron-result.needs-work{ border-color: var(--accent-warning); }
 .verbos-drill .pron-result.incorrect { border-color: var(--vd-red); }
 .verbos-drill .pron-result.error     { border-color: var(--vd-red); }
 
@@ -1020,8 +998,8 @@
 
 .verbos-drill .pron-result.perfect   .pron-score-number,
 .verbos-drill .pron-result.excellent .pron-score-number { color: var(--vd-green); }
-.verbos-drill .pron-result.good      .pron-score-number { color: #9fda8a; }
-.verbos-drill .pron-result.needs-work .pron-score-number { color: #e0c05a; }
+.verbos-drill .pron-result.good      .pron-score-number { color: var(--accent-success); }
+.verbos-drill .pron-result.needs-work .pron-score-number { color: var(--accent-warning); }
 .verbos-drill .pron-result.incorrect .pron-score-number,
 .verbos-drill .pron-result.error     .pron-score-number { color: var(--vd-red); }
 
@@ -1036,7 +1014,7 @@
   transition: width 0.5s ease;
   background: var(--vd-green);
 }
-.verbos-drill .pron-result.needs-work .pron-score-bar { background: #e0c05a; }
+.verbos-drill .pron-result.needs-work .pron-score-bar { background: var(--accent-warning); }
 .verbos-drill .pron-result.incorrect  .pron-score-bar { background: var(--vd-red); }
 .verbos-drill .pron-result.error      .pron-score-bar { background: var(--vd-red); }
 
@@ -1164,13 +1142,13 @@
 
 .verbos-drill .vd-qs-select:focus {
   outline: none;
-  background-color: rgba(255,77,28,0.04);
+  background-color: rgba(242, 242, 240,0.04);
   color: var(--vd-ink);
   border-left-color: var(--vd-accent);
 }
 
 .verbos-drill .vd-qs-select option {
-  background: #111;
+  background: var(--bg-raised);
   color: var(--vd-ink);
 }
 
@@ -1234,7 +1212,7 @@
 }
 
 .verbos-drill .vd-game-btn--active {
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-drill .vd-game-img {

--- a/src/components/gamification/GamificationNotifications.css
+++ b/src/components/gamification/GamificationNotifications.css
@@ -71,7 +71,7 @@
 }
 
 .notification.streak::before {
-  background: linear-gradient(90deg, #ef4444, #f87171);
+  background: linear-gradient(90deg, var(--accent-error), #f87171);
 }
 
 .notification.priority {
@@ -262,11 +262,11 @@
 }
 
 .notification.streak {
-  border-left: 4px solid #ef4444;
+  border-left: 4px solid var(--accent-error);
 }
 
 .notification.streak .notification-title {
-  color: #dc2626;
+  color: var(--accent-error);
 }
 
 /* Animaciones de salida */

--- a/src/components/learning/EndingsDrill.css
+++ b/src/components/learning/EndingsDrill.css
@@ -13,8 +13,8 @@
 .eds-reference {
   width: 100%;
   max-width: 600px;
-  border: 1px solid #1f1d18;
-  font-family: 'JetBrains Mono', monospace;
+  border: 1px solid var(--border);
+  font-family: var(--font-ui);
   font-size: 11px;
 }
 
@@ -23,41 +23,41 @@
   justify-content: space-between;
   align-items: center;
   padding: 8px 16px;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   transition: background 0.12s;
 }
 
 .eds-ref-row:last-child { border-bottom: none; }
 
 .eds-ref-current {
-  background: rgba(255, 77, 28, 0.08);
-  border-left: 2px solid #ff4d1c;
+  background: rgba(242, 242, 240, 0.08);
+  border-left: 2px solid var(--accent-primary);
   padding-left: 14px;
 }
 
 .eds-ref-irreg {
-  border-left: 2px solid rgba(255, 77, 28, 0.4);
+  border-left: 2px solid rgba(242, 242, 240, 0.4);
   padding-left: 14px;
 }
 
 .eds-ref-current.eds-ref-irreg {
-  border-left: 2px solid #ff4d1c;
+  border-left: 2px solid var(--accent-primary);
 }
 
 .eds-ref-person {
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .eds-ref-form {
-  color: #f4f1ea;
+  color: var(--text);
   font-weight: 500;
   letter-spacing: 0.04em;
 }
 
 .eds-ref-current .eds-ref-person {
-  color: #ff4d1c;
+  color: var(--accent-primary);
 }
 
 .eds-ref-current .eds-ref-form {

--- a/src/components/learning/EndingsDrill.jsx
+++ b/src/components/learning/EndingsDrill.jsx
@@ -9,9 +9,9 @@ import './EndingsDrill.css'; // Own specific styles
 import './IrregularEndingsDrill.css'; // Irregular verb specific styles
 import '../onboarding/OnboardingFlow.css';
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
 
 import { safeLazy } from '../../lib/utils/lazyImport.js';
 
@@ -596,7 +596,7 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
       <div className="verbos-onboarding">
         <div className="vo-grid" aria-hidden="true" />
         <div className="vo-vignette" aria-hidden="true" />
-        <div style={{ position:'fixed',top:'50%',left:'50%',transform:'translate(-50%,-50%)',color:INK2,fontFamily:'JetBrains Mono,monospace',fontSize:11,letterSpacing:'0.14em',textTransform:'uppercase' }}>
+        <div style={{ position:'fixed',top:'50%',left:'50%',transform:'translate(-50%,-50%)',color:INK2,fontFamily:'var(--font-ui)',fontSize:11,letterSpacing:'0.14em',textTransform:'uppercase' }}>
           cargando ejercicio...
         </div>
       </div>
@@ -628,7 +628,7 @@ function EndingsDrill({ verb, tense, onComplete, onBack, onHome, onGoToProgress 
           <span className="vo-breadcrumb-sep">/</span>
           <span className="vo-breadcrumb-val"> {verb.lemma}</span>
         </div>
-        <div style={{ fontFamily:'JetBrains Mono,monospace',fontSize:10,letterSpacing:'0.14em',textTransform:'uppercase',color:INK2 }}>
+        <div style={{ fontFamily:'var(--font-ui)',fontSize:10,letterSpacing:'0.14em',textTransform:'uppercase',color:INK2 }}>
           FALTAN <span style={{ color: INK, fontWeight:700 }}>{drillQueue.length - currentIndex}</span>
         </div>
       </header>

--- a/src/components/learning/IrregularRootDrill.css
+++ b/src/components/learning/IrregularRootDrill.css
@@ -2,25 +2,25 @@
 .ird-hint-block {
   width: 100%;
   max-width: 600px;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 16px 20px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 .ird-hint-block .root-meta { display:flex; flex-direction:column; gap:8px; }
 .ird-hint-block .root-line { display:flex; justify-content:space-between; align-items:center; gap:16px; }
-.ird-hint-block .hint-label { color:#2a2823; }
-.ird-hint-block .hint-value { color:#f4f1ea; font-weight:700; }
-.ird-hint-block .root-highlight { color:#ffffff; background:#ff4d1c; font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
-.ird-hint-block .nonfinite-highlight { color:#ffffff; background:#ff4d1c; font-weight:700; padding:2px 8px; }
-.ird-hint-block .hint-note { color:#2a2823; font-size:10px; text-transform:none; font-style:italic; margin:0; }
-.ird-hint-block .hint-note.alternate { color:#6e6a60; }
+.ird-hint-block .hint-label { color:var(--border-strong); }
+.ird-hint-block .hint-value { color:var(--text); font-weight:700; }
+.ird-hint-block .root-highlight { color:#ffffff; background:var(--accent-primary); font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
+.ird-hint-block .nonfinite-highlight { color:#ffffff; background:var(--accent-primary); font-weight:700; padding:2px 8px; }
+.ird-hint-block .hint-note { color:var(--border-strong); font-size:10px; text-transform:none; font-style:italic; margin:0; }
+.ird-hint-block .hint-note.alternate { color:var(--muted); }
 
 /* ── Legacy styles below ── */
 

--- a/src/components/learning/IrregularRootDrill.jsx
+++ b/src/components/learning/IrregularRootDrill.jsx
@@ -15,10 +15,10 @@ import './LearningDrill.css'
 import './IrregularRootDrill.css'
 import '../onboarding/OnboardingFlow.css'
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
 import { highlightStemVowel } from './highlightHelpers.js'
 
 import { safeLazy } from '../../lib/utils/lazyImport.js';
@@ -147,8 +147,8 @@ function IrregularRootDrill({
         </div>
       </header>
       <div style={{ position:'fixed',top:'50%',left:'50%',transform:'translate(-50%,-50%)',maxWidth:400,textAlign:'center',padding:32 }}>
-        <div style={{ fontFamily:'Inter Tight,sans-serif',fontSize:24,fontWeight:900,fontStyle:'italic',color:INK,marginBottom:16 }}>{title}</div>
-        <div style={{ fontFamily:'JetBrains Mono,monospace',fontSize:11,color:INK2,letterSpacing:'0.1em',marginBottom:24 }}>{body}</div>
+        <div style={{ fontFamily:'var(--font-ui)',fontSize:24,fontWeight:900,fontStyle:'italic',color:INK,marginBottom:16 }}>{title}</div>
+        <div style={{ fontFamily:'var(--font-ui)',fontSize:11,color:INK2,letterSpacing:'0.1em',marginBottom:24 }}>{body}</div>
         <button className="ld-confirm-btn" onClick={onBack}>← volver</button>
       </div>
       <footer className="vo-footer">
@@ -361,7 +361,7 @@ function IrregularRootDrill({
           <span className="vo-breadcrumb-sep">/</span>
           <span className="vo-breadcrumb-val"> irregulares</span>
         </div>
-        <div style={{ display:'flex',gap:16,fontFamily:'JetBrains Mono,monospace',fontSize:10,letterSpacing:'0.12em',textTransform:'uppercase',color:INK2 }}>
+        <div style={{ display:'flex',gap:16,fontFamily:'var(--font-ui)',fontSize:10,letterSpacing:'0.12em',textTransform:'uppercase',color:INK2 }}>
           {timeLeft != null && <span>TIEMPO <span style={{ color: INK }}>{Math.max(timeLeft,0)}s</span></span>}
           <span>{Math.min(index+1,questions.length)}<span style={{ color:INK3 }}>/{questions.length}</span></span>
           <span>✓ <span style={{ color: INK }}>{stats.correct}</span></span>
@@ -438,7 +438,7 @@ function IrregularRootDrill({
 
         {/* Utilities */}
         <div className="ld-utils">
-          <button className="ld-util-btn" onClick={() => setShowAccentKeypad(v => !v)} title="Tildes" style={{ background: showAccentKeypad ? ACCENT : 'transparent', color: showAccentKeypad ? '#0c0c0c' : INK2 }}>Ñ</button>
+          <button className="ld-util-btn" onClick={() => setShowAccentKeypad(v => !v)} title="Tildes" style={{ background: showAccentKeypad ? ACCENT : 'transparent', color: showAccentKeypad ? 'var(--bg)' : INK2 }}>Ñ</button>
           <button className="ld-util-btn" onClick={() => handleTogglePronunciation()} title="Pronunciación">◉</button>
           {onGoToProgress && <button className="ld-util-btn" onClick={onGoToProgress} title="Métricas">⬡</button>}
           {onHome && <button className="ld-util-btn" onClick={onHome} title="Inicio">⌂</button>}

--- a/src/components/learning/LearnTenseFlow.css
+++ b/src/components/learning/LearnTenseFlow.css
@@ -127,7 +127,7 @@
   margin-left: auto;
   margin-right: auto;
   text-align: center;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 /* Tense sections */
@@ -157,7 +157,7 @@
 .learn-flow .learning-option-card.selected {
   background: rgba(255, 255, 255, 0.93);
   border-color: #ffffff;
-  box-shadow: 10px 10px 0 rgba(255, 255, 255, 0.7);
+  box-shadow: var(--shadow-soft);
 }
 
 /* Selected state for tense cards */
@@ -255,7 +255,7 @@
   font-size: 0.9rem;
   min-width: 140px;
   justify-content: center;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   color: #888;
 }
 

--- a/src/components/learning/LearnTenseFlow.jsx
+++ b/src/components/learning/LearnTenseFlow.jsx
@@ -699,14 +699,14 @@ function LearnTenseFlowContainer({ onHome, onGoToProgress }) {
   if (currentStep === 'session-complete') {
     return (
       <div className="learning-menu-layout" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '70vh', gap: '1.5rem', textAlign: 'center' }}>
-        <div style={{ fontSize: '2.5rem', fontWeight: 900, color: '#ff4d1c' }}>✓</div>
-        <h2 style={{ margin: 0, fontFamily: 'Inter Tight, sans-serif', fontSize: '1.75rem', fontWeight: 900, fontStyle: 'italic' }}>¡Sesión completada!</h2>
-        <p style={{ margin: 0, opacity: 0.6, fontSize: '0.9rem', letterSpacing: '0.05em', textTransform: 'uppercase', fontFamily: 'JetBrains Mono, monospace' }}>
+        <div style={{ fontSize: '2.5rem', fontWeight: 900, color: 'var(--accent-primary)' }}>✓</div>
+        <h2 style={{ margin: 0, fontFamily: 'var(--font-ui)', fontSize: '1.75rem', fontWeight: 900, fontStyle: 'italic' }}>¡Sesión completada!</h2>
+        <p style={{ margin: 0, opacity: 0.6, fontSize: '0.9rem', letterSpacing: '0.05em', textTransform: 'uppercase', fontFamily: 'var(--font-ui)' }}>
           Practicaste con éxito. Buen trabajo.
         </p>
         <button
           onClick={handleFinish}
-          style={{ marginTop: '0.5rem', padding: '0.75rem 2rem', cursor: 'pointer', background: '#ff4d1c', color: '#0c0c0c', border: 'none', borderRadius: 4, fontSize: '0.95rem', fontWeight: 700, fontFamily: 'JetBrains Mono, monospace', letterSpacing: '0.1em', textTransform: 'uppercase' }}
+          style={{ marginTop: '0.5rem', padding: '0.75rem 2rem', cursor: 'pointer', background: 'var(--accent-primary)', color: 'var(--bg)', border: 'none', borderRadius: 4, fontSize: '0.95rem', fontWeight: 700, fontFamily: 'var(--font-ui)', letterSpacing: '0.1em', textTransform: 'uppercase' }}
         >
           Volver al inicio →
         </button>

--- a/src/components/learning/LearningDrill.css
+++ b/src/components/learning/LearningDrill.css
@@ -3,15 +3,15 @@
 /* ── CSS variables (same tokens as DrillVerbos) ── */
 .verbos-onboarding {
   --vd-bg:     #0c0b08;
-  --vd-ink:    #f4f1ea;
-  --vd-ink2:   #6e6a60;
-  --vd-ink3:   #2a2823;
-  --vd-line:   #1f1d18;
-  --vd-accent: #ff4d1c;
-  --vd-green:  #5ee6a5;
-  --vd-red:    #ff6b6b;
-  --vd-font:   'Inter Tight', -apple-system, sans-serif;
-  --vd-mono:   'JetBrains Mono', monospace;
+  --vd-ink:    var(--text);
+  --vd-ink2:   var(--muted);
+  --vd-ink3:   var(--border-strong);
+  --vd-line:   var(--border);
+  --vd-accent: var(--accent-primary);
+  --vd-green:  var(--accent-success);
+  --vd-red:    var(--accent-error);
+  --vd-font:   var(--font-ui);
+  --vd-mono:   var(--font-ui);
 }
 
 /* ── Pronunciation panel overlay (below vo-header, above main content) ── */
@@ -55,7 +55,7 @@
 .verbos-onboarding .pron-target-word {
   font-family: var(--vd-font);
   font-size: clamp(32px, 6vw, 52px);
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   color: var(--vd-accent);
   letter-spacing: -0.04em;
@@ -88,7 +88,7 @@
 .verbos-onboarding .pron-listen-btn:hover {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-onboarding .pron-listen-btn img,
@@ -131,19 +131,19 @@
 .verbos-onboarding .pron-mic-btn:hover:not(:disabled) {
   border-color: var(--vd-accent);
   color: var(--vd-accent);
-  background: rgba(255,77,28,0.06);
+  background: rgba(242, 242, 240,0.06);
 }
 
 .verbos-onboarding .pron-mic-btn.recording {
   border-color: var(--vd-accent);
-  background: rgba(255,77,28,0.12);
+  background: rgba(242, 242, 240,0.12);
   color: var(--vd-accent);
   animation: vdMicPulse 1.5s ease-in-out infinite;
 }
 
 @keyframes vdMicPulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255,77,28,0.3); }
-  50%       { box-shadow: 0 0 0 10px rgba(255,77,28,0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(242, 242, 240,0.3); }
+  50%       { box-shadow: 0 0 0 10px rgba(242, 242, 240,0); }
 }
 
 .verbos-onboarding .pron-mic-btn:disabled {
@@ -342,25 +342,25 @@
 
 /* ── Verb focal word ── */
 .ld-verb-focal {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: clamp(48px, 10vw, 96px);
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   letter-spacing: -0.055em;
   line-height: 0.9;
-  color: #ff4d1c;
+  color: var(--accent-primary);
   text-transform: lowercase;
   text-align: center;
 }
 
 /* ── Person display ── */
 .ld-person-mono {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   text-align: center;
 }
 
@@ -370,7 +370,7 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
 }
 
 .ld-input {
@@ -378,28 +378,28 @@
   background: transparent;
   border: none;
   outline: none;
-  color: #f4f1ea;
-  font-family: 'Inter Tight', sans-serif;
+  color: var(--text);
+  font-family: var(--font-ui);
   font-size: 24px;
   font-weight: 300;
   letter-spacing: -0.02em;
   padding: 16px 20px;
   text-align: center;
-  caret-color: #ff4d1c;
+  caret-color: var(--accent-primary);
   transition: background 0.15s;
 }
 
 .ld-input::placeholder {
-  color: #2a2823;
+  color: var(--border-strong);
   font-style: italic;
 }
 
 .ld-input:focus {
-  background: rgba(255, 77, 28, 0.04);
+  background: rgba(242, 242, 240, 0.04);
 }
 
 .ld-input.correct  { background: rgba(80, 200, 120, 0.08); }
-.ld-input.incorrect { background: rgba(255, 77, 28, 0.08); }
+.ld-input.incorrect { background: rgba(242, 242, 240, 0.08); }
 
 /* ── Result bar ── */
 .ld-result-bar {
@@ -407,14 +407,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 20px;
-  border-top: 1px solid #1f1d18;
-  font-family: 'JetBrains Mono', monospace;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-ui);
   font-size: 12px;
   letter-spacing: 0.1em;
 }
 
 .ld-result-bar.correct  { background: rgba(80, 200, 120, 0.06); }
-.ld-result-bar.incorrect { background: rgba(255, 77, 28, 0.06); }
+.ld-result-bar.incorrect { background: rgba(242, 242, 240, 0.06); }
 
 .ld-correct {
   color: #50c878;
@@ -423,32 +423,32 @@
 }
 
 .ld-incorrect {
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .ld-incorrect strong {
-  color: #ff4d1c;
+  color: var(--accent-primary);
   font-weight: 700;
 }
 
 .ld-tts-btn {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   cursor: pointer;
   padding: 5px 8px;
   color: rgba(244, 241, 234, 0.55);
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   transition: color 0.15s, border-color 0.15s;
 }
 .ld-tts-btn:hover {
-  color: #f4f1ea;
-  border-color: #ff4d1c;
+  color: var(--text);
+  border-color: var(--accent-primary);
 }
 
 /* ── Accent keypad ── */
@@ -461,9 +461,9 @@
 
 .ld-accent-key {
   background: transparent;
-  border: 1px solid #1f1d18;
-  color: #f4f1ea;
-  font-family: 'Inter Tight', sans-serif;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-ui);
   font-size: 16px;
   font-weight: 500;
   padding: 8px 14px;
@@ -472,8 +472,8 @@
 }
 
 .ld-accent-key:hover:not(:disabled) {
-  border-color: #ff4d1c;
-  color: #ff4d1c;
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 .ld-accent-key:disabled {
@@ -489,11 +489,11 @@
 }
 
 .ld-confirm-btn {
-  background: #ff4d1c;
-  color: #0c0c0c;
+  background: var(--accent-primary);
+  color: var(--bg);
   border: none;
   padding: 14px 40px;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 16px;
   font-weight: 700;
   font-style: italic;
@@ -516,7 +516,7 @@
 
 .ld-util-btn {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   color: rgba(244, 241, 234, 0.55);
   padding: 8px 10px;
   cursor: pointer;
@@ -528,14 +528,14 @@
 }
 
 .ld-util-btn:hover {
-  border-color: #ff4d1c;
-  color: #f4f1ea;
+  border-color: var(--accent-primary);
+  color: var(--text);
 }
 
 .ld-util-active {
-  border-color: #ff4d1c;
-  background: rgba(255, 77, 28, 0.1);
-  color: #ff4d1c;
+  border-color: var(--accent-primary);
+  background: rgba(242, 242, 240, 0.1);
+  color: var(--accent-primary);
 }
 
 /* Punto pulsante en el ícono del micrófono mientras se graba */
@@ -551,7 +551,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   animation: ldRecDot 1s ease-in-out infinite;
 }
 

--- a/src/components/learning/LearningDrill.jsx
+++ b/src/components/learning/LearningDrill.jsx
@@ -71,10 +71,10 @@ import { createLogger } from '../../lib/utils/logger.js';
 import './LearningDrill.css';
 import '../onboarding/OnboardingFlow.css';
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
 import { getCurrentUserId } from '../../lib/progress/userManager/index.js';
 
 const logger = createLogger('LearningDrill');
@@ -917,11 +917,11 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
             <span className="vo-logo-name">VERB<span style={{ color: ACCENT }}>/</span>OS</span>
             <span style={{ marginLeft: 8 }}>drill</span>
           </div>
-          <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', color: INK2 }}>
+          <div style={{ fontFamily: 'var(--font-ui)', fontSize: 10, letterSpacing: '0.14em', color: INK2 }}>
             CARGANDO...
           </div>
         </header>
-        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', color: INK2, fontFamily: 'JetBrains Mono, monospace', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', color: INK2, fontFamily: 'var(--font-ui)', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
           cargando ejercicios...
         </div>
         <footer className="vo-footer">
@@ -964,7 +964,7 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
           <span className="vo-breadcrumb-sep">/</span>
           <span className="vo-breadcrumb-val"> {tenseLabelDisplay}</span>
         </div>
-        <div style={{ display: 'flex', gap: 16, fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: INK2 }}>
+        <div style={{ display: 'flex', gap: 16, fontFamily: 'var(--font-ui)', fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', color: INK2 }}>
           <span>RACHA <span style={{ color: correctStreak > 0 ? ACCENT : INK, fontWeight: 700 }} className={showStreakAnimation ? 'streak-shake' : ''}>{correctStreak}</span></span>
           <span>PREC <span style={{ color: INK }}>{totalAttempts > 0 ? Math.round((correctAnswers / totalAttempts) * 100) : 0}%</span></span>
           {failedItemsQueue.length > 0 && <span style={{ color: ACCENT }}>↺ {failedItemsQueue.length}</span>}

--- a/src/components/learning/LearningStepView.jsx
+++ b/src/components/learning/LearningStepView.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import '../onboarding/OnboardingFlow.css'
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
-const LINE   = '#1f1d18'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
+const LINE   = 'var(--border)'
 
 function Crosshairs() {
   const positions = [
@@ -136,7 +136,7 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
                     className="vo-option-num-box"
                     style={{
                       borderColor: active || selected ? ACCENT : LINE,
-                      background: selected && !active ? 'rgba(255,77,28,0.12)' : 'transparent',
+                      background: selected && !active ? 'rgba(242, 242, 240,0.12)' : 'transparent',
                     }}
                   >
                     {selected && !active ? '✓' : i + 1}
@@ -240,7 +240,7 @@ function LearningStepView({ stepConfig, onBack, breadcrumb = [], stepNum = 1, to
           }
         </div>
 
-        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
+        <div style={{ fontFamily: 'var(--font-ui)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
           PASO <span style={{ color: INK }}>{String(stepNum).padStart(2, '0')}</span> / {String(totalSteps).padStart(2, '0')}
         </div>
       </header>

--- a/src/components/learning/MeaningfulPractice.css
+++ b/src/components/learning/MeaningfulPractice.css
@@ -83,12 +83,12 @@
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   margin-top: 1.5rem;
-  box-shadow: 4px 4px 0 var(--accent-orange, #ff5722);
+  box-shadow: var(--shadow-soft);
 }
 
 .retry-button:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange, #ff5722);
+  box-shadow: var(--shadow-soft);
 }
 
 .retry-button:active {
@@ -629,7 +629,7 @@
 .response-textarea:focus {
   outline: none;
   border-color: var(--text, #fff);
-  box-shadow: 4px 4px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .response-textarea::placeholder {
@@ -743,7 +743,7 @@
 .hint-button:hover:not(:disabled) {
   border-color: var(--text, #fff);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 var(--text, #fff);
+  box-shadow: var(--shadow-soft);
 }
 
 .hint-button:active:not(:disabled) {
@@ -772,12 +772,12 @@
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   min-width: 140px;
-  box-shadow: 4px 4px 0 var(--accent-orange, #ff5722);
+  box-shadow: var(--shadow-soft);
 }
 
 .submit-button:hover:not(:disabled) {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange, #ff5722);
+  box-shadow: var(--shadow-soft);
 }
 
 .submit-button:active:not(:disabled) {

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -26,11 +26,11 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   margin-bottom: 20px;
 }
 
@@ -38,7 +38,7 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: #1f1d18;
+  background: var(--border);
 }
 
 /* Story block */
@@ -47,20 +47,20 @@
 }
 
 .ni-story-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 13px;
   font-style: italic;
   font-weight: 300;
   letter-spacing: 0.03em;
-  color: #6e6a60;
+  color: var(--muted);
   margin-bottom: 20px;
   line-height: 1.5;
   text-transform: none;
 }
 
 .ni-not-implemented {
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 0.85rem;
 }
 
@@ -72,11 +72,11 @@
 /* Continue button */
 .ni-continue-btn {
   align-self: flex-end;
-  background: #ff4d1c;
-  color: #0c0c0c;
+  background: var(--accent-primary);
+  color: var(--bg);
   border: none;
   padding: 14px 28px;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 16px;
   font-weight: 700;
   font-style: italic;
@@ -91,7 +91,7 @@
 .ni-continue-btn:active { opacity: 0.7; }
 
 .ni-continue-arrow {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.8em;
   font-style: normal;
 }
@@ -111,7 +111,7 @@
   font-size: 1.05rem;
   line-height: 1.8;
   margin-bottom: 0.75rem;
-  color: #f4f1ea;
+  color: var(--text);
   opacity: 0;
   transform: translateY(10px);
   transition: opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1),
@@ -125,10 +125,10 @@
 
 .story-sentence .highlight {
   color: #ffffff;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   font-weight: 700;
   padding: 0.1em 0.35em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.88em;
   text-transform: uppercase;
 }
@@ -146,7 +146,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 1.25rem 0;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   gap: 1.5rem;
 }
 
@@ -157,16 +157,16 @@
 /* Verb lemma */
 .verb-lemma {
   font-size: 0.95rem;
-  color: #f4f1ea;
+  color: var(--text);
   letter-spacing: 0.06em;
   text-transform: uppercase;
   font-weight: 700;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   flex-shrink: 0;
 }
 
-.lemma-stem  { color: #f4f1ea; }
-.group-label { color: #ff4d1c; opacity: 0.85; }
+.lemma-stem  { color: var(--text); }
+.group-label { color: var(--accent-primary); opacity: 0.85; }
 
 /* Verb deconstruction row */
 .verb-deconstruction {
@@ -174,7 +174,7 @@
   align-items: center;
   justify-content: flex-end;
   gap: 0.6rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 1rem;
   font-weight: 600;
   flex-grow: 1;
@@ -182,22 +182,22 @@
 }
 
 /* Irregular forms */
-.verb-deconstruction.irregular .conjugated-form { color: #f4f1ea; }
+.verb-deconstruction.irregular .conjugated-form { color: var(--text); }
 
 .verb-deconstruction.irregular .conjugated-form .irreg-frag {
-  color: #ff4d1c;
+  color: var(--accent-primary);
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: #ff4d1c;
+  text-decoration-color: var(--accent-primary);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
 
 .irreg-frag {
-  color: #ff4d1c !important;
+  color: var(--accent-primary) !important;
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: #ff4d1c;
+  text-decoration-color: var(--accent-primary);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
@@ -212,15 +212,15 @@
 }
 
 .verb-deconstruction.irregular .form-separator {
-  color: #6e6a60;
+  color: var(--muted);
 }
 
 /* Stem box */
 .verb-stem {
-  color: #f4f1ea;
+  color: var(--text);
   background: transparent;
   padding: 0.4rem 0.8rem;
-  border: 1px solid #2a2823;
+  border: 1px solid var(--border-strong);
   text-transform: uppercase;
   font-weight: 700;
   letter-spacing: 0.05em;
@@ -238,8 +238,8 @@
 }
 
 .ending-item {
-  color: #0c0c0c;
-  background: #f4f1ea;
+  color: var(--bg);
+  background: var(--text);
   padding: 0.4rem 0.65rem;
   font-size: 1em;
   font-weight: 700;
@@ -267,7 +267,7 @@
 .deconstruction-item.future-root-group,
 .deconstruction-item.nonfinite-irregular-group {
   border: none;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   padding: 1.5rem 0;
   display: flex;
   flex-direction: column;
@@ -281,11 +281,11 @@
 .deconstruction-item.nonfinite-irregular-group::before {
   all: unset;
   display: block;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #2a2823;
+  color: var(--border-strong);
   align-self: flex-start;
 }
 
@@ -307,7 +307,7 @@
   gap: 0.6rem;
   align-items: center;
   padding: 1rem 1.25rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   min-width: 140px;
 }
 
@@ -315,37 +315,37 @@
   font-size: 1.3rem;
   font-weight: 800;
   color: #ffffff;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   padding: 0.15rem 0.5rem;
   letter-spacing: 0.06em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 .regular-stem-base {
   font-size: 1.1rem;
   font-weight: 500;
-  color: #f4f1ea;
+  color: var(--text);
   letter-spacing: 0.02em;
 }
 
 .regular-stem-suffix {
   font-size: 1.1rem;
-  color: #2a2823;
+  color: var(--border-strong);
 }
 
 .regular-ending-highlight {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #ff4d1c;
+  color: var(--accent-primary);
   letter-spacing: 0.04em;
   text-decoration: underline;
-  text-decoration-color: rgba(255, 77, 28, 0.4);
+  text-decoration-color: rgba(242, 242, 240, 0.4);
   text-underline-offset: 3px;
 }
 
 .future-root-example {
   font-size: 0.9rem;
-  color: #6e6a60;
+  color: var(--muted);
   text-align: center;
 }
 
@@ -357,20 +357,20 @@
 }
 
 .root-endings-title {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9.5px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: #6e6a60;
+  color: var(--muted);
 }
 
 /* Non-finite (gerund / participle) */
 .nonfinite-title {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9.5px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: #6e6a60;
+  color: var(--muted);
   align-self: center;
 }
 
@@ -385,41 +385,41 @@
   display: flex;
   align-items: center;
   gap: 0.65rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 0.75rem 1rem;
 }
 
-.nonfinite-item .arrow { color: #6e6a60; font-weight: 700; }
+.nonfinite-item .arrow { color: var(--muted); font-weight: 700; }
 
 .narrative-introduction .nonfinite-highlight {
   font-weight: 800;
   color: #ffffff;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   padding: 0.15rem 0.45rem;
   letter-spacing: 0.05em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 /* ── Verb lemma large (used in group items) ── */
 
 .verb-lemma-large {
   font-size: 1.3rem;
-  color: #f4f1ea;
+  color: var(--text);
   letter-spacing: 0.02em;
   text-transform: uppercase;
   font-weight: 800;
 }
 
-.lemma-stem-large  { color: #f4f1ea; font-weight: 800; }
-.group-label-large { color: #f4f1ea; opacity: 0.45; font-weight: 800; }
+.lemma-stem-large  { color: var(--text); font-weight: 800; }
+.group-label-large { color: var(--text); opacity: 0.45; font-weight: 800; }
 
 .stem-vowel-highlight-large {
   color: #ffffff;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   font-weight: 800;
   font-size: 1.05em;
   padding: 0 0.12em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 /* ── Strong preterites ── */
@@ -448,7 +448,7 @@
 }
 
 .strong-verb-item .arrow {
-  color: #6e6a60;
+  color: var(--muted);
   font-weight: 700;
   font-size: 1.1rem;
 }
@@ -456,15 +456,15 @@
 .irregular-stem-large {
   font-size: 1.3rem;
   font-weight: 800;
-  color: #0c0c0c;
-  background: #f4f1ea;
+  color: var(--bg);
+  background: var(--text);
   padding: 0.4rem 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 .plus-symbol {
   font-size: 1.3rem;
-  color: #2a2823;
+  color: var(--border-strong);
   font-weight: 600;
   animation: fadeIn 0.4s ease-in-out 0.4s both;
 }
@@ -482,12 +482,12 @@
 }
 
 .strong-ending-item {
-  color: #0c0c0c;
-  background: #f4f1ea;
+  color: var(--bg);
+  background: var(--text);
   padding: 0.35rem 0.7rem;
   font-size: 0.95rem;
   font-weight: 700;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   text-transform: uppercase;
   animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   opacity: 0;
@@ -511,7 +511,7 @@
 
 .irregular-yo-verb-complete {
   border: none;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   padding: 1.25rem 0;
   display: flex;
   flex-direction: column;
@@ -531,9 +531,9 @@
   font-size: 1.3rem;
   font-weight: 800;
   color: #ffffff;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   padding: 0.4rem 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   text-transform: uppercase;
 }
 
@@ -542,30 +542,30 @@
   flex-wrap: wrap;
   gap: 0.35rem;
   padding-top: 0.75rem;
-  border-top: 1px solid #1f1d18;
+  border-top: 1px solid var(--border);
 }
 
 .irregular-yo-verb-complete .form-item {
   font-size: 0.9rem;
-  color: #6e6a60;
+  color: var(--muted);
   padding: 0.3rem 0.65rem;
   background: transparent;
-  border: 1px solid #1f1d18;
-  font-family: 'JetBrains Mono', monospace;
+  border: 1px solid var(--border);
+  font-family: var(--font-ui);
 }
 
 .irregular-yo-verb-complete .form-item.yo-form-irregular {
   font-weight: 800;
-  color: #f4f1ea;
-  background: #2a2823;
-  border-color: #2a2823;
+  color: var(--text);
+  background: var(--border-strong);
+  border-color: var(--border-strong);
 }
 
 /* ── Third-person irregulars ── */
 
 .deconstruction-item.third-person-irregular-group {
   border: none;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   padding: 1.5rem 0;
   display: flex;
   flex-direction: column;
@@ -599,22 +599,22 @@
   gap: 0.65rem;
   padding: 1rem;
   width: 100%;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
 }
 
 .regular-forms-title {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9.5px;
-  color: #6e6a60;
+  color: var(--muted);
   font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .irregular-forms-title {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9.5px;
-  color: #ff4d1c;
+  color: var(--accent-primary);
   font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -634,7 +634,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 0.7rem 0.9rem;
   animation: fadeSlideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
@@ -643,14 +643,14 @@
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-weight: 600;
   font-size: 0.9rem;
 }
 
-.normal-stem          { color: #6e6a60; }
-.arrow                { color: #2a2823; font-weight: 700; }
-.irregular-stem-highlight { color: #ff4d1c; font-weight: 700; }
+.normal-stem          { color: var(--muted); }
+.arrow                { color: var(--border-strong); font-weight: 700; }
+.irregular-stem-highlight { color: var(--accent-primary); font-weight: 700; }
 
 .resulting-forms {
   display: flex;
@@ -659,21 +659,21 @@
 }
 
 .irregular-form {
-  color: #f4f1ea;
+  color: var(--text);
   padding: 0.2rem 0.4rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   font-size: 0.8rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 .regular-ending-item {
-  color: #6e6a60;
+  color: var(--muted);
   background: transparent;
   padding: 0.3rem 0.5rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   font-size: 0.88rem;
   font-weight: 600;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   animation: fadeSlideUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
   opacity: 0;
   transform: translateY(10px);
@@ -691,20 +691,20 @@
 }
 
 .infinitive-part {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.9rem;
-  color: #6e6a60;
-  border: 1px solid #1f1d18;
+  color: var(--muted);
+  border: 1px solid var(--border);
   padding: 0.3rem 0.6rem;
 }
 
 .irregular-stem {
   font-size: 1rem;
   font-weight: 800;
-  color: #0c0c0c;
-  background: #f4f1ea;
+  color: var(--bg);
+  background: var(--text);
   padding: 0.35rem 0.7rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 /* ── Paradigm table (terminaciones) ── */
@@ -712,7 +712,7 @@
 .ni-paradigm-table {
   width: 100%;
   margin-bottom: 1.5rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   overflow-x: auto;
 }
 
@@ -721,7 +721,7 @@
   display: grid;
   grid-template-columns: 7rem repeat(var(--pronoun-count, 6), minmax(4rem, 1fr));
   align-items: center;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
 }
 
 .ni-paradigm-row:last-child { border-bottom: none; }
@@ -729,14 +729,14 @@
 .ni-paradigm-header { background: rgba(255,255,255,0.02); }
 
 .ni-paradigm-pronoun {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #2a2823;
+  color: var(--border-strong);
   padding: 0.5rem 0.4rem;
   text-align: center;
-  border-left: 1px solid #1f1d18;
+  border-left: 1px solid var(--border);
 }
 
 .ni-paradigm-lemma-cell {
@@ -744,45 +744,45 @@
 }
 
 .ni-paradigm-lemma {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #f4f1ea;
+  color: var(--text);
   padding: 0.75rem 0.75rem;
-  border-right: 1px solid #1f1d18;
+  border-right: 1px solid var(--border);
   white-space: nowrap;
 }
 
 .ni-paradigm-cell {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.82rem;
   padding: 0.75rem 0.3rem;
   text-align: center;
-  border-left: 1px solid #1f1d18;
+  border-left: 1px solid var(--border);
   white-space: nowrap;
 }
 
 .ni-form-stem {
-  color: #6e6a60;
+  color: var(--muted);
   font-weight: 400;
 }
 
 .ni-form-ending {
-  color: #f4f1ea;
+  color: var(--text);
   font-weight: 700;
 }
 
 .ni-cell-empty { opacity: 0.35; }
 .ni-form-empty {
-  color: #2a2823;
+  color: var(--border-strong);
   font-size: 0.7rem;
 }
 
 /* Chip de grupo verbal en panel izquierdo */
 .vo-group-chip {
-  color: #ff4d1c !important;
+  color: var(--accent-primary) !important;
   font-style: normal !important;
 }
 

--- a/src/components/learning/NarrativeIntroduction.jsx
+++ b/src/components/learning/NarrativeIntroduction.jsx
@@ -16,10 +16,10 @@ import './NarrativeIntroduction.css';
 import '../onboarding/OnboardingFlow.css';
 import { useSettings } from '../../state/settings.js';
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
 import { LEARNING_IRREGULAR_FAMILIES } from '../../lib/data/learningIrregularFamilies.js';
 import { highlightStemVowel } from './highlightHelpers.js';
 
@@ -945,9 +945,9 @@ function NarrativeIntroduction({ tense, exampleVerbs = [], onBack, onContinue })
       <div className="verbos-onboarding">
         <div className="vo-grid" aria-hidden="true" />
         <div className="vo-vignette" aria-hidden="true" />
-        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', color: INK2, fontFamily: 'JetBrains Mono, monospace' }}>
+        <div style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', color: INK2, fontFamily: 'var(--font-ui)' }}>
           <p>No hay tiempo seleccionado.</p>
-          <button onClick={handleAnimatedBack} style={{ marginTop: 16, background: ACCENT, color: '#0c0c0c', border: 'none', padding: '12px 24px', fontFamily: 'JetBrains Mono, monospace', cursor: 'pointer' }}>
+          <button onClick={handleAnimatedBack} style={{ marginTop: 16, background: ACCENT, color: 'var(--bg)', border: 'none', padding: '12px 24px', fontFamily: 'var(--font-ui)', cursor: 'pointer' }}>
             ← volver
           </button>
         </div>
@@ -1406,7 +1406,7 @@ function NarrativeIntroduction({ tense, exampleVerbs = [], onBack, onContinue })
           <span className="vo-breadcrumb-sep">/</span>
           <span className="vo-breadcrumb-val"> {tenseName.toLowerCase()}</span>
         </div>
-        <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
+        <div style={{ fontFamily: 'var(--font-ui)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
           INTRO · <span style={{ color: INK }}>01</span>
         </div>
       </header>

--- a/src/components/learning/PronunciationPractice.css
+++ b/src/components/learning/PronunciationPractice.css
@@ -164,7 +164,7 @@
 }
 
 .ipa-notation span {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-size: 1.2em;
   background: #222;
   padding: 6px 12px;
@@ -201,7 +201,7 @@
 
 .record-btn {
   background: #222;
-  border: 1px solid #dc2626;
+  border: 1px solid var(--accent-error);
   border-radius: 6px;
   color: white;
   font-size: 1.2em;
@@ -218,7 +218,7 @@
 
 .record-btn:hover:not(:disabled) {
   background: #333;
-  border-color: #ef4444;
+  border-color: var(--accent-error);
   transform: translateY(-1px);
 }
 
@@ -229,8 +229,8 @@
 }
 
 .record-btn.recording {
-  background: #dc2626;
-  border-color: #dc2626;
+  background: var(--accent-error);
+  border-color: var(--accent-error);
   animation: pulse-recording 1.5s infinite;
 }
 
@@ -246,7 +246,7 @@
 .mic-icon {
   display: inline-block;
   font-size: 18px;
-  color: #dc2626;
+  color: var(--accent-error);
   opacity: 0.9;
 }
 
@@ -305,12 +305,12 @@
 }
 
 .recording-result.needs-work {
-  border-left-color: #ef4444;
+  border-left-color: var(--accent-error);
   background: rgba(239, 68, 68, 0.05);
 }
 
 .recording-result.error {
-  border-left-color: #dc2626;
+  border-left-color: var(--accent-error);
   background: rgba(220, 38, 38, 0.05);
 }
 
@@ -347,7 +347,7 @@
 }
 
 .recording-result.needs-work .score-number {
-  color: #ef4444;
+  color: var(--accent-error);
 }
 
 .score-label {
@@ -384,7 +384,7 @@
 }
 
 .recording-result.needs-work .accuracy-fill {
-  background: #ef4444;
+  background: var(--accent-error);
 }
 
 .feedback {
@@ -633,7 +633,7 @@
 }
 
 .compatibility-error h3 {
-  color: #ef4444;
+  color: var(--accent-error);
   margin-bottom: 20px;
   font-size: 1.3em;
   font-weight: 600;

--- a/src/components/learning/SessionSummary.jsx
+++ b/src/components/learning/SessionSummary.jsx
@@ -28,8 +28,8 @@ function SessionSummary({ onFinish, summary = {} }) {
       'C-': '#d97706',
       'D+': '#fb923c',
       'D': '#ea580c',
-      'D-': '#dc2626',
-      'F': '#ef4444'
+      'D-': 'var(--accent-error)',
+      'F': 'var(--accent-error)'
     };
     return colors[grade] || '#6b7280';
   };

--- a/src/components/levels/PlacementTest.css
+++ b/src/components/levels/PlacementTest.css
@@ -22,7 +22,7 @@
   max-width: 800px;
   width: 100%;
   text-align: center;
-  box-shadow: 12px 12px 0px #fff;
+  box-shadow: var(--shadow-soft);
   position: relative;
 }
 
@@ -67,7 +67,7 @@
 
 .test-start-card:hover {
   transform: translate(-4px, -4px);
-  box-shadow: 8px 8px 0px #fff;
+  box-shadow: var(--shadow-soft);
   background: #fff;
 }
 
@@ -82,7 +82,7 @@
 
 .start-title {
   font-size: 2rem;
-  font-weight: 900;
+  font-weight: 600;
   color: #fff;
   display: block;
   margin-bottom: 0.5rem;
@@ -140,7 +140,7 @@
   padding: 3rem;
   max-width: 900px;
   width: 100%;
-  box-shadow: 12px 12px 0px #fff;
+  box-shadow: var(--shadow-soft);
   position: relative;
 }
 
@@ -194,7 +194,7 @@
 
 .level-badge {
   font-size: 2rem;
-  font-weight: 900;
+  font-weight: 600;
   color: #fff;
   background: #000;
   border: 2px solid #fff;
@@ -249,14 +249,14 @@
 .option-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 4px 4px 0px #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .option-card.selected {
   background: #fff;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 4px 4px 0px #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .option-card.selected .option-text,
@@ -285,23 +285,23 @@
 
 /* FEEDBACK COLORS */
 .option-card.correct {
-  border-color: #4ade80 !important;
+  border-color: var(--accent-success) !important;
   /* Green */
-  box-shadow: 4px 4px 0px #4ade80 !important;
+  box-shadow: 0 0 0 2px var(--accent-success) !important;
 }
 
 .option-card.correct .option-text {
-  color: #4ade80;
+  color: var(--accent-success);
 }
 
 .option-card.incorrect {
-  border-color: #ef4444 !important;
+  border-color: var(--accent-error) !important;
   /* Red */
-  box-shadow: 4px 4px 0px #ef4444 !important;
+  box-shadow: 0 0 0 2px var(--accent-error) !important;
 }
 
 .option-card.incorrect .option-text {
-  color: #ef4444;
+  color: var(--accent-error);
 }
 
 
@@ -330,7 +330,7 @@
   padding: 1rem 3rem;
   background: #fff;
   color: #000;
-  font-weight: 900;
+  font-weight: 600;
   text-transform: uppercase;
   font-size: 1.1rem;
   border: 2px solid #fff;
@@ -340,7 +340,7 @@
 
 .submit-button-modern:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 4px 4px 0px #fff;
+  box-shadow: var(--shadow-soft);
   /* Shadow on white button? Maybe inverse */
   background: #000;
   color: #fff;
@@ -361,7 +361,7 @@
   padding: 4rem;
   max-width: 800px;
   width: 100%;
-  box-shadow: 16px 16px 0px #fff;
+  box-shadow: var(--shadow-soft);
   text-align: center;
 }
 
@@ -371,7 +371,7 @@
 
 .result-level-text {
   font-size: 8rem;
-  font-weight: 900;
+  font-weight: 600;
   color: #fff;
   line-height: 1;
   display: block;
@@ -425,7 +425,7 @@
   .placement-test-intro,
   .placement-test-active {
     padding: 1.5rem;
-    box-shadow: 6px 6px 0px #fff;
+    box-shadow: var(--shadow-soft);
   }
 
   .test-progress-section {

--- a/src/components/levels/PlacementTest.jsx
+++ b/src/components/levels/PlacementTest.jsx
@@ -289,7 +289,7 @@ function PlacementTest({ onComplete, onCancel }) {
         {/* EXPLANATION / FEEDBACK OVERLAY or INLINE */}
         {showExplanation && feedbackResult && (
           <div style={{ marginTop: '2rem', borderTop: '2px solid #333', paddingTop: '1rem', textAlign: 'left' }}>
-            <span style={{ color: feedbackResult.isCorrect ? '#4ade80' : '#ef4444', fontWeight: 'bold', textTransform: 'uppercase' }}>
+            <span style={{ color: feedbackResult.isCorrect ? 'var(--accent-success)' : 'var(--accent-error)', fontWeight: 'bold', textTransform: 'uppercase' }}>
               {feedbackResult.isCorrect ? '¡CORRECTO!' : 'INCORRECTO'}
             </span>
             <p style={{ color: '#888', marginTop: '0.5rem' }}>

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -1,11 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 .verbos-onboarding {
   position: fixed;
   inset: 0;
-  background: #0c0c0c;
-  color: #f4f1ea;
-  font-family: 'Inter Tight', -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
   -webkit-font-smoothing: antialiased;
   font-feature-settings: 'ss01', 'ss02', 'cv11';
   overflow: hidden;
@@ -19,8 +18,8 @@
 }
 
 .verbos-onboarding ::selection {
-  background: #ff4d1c;
-  color: #0c0c0c;
+  background: var(--accent-primary);
+  color: var(--bg);
 }
 
 /* ── Scrollbar hidden ── */
@@ -44,7 +43,7 @@
 }
 
 .vo-scan-in {
-  animation: voScanIn 0.45s cubic-bezier(0.7, 0, 0.2, 1) both;
+  animation: voLiftIn 0.4s cubic-bezier(0.2, 0.9, 0.3, 1) both;
 }
 
 .vo-lift-in {
@@ -64,13 +63,13 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 20px;
-  border-bottom: 1px solid #1f1d18;
-  background: #0c0c0c;
-  font-family: 'JetBrains Mono', monospace;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   z-index: 50;
 }
 
@@ -82,19 +81,19 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 20px;
-  border-top: 1px solid #1f1d18;
-  background: #0c0c0c;
-  font-family: 'JetBrains Mono', monospace;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-ui);
   font-size: 9.5px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: #6e6a60;
+  color: var(--muted);
   z-index: 50;
 }
 
 .vo-footer-hints { display: flex; gap: 16px; }
 .vo-footer-hints span { white-space: nowrap; }
-.vo-footer-hints em { font-style: normal; color: #6e6a60; }
+.vo-footer-hints em { font-style: normal; color: var(--muted); }
 
 .vo-header-left {
   display: flex;
@@ -108,8 +107,8 @@
   gap: 6px;
   background: none;
   border: none;
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -120,7 +119,7 @@
 }
 
 .vo-back-btn:hover {
-  color: #ff4d1c;
+  color: var(--accent-primary);
 }
 
 .vo-logo {
@@ -134,12 +133,12 @@
 .vo-logo-dot {
   width: 8px;
   height: 8px;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   flex-shrink: 0;
 }
 
 .vo-logo-name {
-  color: #f4f1ea;
+  color: var(--text);
   font-weight: 700;
   letter-spacing: 0.18em;
 }
@@ -152,37 +151,17 @@
   max-width: 40%;
 }
 
-.vo-breadcrumb-sep { color: #2a2823; }
-.vo-breadcrumb-label { color: #6e6a60; }
-.vo-breadcrumb-val { color: #f4f1ea; margin-left: 4px; }
+.vo-breadcrumb-sep { color: var(--border-strong); }
+.vo-breadcrumb-label { color: var(--muted); }
+.vo-breadcrumb-val { color: var(--text); margin-left: 4px; }
 
-.vo-step-counter span { color: #f4f1ea; }
+.vo-step-counter span { color: var(--text); }
 
 /* ── Background grid ── */
-.vo-grid {
-  position: fixed;
-  inset: 44px 0 32px 0;
-  background-image:
-    linear-gradient(#1f1d18 1px, transparent 1px),
-    linear-gradient(90deg, #1f1d18 1px, transparent 1px);
-  background-size: 64px 64px;
-  opacity: 0.55;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.vo-vignette {
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,0.5) 100%);
-  pointer-events: none;
-  z-index: 1;
-}
-
+.vo-grid,
+.vo-vignette,
 .vo-crosshair {
-  position: fixed;
-  pointer-events: none;
-  z-index: 2;
+  display: none;
 }
 
 /* ── Two-panel step view ── */
@@ -200,7 +179,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  border-right: 1px solid #1f1d18;
+  border-right: 1px solid var(--border);
   overflow: hidden;
   min-width: 0;
 }
@@ -208,24 +187,24 @@
 .vo-step-tag {
   position: absolute;
   top: 24px; right: 24px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   letter-spacing: 0.16em;
-  color: #2a2823;
+  color: var(--border-strong);
 }
 
 .vo-watermark {
   position: absolute;
   top: 54px; right: 24px;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-display);
   font-size: clamp(160px, 26vw, 400px);
-  font-weight: 900;
+  font-weight: 500;
   font-style: italic;
-  letter-spacing: -0.06em;
-  color: #2a2823;
+  letter-spacing: -0.04em;
+  color: var(--border-strong);
   line-height: 0.78;
   pointer-events: none;
-  opacity: 0.45;
+  opacity: 0.4;
   user-select: none;
 }
 
@@ -236,28 +215,28 @@
 }
 
 .vo-aux {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   letter-spacing: 0.16em;
-  color: #6e6a60;
+  color: var(--muted);
   text-transform: uppercase;
   margin-bottom: 16px;
 }
 
 .vo-prompt {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 22px;
   font-weight: 300;
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: -0.01em;
   margin-bottom: 8px;
 }
 
 .vo-focal-word {
-  font-family: 'Inter Tight', sans-serif;
-  font-weight: 900;
+  font-family: var(--font-display);
+  font-weight: 600;
   font-style: italic;
-  letter-spacing: -0.055em;
+  letter-spacing: -0.03em;
   line-height: 0.9;
   text-transform: lowercase;
   overflow-wrap: break-word;
@@ -271,8 +250,8 @@
   display: flex;
   gap: 20px;
   padding-top: 16px;
-  border-top: 1px dashed #2a2823;
-  font-family: 'JetBrains Mono', monospace;
+  border-top: 1px dashed var(--border-strong);
+  font-family: var(--font-ui);
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -281,8 +260,8 @@
 }
 
 .vo-meta-item { display: flex; flex-direction: column; gap: 4px; }
-.vo-meta-key { color: #6e6a60; }
-.vo-meta-val { color: #f4f1ea; }
+.vo-meta-key { color: var(--muted); }
+.vo-meta-val { color: var(--text); }
 .vo-meta-ex { font-style: italic; text-transform: none; letter-spacing: 0.04em; }
 
 .vo-meta-right { margin-left: auto; text-align: right; }
@@ -301,17 +280,17 @@
 .vo-options-label {
   position: absolute;
   top: 24px; left: 40px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   letter-spacing: 0.16em;
-  color: #2a2823;
+  color: var(--border-strong);
 }
 
 .vo-options-list { display: flex; flex-direction: column; }
 
 .vo-option {
   position: relative;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
   cursor: pointer;
   display: flex;
   align-items: baseline;
@@ -326,7 +305,7 @@
   left: 0;
   top: 50%;
   transform: translateY(-50%);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 700;
   display: flex;
@@ -354,7 +333,7 @@
 }
 
 .vo-option-label {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   letter-spacing: -0.025em;
   text-transform: lowercase;
   line-height: 1.05;
@@ -364,7 +343,7 @@
 }
 
 .vo-option-tag {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 9.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -374,7 +353,7 @@
 }
 
 .vo-option-arrow {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 16px;
   width: 16px;
   transition: all 0.18s;
@@ -386,7 +365,7 @@
   position: absolute;
   top: 44px; bottom: 32px; left: 0; right: 0;
   z-index: 10;
-  background: #0c0c0c;
+  background: var(--bg);
   overflow-y: auto;
   display: flex;
   align-items: flex-start;
@@ -406,27 +385,27 @@
 }
 
 .placement-report-modal {
-  background: #141412;
-  border: 1px solid #1f1d18;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
   max-width: 560px;
   width: 100%;
   max-height: 80vh;
   overflow-y: auto;
   padding: 40px;
-  font-family: 'JetBrains Mono', monospace;
-  color: #f4f1ea;
+  font-family: var(--font-ui);
+  color: var(--text);
 }
 
 .placement-report-header { margin-bottom: 32px; }
 .placement-report-header h3 {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-display);
   font-size: 28px;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.02em;
   margin-bottom: 8px;
 }
-.placement-report-header p { font-size: 11px; letter-spacing: 0.12em; color: #6e6a60; text-transform: uppercase; }
+.placement-report-header p { font-size: 11px; letter-spacing: 0.12em; color: var(--muted); text-transform: uppercase; }
 
 .placement-report-summary {
   display: grid;
@@ -436,20 +415,20 @@
 }
 
 .summary-card {
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 14px;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.summary-label { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: #6e6a60; }
-.summary-value { font-size: 28px; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-style: italic; }
+.summary-label { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
+.summary-value { font-size: 28px; font-family: var(--font-display); font-weight: 600; font-style: italic; }
 
 .placement-report-section { margin-bottom: 20px; }
-.placement-report-section h4 { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: #6e6a60; margin-bottom: 10px; }
+.placement-report-section h4 { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin-bottom: 10px; }
 .placement-report-section ul { list-style: none; display: flex; flex-direction: column; gap: 6px; }
-.placement-report-section li { font-size: 12px; letter-spacing: 0.06em; padding: 8px 0; border-bottom: 1px solid #1f1d18; }
+.placement-report-section li { font-size: 12px; letter-spacing: 0.06em; padding: 8px 0; border-bottom: 1px solid var(--border); }
 
 .placement-report-actions {
   display: flex;
@@ -459,7 +438,7 @@
 }
 
 .placement-report-button {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -471,9 +450,9 @@
 }
 
 .placement-report-button:hover { opacity: 0.8; }
-.placement-report-button.primary { background: #ff4d1c; color: #0c0c0c; flex: 1; }
-.placement-report-button.secondary { background: transparent; color: #f4f1ea; border: 1px solid #1f1d18; }
-.placement-report-button.ghost { background: transparent; color: #6e6a60; }
+.placement-report-button.primary { background: var(--accent-primary); color: var(--bg); flex: 1; }
+.placement-report-button.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+.placement-report-button.ghost { background: transparent; color: var(--muted); }
 
 /* ── Mobile ── */
 @media (max-width: 680px) {
@@ -487,7 +466,7 @@
 
   .vo-left {
     border-right: none;
-    border-bottom: 1px solid #1f1d18;
+    border-bottom: 1px solid var(--border);
     padding: 28px 20px 24px 20px;
     min-height: 0;
   }

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -11,11 +11,11 @@ import {
 } from '../../lib/data/simplifiedFamilyGroups.js'
 
 /* ── Design tokens ── */
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
-const LINE   = '#1f1d18'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
+const LINE   = 'var(--border)'
 
 /* ── Static option datasets ── */
 const MOOD_OPTS = [
@@ -991,7 +991,7 @@ function OnboardingFlow({
           }
         </div>
 
-        <div className="vo-step-counter" style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
+        <div className="vo-step-counter" style={{ fontFamily: 'var(--font-ui)', fontSize: 10, letterSpacing: '0.14em', textTransform: 'uppercase', color: INK2 }}>
           STEP <span>{String(onboardingStep).padStart(2, '0')}</span> / {String(TOTAL_STEPS).padStart(2, '0')}
         </div>
       </header>

--- a/src/components/progress/ProgressJourney.css
+++ b/src/components/progress/ProgressJourney.css
@@ -271,7 +271,7 @@
 }
 
 .connector-line.completed {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .connector-line.remaining {
@@ -294,7 +294,7 @@
 
 .milestone.achieved .milestone-icon {
   animation: milestone-achieved 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-  border-color: #5ee6a5;
+  border-color: var(--accent-success);
 }
 
 @keyframes milestone-achieved {
@@ -318,7 +318,7 @@
 .milestone-info:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .milestone.achieved .milestone-info {
@@ -349,7 +349,7 @@
 }
 
 .achievement-badge {
-  background: #5ee6a5;
+  background: var(--accent-success);
   color: #000;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -416,7 +416,7 @@
   border-style: solid;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .next-icon {
@@ -490,7 +490,7 @@
 .insight-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .insight-icon {
@@ -511,11 +511,11 @@
 }
 
 .insight-value.positive {
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 .insight-value.negative {
-  color: #ff6b6b;
+  color: var(--accent-error);
 }
 
 .insight-value.neutral {

--- a/src/components/progress/ProgressJourney.jsx
+++ b/src/components/progress/ProgressJourney.jsx
@@ -103,7 +103,7 @@ export default function ProgressJourney({ compact = false }) {
         threshold: 250,
         achieved: totalAttempts >= 250,
         value: Math.min(totalAttempts, 250),
-        color: '#ef4444'
+        color: 'var(--accent-error)'
       },
       {
         id: 'spanish_warrior',

--- a/src/components/sync/SyncStatusIndicator.css
+++ b/src/components/sync/SyncStatusIndicator.css
@@ -7,7 +7,7 @@
   z-index: 9999;
   cursor: pointer;
   user-select: none;
-  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  font-family: var(--font-ui), var(--font-mono);
 }
 
 .sync-status-badge {
@@ -48,12 +48,12 @@
 }
 
 .sync-status-indicator.error .sync-status-badge {
-  border-color: #ff0000;
+  border-color: var(--accent-error);
   background: #220000;
 }
 
 .sync-status-indicator.error .status-code {
-  color: #ff0000;
+  color: var(--accent-error);
 }
 
 .sync-status-indicator.offline .sync-status-badge {
@@ -89,7 +89,7 @@
   background: #000;
   border: 1px solid #fff;
   padding: 16px;
-  box-shadow: 8px 8px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-soft);
 }
 
 .tooltip-header {
@@ -124,7 +124,7 @@
 .status-row .value {
   color: #fff;
   text-align: right;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
 }
 
 .status-row.warning .value {
@@ -133,7 +133,7 @@
 }
 
 .status-row.error .value {
-  color: #ff0000;
+  color: var(--accent-error);
   font-weight: bold;
 }
 

--- a/src/features/drill/session-progress-hud.css
+++ b/src/features/drill/session-progress-hud.css
@@ -18,7 +18,7 @@
 }
 
 .session-progress-hud.completed {
-  border-color: #5ee6a5;
+  border-color: var(--accent-success);
 }
 
 .hud-header {
@@ -58,7 +58,7 @@
 
 .hud-header .btn:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -109,7 +109,7 @@
 
 .progress-fill {
   height: 100%;
-  background: #5ee6a5;
+  background: var(--accent-success);
   transition: width 0.3s ease;
 }
 
@@ -232,12 +232,12 @@
   width: 100%;
   transition: all 0.15s ease;
   cursor: pointer;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .session-progress-hud.completed .btn-primary:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .session-progress-hud.completed .btn-primary:active {

--- a/src/features/progress/EnhancedErrorAnalysis.css
+++ b/src/features/progress/EnhancedErrorAnalysis.css
@@ -68,7 +68,7 @@
   color: var(--text);
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .view-btn:active {
@@ -80,7 +80,7 @@
   background: #fff;
   color: #000;
   border-color: #fff;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .view-btn .view-icon {
@@ -167,7 +167,7 @@
 .dashboard-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .dashboard-card:active {
@@ -228,7 +228,7 @@
   background: transparent;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .action-btn:active {
@@ -324,7 +324,7 @@
 .pattern-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .pattern-card:active {
@@ -396,12 +396,12 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .pattern-action-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .pattern-action-btn:active {
@@ -475,7 +475,7 @@
 .challenge-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .challenge-card:active {
@@ -590,12 +590,12 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .challenge-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .challenge-btn:active {
@@ -631,7 +631,7 @@
 .timeline-day:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .timeline-day:active {
@@ -784,5 +784,5 @@
 }
 
 .enhanced-error-analysis button:focus {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }

--- a/src/features/progress/ErrorAnalysisForensics.css
+++ b/src/features/progress/ErrorAnalysisForensics.css
@@ -192,7 +192,7 @@
   background: transparent;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .error-item:active {
@@ -259,11 +259,11 @@
 }
 
 .severity-dot.critical {
-  background: #ff6b6b;
+  background: var(--accent-error);
 }
 
 .severity-dot.high {
-  background: #ffd166;
+  background: var(--accent-warning);
 }
 
 .severity-dot.medium {
@@ -271,7 +271,7 @@
 }
 
 .severity-dot.low {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 @keyframes pulse {
@@ -434,11 +434,11 @@
 }
 
 .impact-bar.critical .impact-fill {
-  background: #ff6b6b;
+  background: var(--accent-error);
 }
 
 .impact-bar.high .impact-fill {
-  background: #ffd166;
+  background: var(--accent-warning);
 }
 
 .impact-bar.medium .impact-fill {
@@ -446,7 +446,7 @@
 }
 
 .impact-bar.low .impact-fill {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .metric-value {
@@ -459,11 +459,11 @@
 }
 
 .metric-value.critical {
-  color: #ff6b6b;
+  color: var(--accent-error);
 }
 
 .metric-value.high {
-  color: #ffd166;
+  color: var(--accent-warning);
 }
 
 .metric-value.medium {
@@ -471,7 +471,7 @@
 }
 
 .metric-value.low {
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 /* Contenido de Analisis */
@@ -559,7 +559,7 @@
 }
 
 .bar:hover {
-  background: #ff6b6b;
+  background: var(--accent-error);
   transform: scaleY(1.1);
 }
 
@@ -605,7 +605,7 @@
 
 .pattern-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border-color: #fff;
 }
 
@@ -659,15 +659,15 @@
   gap: 16px;
   padding: 20px;
   background: transparent;
-  border: 1px solid #ff6b6b;
+  border: 1px solid var(--accent-error);
   border-radius: 0;
 }
 
 .period-date {
   background: transparent;
-  color: #ff6b6b;
+  color: var(--accent-error);
   padding: 8px 12px;
-  border: 1px solid #ff6b6b;
+  border: 1px solid var(--accent-error);
   border-radius: 0;
   font-weight: 700;
   font-size: 14px;
@@ -749,7 +749,7 @@
 .trigger-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .linguistic-pattern:active,
@@ -813,13 +813,13 @@
 }
 
 .example .incorrect {
-  color: #ff6b6b;
+  color: var(--accent-error);
   font-family: var(--font-mono);
   font-size: 14px;
 }
 
 .example .correct {
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-family: var(--font-mono);
   font-size: 14px;
 }
@@ -905,7 +905,7 @@
 .error-chain:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .error-chain:active {
@@ -923,9 +923,9 @@
 
 .chain-error {
   background: transparent;
-  color: #ff6b6b;
+  color: var(--accent-error);
   padding: 6px 12px;
-  border: 1px solid #ff6b6b;
+  border: 1px solid var(--accent-error);
   border-radius: 0;
   font-size: 12px;
   font-weight: 700;
@@ -954,11 +954,11 @@
 
 .chain-intervention {
   background: transparent;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   border-radius: 0;
   padding: 12px;
   font-size: 14px;
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 /* Analisis Contextual y Predictivo */
@@ -984,7 +984,7 @@
 .context-factor:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .context-factor:active {
@@ -1032,20 +1032,20 @@
 
 .impact-level.high {
   background: transparent;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
 }
 
 .impact-level.medium {
   background: transparent;
-  color: #ffd166;
-  border: 1px solid #ffd166;
+  color: var(--accent-warning);
+  border: 1px solid var(--accent-warning);
 }
 
 .impact-level.low {
   background: transparent;
-  color: #5ee6a5;
-  border: 1px solid #5ee6a5;
+  color: var(--accent-success);
+  border: 1px solid var(--accent-success);
 }
 
 .factor-description {
@@ -1269,14 +1269,14 @@
 
 .state-impact .impact.high {
   background: transparent;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
 }
 
 .state-impact .impact.positive {
   background: transparent;
-  color: #5ee6a5;
-  border: 1px solid #5ee6a5;
+  color: var(--accent-success);
+  border: 1px solid var(--accent-success);
 }
 
 .state-impact .impact.low {
@@ -1320,23 +1320,23 @@
 }
 
 .risk-card.high {
-  border-color: #ff6b6b;
+  border-color: var(--accent-error);
   background: transparent;
 }
 
 .risk-card.medium {
-  border-color: #ffd166;
+  border-color: var(--accent-warning);
   background: transparent;
 }
 
 .risk-card.low {
-  border-color: #5ee6a5;
+  border-color: var(--accent-success);
   background: transparent;
 }
 
 .risk-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .risk-card:active {
@@ -1379,14 +1379,14 @@
 
 .risk-level.critical {
   background: transparent;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
 }
 
 .risk-level.high {
   background: transparent;
-  color: #ffd166;
-  border: 1px solid #ffd166;
+  color: var(--accent-warning);
+  border: 1px solid var(--accent-warning);
 }
 
 .risk-level.medium {
@@ -1397,8 +1397,8 @@
 
 .risk-level.low {
   background: transparent;
-  color: #5ee6a5;
-  border: 1px solid #5ee6a5;
+  color: var(--accent-success);
+  border: 1px solid var(--accent-success);
 }
 
 .risk-description {
@@ -1461,7 +1461,7 @@
 .projection-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .projection-card:active {
@@ -1489,9 +1489,9 @@
 
 .projection-confidence {
   background: transparent;
-  color: #5ee6a5;
+  color: var(--accent-success);
   padding: 4px 8px;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   border-radius: 0;
   font-size: 12px;
   font-weight: 700;
@@ -1529,7 +1529,7 @@
   min-width: 50px;
   font-family: var(--font-mono);
   font-weight: 700;
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 .point-description {
@@ -1580,7 +1580,7 @@
 .actionable-insight:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .actionable-insight:active {
@@ -1613,20 +1613,20 @@
 
 .priority.high {
   background: transparent;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
 }
 
 .priority.medium {
   background: transparent;
-  color: #ffd166;
-  border: 1px solid #ffd166;
+  color: var(--accent-warning);
+  border: 1px solid var(--accent-warning);
 }
 
 .priority.low {
   background: transparent;
-  color: #5ee6a5;
-  border: 1px solid #5ee6a5;
+  color: var(--accent-success);
+  border: 1px solid var(--accent-success);
 }
 
 .insight-impact {
@@ -1711,12 +1711,12 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-family: var(--font-mono);
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .action-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .action-btn:active {
@@ -1744,7 +1744,7 @@
 .roadmap-step:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .roadmap-step:active {
@@ -1788,9 +1788,9 @@
 
 .step-duration {
   background: transparent;
-  color: #ffd166;
+  color: var(--accent-warning);
   padding: 4px 8px;
-  border: 1px solid #ffd166;
+  border: 1px solid var(--accent-warning);
   border-radius: 0;
   font-size: 12px;
   font-weight: 700;
@@ -1954,5 +1954,5 @@
 }
 
 .error-analysis-forensics button:focus {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }

--- a/src/features/progress/ErrorChallengeSystem.css
+++ b/src/features/progress/ErrorChallengeSystem.css
@@ -37,7 +37,7 @@
 
 .progress-item:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border-color: #fff;
 }
 
@@ -144,7 +144,7 @@
 }
 
 .badge-item.unlocked {
-  border-color: #ffd166;
+  border-color: var(--accent-warning);
 }
 
 .badge-item.locked {
@@ -153,7 +153,7 @@
 
 .badge-item:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .badge-item:active {
@@ -282,7 +282,7 @@
 }
 
 .challenge-card.legendary::before {
-  background: #ffd166;
+  background: var(--accent-warning);
 }
 
 .challenge-card.epic::before {
@@ -294,7 +294,7 @@
 }
 
 .challenge-card.rare::before {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .challenge-card.common::before {
@@ -303,7 +303,7 @@
 
 .challenge-card:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border-color: #fff;
 }
 
@@ -345,7 +345,7 @@
 }
 
 .challenge-difficulty {
-  color: #ffd166;
+  color: var(--accent-warning);
   font-size: 16px;
 }
 
@@ -404,18 +404,18 @@
   gap: 6px;
   padding: 6px 10px;
   background: transparent;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   border-radius: 0;
   font-size: 12px;
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-weight: 700;
   font-family: var(--font-mono);
 }
 
 .reward-item.bonus {
   background: transparent;
-  border-color: #ffd166;
-  color: #ffd166;
+  border-color: var(--accent-warning);
+  color: var(--accent-warning);
 }
 
 .reward-icon {
@@ -469,12 +469,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--font-mono);
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .accept-challenge-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .accept-challenge-btn:active {
@@ -486,10 +486,10 @@
   width: 100%;
   padding: 14px;
   background: transparent;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   border-radius: 0;
   text-align: center;
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -500,10 +500,10 @@
   width: 100%;
   padding: 14px;
   background: transparent;
-  border: 1px solid #ffd166;
+  border: 1px solid var(--accent-warning);
   border-radius: 0;
   text-align: center;
-  color: #ffd166;
+  color: var(--accent-warning);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -594,7 +594,7 @@
   position: absolute;
   width: 6px;
   height: 6px;
-  background: #ffd166;
+  background: var(--accent-warning);
   border-radius: 0;
   animation: particleExplode 2s ease-out infinite;
   animation-delay: var(--delay);
@@ -618,7 +618,7 @@
 
 .unlock-badge {
   background: transparent;
-  border: 2px solid #ffd166;
+  border: 2px solid var(--accent-warning);
   border-radius: 0;
   padding: 40px;
 }
@@ -636,7 +636,7 @@
   margin: 0 0 8px 0;
   font-size: 28px;
   font-weight: 800;
-  color: #ffd166;
+  color: var(--accent-warning);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--font-mono);
@@ -661,7 +661,7 @@
 .unlock-xp {
   font-size: 24px;
   font-weight: 800;
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-family: var(--font-mono);
 }
 
@@ -670,7 +670,7 @@
   text-align: center;
   padding: 80px 40px;
   background: transparent;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   border-radius: 0;
   margin-top: 40px;
 }
@@ -684,7 +684,7 @@
   margin: 0 0 12px 0;
   font-size: 24px;
   font-weight: 800;
-  color: #5ee6a5;
+  color: var(--accent-success);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-family: var(--font-mono);
@@ -799,5 +799,5 @@
 }
 
 .error-challenge-system button:focus {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }

--- a/src/features/progress/InteractiveErrorVisualizations.css
+++ b/src/features/progress/InteractiveErrorVisualizations.css
@@ -44,7 +44,7 @@
   color: var(--text);
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .viz-btn:active {
@@ -56,7 +56,7 @@
   background: #fff;
   color: #000;
   border-color: #fff;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .time-range-selector {
@@ -365,7 +365,7 @@
 .color-solid {
   width: 100px;
   height: 12px;
-  background: #ff6b6b;
+  background: var(--accent-error);
   border-radius: 0;
   border: 1px solid #333;
 }
@@ -528,12 +528,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--font-mono);
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .focus-error-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .focus-error-btn:active {
@@ -647,15 +647,15 @@
 
 /* Hover Effects */
 .constellation-canvas:hover {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .heatmap-canvas:hover {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .network-svg:hover {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 /* Accessibility */
@@ -672,7 +672,7 @@
 }
 
 .interactive-error-visualizations button:focus {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 /* Canvas cursor states */

--- a/src/features/progress/PersonalizedErrorCoach.css
+++ b/src/features/progress/PersonalizedErrorCoach.css
@@ -171,7 +171,7 @@
 .insight-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .insight-card:active {
@@ -224,7 +224,7 @@
 
 .insight-action:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -263,7 +263,7 @@
 .strategy-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .strategy-card:active {
@@ -345,7 +345,7 @@
 
 .apply-strategy-btn:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -450,13 +450,13 @@
 }
 
 .example-item .incorrect {
-  color: #ff6b6b;
+  color: var(--accent-error);
   font-family: var(--font-mono);
   font-size: 13px;
 }
 
 .example-item .correct {
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-family: var(--font-mono);
   font-size: 13px;
 }
@@ -533,8 +533,8 @@
 
 .step.completed {
   background: transparent;
-  border-color: #5ee6a5;
-  color: #5ee6a5;
+  border-color: var(--accent-success);
+  color: var(--accent-success);
 }
 
 .close-session-btn {
@@ -552,8 +552,8 @@
 }
 
 .close-session-btn:hover {
-  border-color: #ff6b6b;
-  color: #ff6b6b;
+  border-color: var(--accent-error);
+  color: var(--accent-error);
 }
 
 .session-content {
@@ -637,7 +637,7 @@
   color: var(--text);
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .back-btn:active,
@@ -659,13 +659,13 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--font-mono);
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .next-step-btn:hover,
 .finish-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .next-step-btn:active,
@@ -747,14 +747,14 @@
 
 .severity-level.high {
   background: transparent;
-  color: #ff6b6b;
-  border: 1px solid #ff6b6b;
+  color: var(--accent-error);
+  border: 1px solid var(--accent-error);
 }
 
 .severity-level.medium {
   background: transparent;
-  color: #ffd166;
-  border: 1px solid #ffd166;
+  color: var(--accent-warning);
+  border: 1px solid var(--accent-warning);
 }
 
 .cause-chain {
@@ -807,7 +807,7 @@
 .phase-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .phase-card:active {
@@ -847,9 +847,9 @@
 
 .phase-duration {
   background: transparent;
-  color: #ffd166;
+  color: var(--accent-warning);
   padding: 4px 8px;
-  border: 1px solid #ffd166;
+  border: 1px solid var(--accent-warning);
   font-size: 11px;
   font-weight: 700;
   font-family: var(--font-mono);
@@ -901,7 +901,7 @@
 
 .practice-option:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border-color: #fff;
 }
 
@@ -967,12 +967,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: var(--font-mono);
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .start-practice-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .start-practice-btn:active {
@@ -1143,5 +1143,5 @@
 }
 
 .personalized-error-coach button:focus {
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }

--- a/src/features/progress/ProgressDashboard.jsx
+++ b/src/features/progress/ProgressDashboard.jsx
@@ -22,10 +22,10 @@ import { createLogger } from '../../lib/utils/logger.js'
 
 const logger = createLogger('features:ProgressDashboard')
 
-const ACCENT = '#ff4d1c'
-const INK    = '#f4f1ea'
-const INK2   = '#6e6a60'
-const INK3   = '#2a2823'
+const ACCENT = 'var(--accent-primary)'
+const INK    = 'var(--text)'
+const INK2   = 'var(--muted)'
+const INK3   = 'var(--border-strong)'
 
 function Crosshairs() {
   const positions = [
@@ -129,7 +129,7 @@ export default function ProgressDashboard({
         </header>
         <div className="vp-content vp-loading">
           <div className="vp-spinner" />
-          <p style={{ color: INK2, fontFamily: 'JetBrains Mono, monospace', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
+          <p style={{ color: INK2, fontFamily: 'var(--font-ui)', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase' }}>
             {!systemReady ? 'Inicializando...' : 'Cargando progreso...'}
           </p>
         </div>
@@ -151,7 +151,7 @@ export default function ProgressDashboard({
           </div>
         </header>
         <div className="vp-content vp-loading">
-          <p style={{ color: ACCENT, fontFamily: 'JetBrains Mono, monospace', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 12 }}>
+          <p style={{ color: ACCENT, fontFamily: 'var(--font-ui)', fontSize: 11, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 12 }}>
             ERROR
           </p>
           <p style={{ color: INK2, fontSize: 13, marginBottom: 20 }}>{error}</p>

--- a/src/features/progress/SRSReviewQueueModal.css
+++ b/src/features/progress/SRSReviewQueueModal.css
@@ -66,7 +66,7 @@
 .srs-queue__close:hover {
   border-color: #fff;
   color: var(--text);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -184,7 +184,7 @@
 
 .srs-queue__refresh:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -221,12 +221,12 @@
   background: #fff;
   border-color: #fff;
   color: #000;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .srs-queue__actions .btn-primary:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .srs-queue__actions .btn-primary:active {
@@ -243,7 +243,7 @@
 .srs-queue__actions .btn-secondary:hover {
   border-color: #fff;
   color: var(--text);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -300,7 +300,7 @@
 }
 
 .srs-queue__item.urgency-2 {
-  border-left: 4px solid #5ee6a5;
+  border-left: 4px solid var(--accent-success);
 }
 
 .srs-queue__item.urgency-1 {

--- a/src/features/progress/SummaryStrip.jsx
+++ b/src/features/progress/SummaryStrip.jsx
@@ -7,8 +7,8 @@ const GOAL_TYPES = {
 }
 
 function getMasteryColor(ratio) {
-  if (ratio >= 0.7) return '#7de9b8'
-  if (ratio >= 0.4) return '#f5d688'
+  if (ratio >= 0.7) return 'var(--accent-success)'
+  if (ratio >= 0.4) return 'var(--accent-warning)'
   return '#ff9f7a'
 }
 
@@ -45,7 +45,7 @@ export default function SummaryStrip({ srsStats, userStats, onSRSReview }) {
         onClick={itemsDue > 0 ? onSRSReview : undefined}
         disabled={itemsDue === 0}
       >
-        <div className="summary-value" style={itemsDue > 0 ? { color: '#7de9b8' } : { color: '#555' }}>
+        <div className="summary-value" style={itemsDue > 0 ? { color: 'var(--accent-success)' } : { color: '#555' }}>
           {itemsDue}
         </div>
         <div className="summary-label">pendiente{itemsDue !== 1 ? 's' : ''}</div>

--- a/src/features/progress/accuracy-trend-card.css
+++ b/src/features/progress/accuracy-trend-card.css
@@ -37,17 +37,17 @@
 }
 
 .trend-chip.trend-up {
-  color: #5ee6a5;
+  color: var(--accent-success);
   border-color: rgba(94, 230, 165, 0.3);
 }
 
 .trend-chip.trend-down {
-  color: #ff6b6b;
+  color: var(--accent-error);
   border-color: rgba(255, 107, 107, 0.3);
 }
 
 .trend-chip.trend-stable {
-  color: #ffd166;
+  color: var(--accent-warning);
   border-color: rgba(255, 209, 102, 0.3);
 }
 
@@ -135,15 +135,15 @@
 }
 
 .distribution-mastered {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .distribution-progress {
-  background: #ffd166;
+  background: var(--accent-warning);
 }
 
 .distribution-struggling {
-  background: #ff6b6b;
+  background: var(--accent-error);
 }
 
 .distribution-legend {
@@ -171,15 +171,15 @@
 }
 
 .legend-mastered {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .legend-progress {
-  background: #ffd166;
+  background: var(--accent-warning);
 }
 
 .legend-struggling {
-  background: #ff6b6b;
+  background: var(--accent-error);
 }
 
 .accuracy-empty {

--- a/src/features/progress/advanced-analytics-panel.css
+++ b/src/features/progress/advanced-analytics-panel.css
@@ -38,11 +38,11 @@
 }
 
 .advanced-trend.positive {
-  color: #5ee6a5;
+  color: var(--accent-success);
 }
 
 .advanced-trend.negative {
-  color: #ff6b6b;
+  color: var(--accent-error);
 }
 
 .advanced-retention-series {

--- a/src/features/progress/community-pulse.css
+++ b/src/features/progress/community-pulse.css
@@ -86,7 +86,7 @@
 
 .community-leaderboard li.current-user {
   border-color: #fff;
-  box-shadow: 3px 3px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .community-rank {

--- a/src/features/progress/expert-mode-panel.css
+++ b/src/features/progress/expert-mode-panel.css
@@ -61,7 +61,7 @@
 
 .expert-profile:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 

--- a/src/features/progress/flow-indicator.css
+++ b/src/features/progress/flow-indicator.css
@@ -62,7 +62,7 @@
 
 .flow-indicator-main:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .flow-indicator-main:active {
@@ -122,7 +122,7 @@
 
 .momentum-indicator:hover {
   transform: translate(-1px, -1px);
-  box-shadow: 2px 2px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 /* State change animation */
@@ -147,7 +147,7 @@
   width: 320px;
   background: #0a0a0a;
   padding: 20px;
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
   border: 1px solid #333;
   animation: panel-slide-in 0.15s ease-out;
   z-index: 1001;
@@ -303,7 +303,7 @@
 }
 
 .metric-fill.confidence {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .metric-fill.flow-time {
@@ -336,7 +336,7 @@
   font-family: var(--font-mono);
   font-size: 18px;
   font-weight: 800;
-  color: #ff6b6b;
+  color: var(--accent-error);
 }
 
 .streak-icon {

--- a/src/features/progress/offline-status-banner.css
+++ b/src/features/progress/offline-status-banner.css
@@ -38,7 +38,7 @@
 
 .offline-banner button:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 

--- a/src/features/progress/personalized-plan.css
+++ b/src/features/progress/personalized-plan.css
@@ -42,7 +42,7 @@
   background: transparent;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .plan-refresh:active {
@@ -127,7 +127,7 @@
 .plan-goal-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .plan-goal-card:active {
@@ -145,10 +145,10 @@
   font-family: var(--font-mono);
   font-size: 0.7rem;
   font-weight: 700;
-  color: #5ee6a5;
+  color: var(--accent-success);
   background: transparent;
   padding: 0.1rem 0.4rem;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -187,7 +187,7 @@
 .plan-week:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .plan-week:active {
@@ -244,7 +244,7 @@
 .plan-session-block:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .plan-session-block:active {
@@ -306,7 +306,7 @@
 
 .plan-progress-fill-compact {
   height: 100%;
-  background: #5ee6a5;
+  background: var(--accent-success);
   transition: width 0.4s ease;
 }
 

--- a/src/features/progress/practice-recommendations.css
+++ b/src/features/progress/practice-recommendations.css
@@ -49,13 +49,13 @@
   background: transparent;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .focus-mode-selector .mode-select:focus {
   outline: none;
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .focus-mode-selector .mode-select option {
@@ -103,12 +103,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   transition: all 0.15s ease;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .retry-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .retry-btn:active {
@@ -121,12 +121,12 @@
   text-align: center;
   padding: 2rem;
   background: transparent;
-  border: 1px solid #5ee6a5;
+  border: 1px solid var(--accent-success);
 }
 
 .no-recommendations p {
   margin: 0.5rem 0;
-  color: #5ee6a5;
+  color: var(--accent-success);
   font-weight: 700;
   line-height: 1.5;
   font-family: var(--font-mono);
@@ -156,7 +156,7 @@
 .recommendation-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .recommendation-card:active {
@@ -165,17 +165,17 @@
 }
 
 .recommendation-card.high {
-  border-left: 4px solid #ff6b6b;
+  border-left: 4px solid var(--accent-error);
   background: transparent;
 }
 
 .recommendation-card.medium {
-  border-left: 4px solid #ffd166;
+  border-left: 4px solid var(--accent-warning);
   background: transparent;
 }
 
 .recommendation-card.low {
-  border-left: 4px solid #5ee6a5;
+  border-left: 4px solid var(--accent-success);
   background: transparent;
 }
 
@@ -217,20 +217,20 @@
 
 .priority-badge.high {
   background: transparent;
-  border-color: #ff6b6b;
-  color: #ff6b6b;
+  border-color: var(--accent-error);
+  color: var(--accent-error);
 }
 
 .priority-badge.medium {
   background: transparent;
-  border-color: #ffd166;
-  color: #ffd166;
+  border-color: var(--accent-warning);
+  color: var(--accent-warning);
 }
 
 .priority-badge.low {
   background: transparent;
-  border-color: #5ee6a5;
-  color: #5ee6a5;
+  border-color: var(--accent-success);
+  color: var(--accent-success);
 }
 
 .recommendation-description {
@@ -260,12 +260,12 @@
   letter-spacing: 0.05em;
 }
 
-.difficulty-badge.green { background: transparent; border-color: #5ee6a5; color: #5ee6a5; }
-.difficulty-badge.orange { background: transparent; border-color: #ffd166; color: #ffd166; }
-.difficulty-badge.red { background: transparent; border-color: #ff6b6b; color: #ff6b6b; }
+.difficulty-badge.green { background: transparent; border-color: var(--accent-success); color: var(--accent-success); }
+.difficulty-badge.orange { background: transparent; border-color: var(--accent-warning); color: var(--accent-warning); }
+.difficulty-badge.red { background: transparent; border-color: var(--accent-error); color: var(--accent-error); }
 .difficulty-badge.blue { background: transparent; border-color: #fff; color: #fff; }
 .difficulty-badge.purple { background: transparent; border-color: var(--muted); color: var(--muted); }
-.difficulty-badge.teal { background: transparent; border-color: #5ee6a5; color: #5ee6a5; }
+.difficulty-badge.teal { background: transparent; border-color: var(--accent-success); color: var(--accent-success); }
 .difficulty-badge.gray { background: transparent; border-color: var(--muted-2); color: var(--muted-2); }
 
 .duration-badge {
@@ -346,7 +346,7 @@
   background: transparent;
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .session-btn:active {
@@ -354,12 +354,12 @@
   box-shadow: none;
 }
 
-.session-btn.short { border-color: #5ee6a5; color: #5ee6a5; }
-.session-btn.short:hover { box-shadow: 3px 3px 0 #5ee6a5; }
-.session-btn.medium { border-color: #ffd166; color: #ffd166; }
-.session-btn.medium:hover { box-shadow: 3px 3px 0 #ffd166; }
-.session-btn.long { border-color: #ff6b6b; color: #ff6b6b; }
-.session-btn.long:hover { box-shadow: 3px 3px 0 #ff6b6b; }
+.session-btn.short { border-color: var(--accent-success); color: var(--accent-success); }
+.session-btn.short:hover { box-shadow: var(--shadow-soft); }
+.session-btn.medium { border-color: var(--accent-warning); color: var(--accent-warning); }
+.session-btn.medium:hover { box-shadow: var(--shadow-soft); }
+.session-btn.long { border-color: var(--accent-error); color: var(--accent-error); }
+.session-btn.long:hover { box-shadow: var(--shadow-soft); }
 
 .session-preview {
   background: transparent;
@@ -412,7 +412,7 @@
 .session-activity:hover {
   border-color: #333;
   transform: translate(-1px, -1px);
-  box-shadow: 2px 2px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .activity-icon {
@@ -449,12 +449,12 @@
   letter-spacing: 0.1em;
   cursor: pointer;
   transition: all 0.15s ease;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .start-session-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .start-session-btn:active {
@@ -489,7 +489,7 @@
   border-color: #fff;
   color: var(--text);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .refresh-btn:active {
@@ -601,7 +601,7 @@
   align-items: center;
   gap: 0.5rem;
   transition: all 0.15s ease;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
   flex: 1;
   justify-content: center;
   min-width: 140px;
@@ -609,7 +609,7 @@
 
 .practice-now-btn:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .practice-now-btn:active {
@@ -640,7 +640,7 @@
   border-color: #fff;
   color: var(--text);
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .details-btn:active {
@@ -650,19 +650,19 @@
 
 /* Priority-based styling for practice buttons */
 .recommendation-card.high .practice-now-btn {
-  box-shadow: 4px 4px 0 #ff6b6b;
+  box-shadow: var(--shadow-soft);
 }
 
 .recommendation-card.high .practice-now-btn:hover {
-  box-shadow: 6px 6px 0 #ff6b6b;
+  box-shadow: var(--shadow-soft);
 }
 
 .recommendation-card.medium .practice-now-btn {
-  box-shadow: 4px 4px 0 #ffd166;
+  box-shadow: var(--shadow-soft);
 }
 
 .recommendation-card.medium .practice-now-btn:hover {
-  box-shadow: 6px 6px 0 #ffd166;
+  box-shadow: var(--shadow-soft);
 }
 
 .recommendation-card.medium .practice-now-btn .inline-icon {
@@ -677,9 +677,9 @@
 }
 
 .recommendation-card.high .practice-now-btn:focus {
-  outline-color: #ff6b6b;
+  outline-color: var(--accent-error);
 }
 
 .recommendation-card.medium .practice-now-btn:focus {
-  outline-color: #ffd166;
+  outline-color: var(--accent-warning);
 }

--- a/src/features/progress/progress-streamlined.css
+++ b/src/features/progress/progress-streamlined.css
@@ -1,5 +1,4 @@
 /* Progress Dashboard — VERB/OS Dark Brutalist Theme */
-@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 /* ═══════════════════════════════════════
    Shell & Layout
@@ -7,7 +6,7 @@
 
 /* vp-shell: full-screen fixed shell using verbos-onboarding as base */
 .vp-shell {
-  /* verbos-onboarding gives us: position fixed, inset 0, bg #0c0c0c, overflow hidden */
+  /* verbos-onboarding gives us: position fixed, inset 0, bg var(--bg), overflow hidden */
   /* Content scrolls inside vp-content, not the shell itself */
 }
 
@@ -34,8 +33,8 @@
 .vp-spinner {
   width: 28px;
   height: 28px;
-  border: 2px solid #1f1d18;
-  border-top-color: #ff4d1c;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent-primary);
   animation: vp-spin 0.9s linear infinite;
 }
 
@@ -44,30 +43,30 @@
 }
 
 .vp-retry-btn {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   background: transparent;
-  border: 1px solid #ff4d1c;
-  color: #ff4d1c;
+  border: 1px solid var(--accent-primary);
+  color: var(--accent-primary);
   padding: 10px 20px;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .vp-retry-btn:hover {
-  background: #ff4d1c;
-  color: #0c0c0c;
+  background: var(--accent-primary);
+  color: var(--bg);
 }
 
 /* Back button in header */
 .vp-back-btn {
   background: transparent;
   border: none;
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 16px;
   cursor: pointer;
   padding: 0 8px 0 0;
@@ -78,7 +77,7 @@
 }
 
 .vp-back-btn:hover {
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 /* ═══════════════════════════════════════
@@ -88,13 +87,13 @@
 .summary-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
 }
 
 .summary-cell {
   padding: 1.25rem 1rem;
   text-align: center;
-  border-right: 1px solid #1f1d18;
+  border-right: 1px solid var(--border);
   position: relative;
 }
 
@@ -106,7 +105,7 @@
   cursor: default;
   background: transparent;
   border: none;
-  border-right: 1px solid #1f1d18;
+  border-right: 1px solid var(--border);
   font-family: inherit;
   color: inherit;
 }
@@ -116,25 +115,25 @@
 }
 
 .summary-cell--srs.has-items:hover {
-  background: rgba(255, 77, 28, 0.04);
+  background: rgba(242, 242, 240, 0.04);
 }
 
 .summary-value {
-  font-family: 'Inter Tight', -apple-system, sans-serif;
+  font-family: var(--font-ui);
   font-size: 2rem;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
   letter-spacing: -0.04em;
   line-height: 1;
 }
 
 .summary-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.6rem;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: #2a2823;
+  color: var(--border-strong);
   margin-top: 0.4rem;
 }
 
@@ -144,12 +143,12 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: #1f1d18;
+  background: var(--border);
 }
 
 .summary-goal-fill {
   height: 100%;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   transition: width 0.3s ease;
 }
 
@@ -159,22 +158,22 @@
 
 .unified-practice {
   padding: 2rem 1.5rem;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
 }
 
 .unified-practice-heading {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: #2a2823;
+  color: var(--border-strong);
   margin: 0 0 1.25rem;
 }
 
 .practice-primary {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 2rem;
   cursor: pointer;
   transition: all 0.15s cubic-bezier(0.2, 0.9, 0.3, 1);
@@ -182,40 +181,40 @@
 }
 
 .practice-primary:hover {
-  border-color: #ff4d1c;
-  box-shadow: 4px 4px 0 #ff4d1c;
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
 .practice-primary:focus-visible {
-  outline: 2px solid #ff4d1c;
+  outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
 
 .practice-primary-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 1.1rem;
   font-weight: 700;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
   letter-spacing: -0.025em;
   text-transform: lowercase;
   margin-bottom: 0.5rem;
 }
 
 .practice-primary-reason {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.72rem;
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: 0.04em;
   margin-bottom: 1.25rem;
   line-height: 1.5;
 }
 
 .practice-primary-cta {
-  font-family: 'JetBrains Mono', monospace;
-  background: #ff4d1c;
-  color: #0c0c0c;
+  font-family: var(--font-ui);
+  background: var(--accent-primary);
+  color: var(--bg);
   display: inline-block;
   padding: 0.55rem 1.5rem;
   text-transform: uppercase;
@@ -232,12 +231,12 @@
 .practice-secondary {
   flex: 1;
   background: transparent;
-  border: 1px solid #1f1d18;
-  color: #6e6a60;
+  border: 1px solid var(--border);
+  color: var(--muted);
   padding: 0.75rem 1rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.68rem;
   font-weight: 500;
   cursor: pointer;
@@ -245,9 +244,9 @@
 }
 
 .practice-secondary:hover {
-  border-color: #f4f1ea;
-  color: #f4f1ea;
-  box-shadow: 2px 2px 0 #f4f1ea;
+  border-color: var(--text);
+  color: var(--text);
+  box-shadow: var(--shadow-soft);
   transform: translate(-1px, -1px);
 }
 
@@ -258,7 +257,7 @@
 .heatmap-srs {
   background: transparent;
   padding: 2rem 1.5rem;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
 }
 
 .section-header {
@@ -266,8 +265,8 @@
 }
 
 .section-header h2 {
-  color: #f4f1ea;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--text);
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -279,8 +278,8 @@
 }
 
 .section-header p {
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 0.7rem;
   letter-spacing: 0.06em;
 }
@@ -297,7 +296,7 @@
 }
 
 .mood-section {
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 1.25rem;
   background: rgba(255, 255, 255, 0.01);
 }
@@ -308,7 +307,7 @@
   gap: 0.75rem;
   margin-bottom: 1rem;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid #1f1d18;
+  border-bottom: 1px solid var(--border);
 }
 
 .mood-icon {
@@ -319,10 +318,10 @@
 }
 
 .mood-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.7rem;
   font-weight: 700;
-  color: #6e6a60;
+  color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.12em;
 }
@@ -334,7 +333,7 @@
 }
 
 .data-cell {
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 0.85rem;
   text-align: center;
   min-height: 80px;
@@ -348,13 +347,13 @@
 }
 
 .data-cell:hover {
-  border-color: #f4f1ea;
-  box-shadow: 2px 2px 0 #f4f1ea;
+  border-color: var(--text);
+  box-shadow: var(--shadow-soft);
   transform: translate(-1px, -1px);
 }
 
 .data-cell:focus-visible {
-  outline: 2px solid #ff4d1c;
+  outline: 2px solid var(--accent-primary);
   outline-offset: 2px;
 }
 
@@ -378,17 +377,17 @@
 
 .data-cell.no-data {
   background: transparent;
-  border-color: #1f1d18;
-  color: #2a2823;
+  border-color: var(--border);
+  color: var(--border-strong);
   opacity: 0.7;
 }
 
 .data-cell.srs-due {
-  box-shadow: 0 0 0 1px rgba(255, 77, 28, 0.3);
+  box-shadow: 0 0 0 1px rgba(242, 242, 240, 0.3);
 }
 
 .tense-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.62rem;
   font-weight: 700;
   margin-bottom: 0.35rem;
@@ -397,32 +396,32 @@
 }
 
 .mastery-score {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 1.1rem;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   letter-spacing: -0.04em;
   margin-bottom: 0.15rem;
 }
 
 .attempt-count {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.6rem;
   opacity: 0.5;
   letter-spacing: 0.06em;
 }
 
 .no-data-indicator {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   opacity: 0.3;
   letter-spacing: 0.08em;
 }
 
 .srs-indicator-text {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.62rem;
-  color: rgba(255, 77, 28, 0.8);
+  color: rgba(242, 242, 240, 0.8);
   letter-spacing: 0.06em;
 }
 
@@ -433,15 +432,15 @@
   gap: 1.25rem;
   padding: 1rem 0;
   margin-top: 1rem;
-  border-top: 1px solid #1f1d18;
+  border-top: 1px solid var(--border);
 }
 
 .legend-item {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  color: #2a2823;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--border-strong);
+  font-family: var(--font-ui);
   font-size: 0.62rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -470,7 +469,7 @@
 
 .legend-color.no-data {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
 }
 
 /* ═══════════════════════════════════════
@@ -479,16 +478,16 @@
 
 .details-panel {
   padding: 1.5rem;
-  border-top: 1px solid #1f1d18;
+  border-top: 1px solid var(--border);
 }
 
 .details-toggle {
   background: transparent;
-  border: 1px solid #1f1d18;
-  color: #2a2823;
+  border: 1px solid var(--border);
+  color: var(--border-strong);
   padding: 0.55rem 1.25rem;
   text-transform: uppercase;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   letter-spacing: 0.16em;
   font-weight: 700;
@@ -498,8 +497,8 @@
 }
 
 .details-toggle:hover {
-  border-color: #6e6a60;
-  color: #6e6a60;
+  border-color: var(--muted);
+  color: var(--muted);
 }
 
 .details-content {
@@ -515,7 +514,7 @@
 
 .section-placeholder {
   background: transparent;
-  border: 1px dashed #1f1d18;
+  border: 1px dashed var(--border);
   padding: 2rem;
   min-height: 120px;
   display: flex;
@@ -524,8 +523,8 @@
   justify-content: center;
   gap: 0.75rem;
   text-align: center;
-  color: #2a2823;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--border-strong);
+  font-family: var(--font-ui);
   font-size: 0.68rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -534,22 +533,22 @@
 .section-placeholder-spinner {
   width: 20px;
   height: 20px;
-  border: 1px solid #1f1d18;
-  border-top-color: #6e6a60;
+  border: 1px solid var(--border);
+  border-top-color: var(--muted);
   animation: vp-spin 0.9s linear infinite;
 }
 
 .section-placeholder-error {
-  border-color: #ff4d1c;
-  color: #ff4d1c;
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 .section-placeholder-action {
   background: transparent;
-  border: 1px solid #6e6a60;
+  border: 1px solid var(--muted);
   padding: 0.4rem 1rem;
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-weight: 700;
   cursor: pointer;
   text-transform: uppercase;
@@ -559,8 +558,8 @@
 }
 
 .section-placeholder-action:hover {
-  border-color: #f4f1ea;
-  color: #f4f1ea;
+  border-color: var(--text);
+  color: var(--text);
 }
 
 /* ═══════════════════════════════════════
@@ -571,15 +570,15 @@
   display: grid;
   gap: 1.25rem;
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 1.5rem;
 }
 
 .ei-compact { font-size: 0.95rem; }
 
 .ei-loading {
-  color: #6e6a60;
-  font-family: 'JetBrains Mono', monospace;
+  color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 0.7rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -587,19 +586,19 @@
 
 .ei-section-title {
   margin: 0;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 0.8rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .ei-section-hint {
   margin: 0.25rem 0 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #2a2823;
+  color: var(--border-strong);
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
@@ -618,34 +617,34 @@
 }
 
 .ei-rate-value {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 1.5rem;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   letter-spacing: -0.04em;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .ei-rate-detail {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: 0.08em;
 }
 
 .ei-trend {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
   padding: 0.3rem 0.5rem;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
 }
 
-.ei-trend-worse { color: #ff6b6b; border-color: rgba(255, 107, 107, 0.2); }
-.ei-trend-better { color: #7de9b8; border-color: rgba(125, 233, 184, 0.2); }
-.ei-trend-stable { color: #f5d688; border-color: rgba(245, 214, 136, 0.2); }
+.ei-trend-worse { color: var(--accent-error); border-color: rgba(255, 107, 107, 0.2); }
+.ei-trend-better { color: var(--accent-success); border-color: rgba(125, 233, 184, 0.2); }
+.ei-trend-stable { color: var(--accent-warning); border-color: rgba(245, 214, 136, 0.2); }
 
 /* Error Heatmap */
 .ei-heatmap-section {
@@ -663,12 +662,12 @@
 
 .ei-heatmap-header {
   padding: 6px 8px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-weight: 700;
   font-size: 0.62rem;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: #6e6a60;
+  color: var(--muted);
   white-space: nowrap;
   text-align: center;
 }
@@ -677,8 +676,8 @@
 
 .ei-heatmap-mood {
   padding: 6px 8px;
-  font-family: 'JetBrains Mono', monospace;
-  color: #6e6a60;
+  font-family: var(--font-ui);
+  color: var(--muted);
   white-space: nowrap;
   font-size: 0.68rem;
   letter-spacing: 0.06em;
@@ -686,19 +685,19 @@
 
 .ei-heatmap-cell {
   padding: 6px;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   text-align: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.68rem;
-  color: #6e6a60;
+  color: var(--muted);
   transition: border-color 0.15s;
 }
 
 .ei-heatmap-clickable { cursor: pointer; }
 
 .ei-heatmap-clickable:hover {
-  border-color: #ff4d1c;
-  color: #f4f1ea;
+  border-color: var(--accent-primary);
+  color: var(--text);
 }
 
 .ei-compact .ei-heatmap-header,
@@ -720,7 +719,7 @@
 
 .ei-difficult-card {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 0.75rem 1rem;
   min-width: 200px;
   flex: 1;
@@ -736,26 +735,26 @@
 }
 
 .ei-difficult-combo {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 0.9rem;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .ei-difficult-meta {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: 0.06em;
 }
 
 /* Practice Buttons */
 .ei-practice-btn {
   background: transparent;
-  border: 1px solid #1f1d18;
-  color: #6e6a60;
+  border: 1px solid var(--border);
+  color: var(--muted);
   padding: 0.4rem 0.75rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -766,8 +765,8 @@
 }
 
 .ei-practice-btn:hover {
-  border-color: #ff4d1c;
-  color: #ff4d1c;
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 /* Feedback Cards */
@@ -784,7 +783,7 @@
 
 .ei-feedback-card {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -799,16 +798,16 @@
 }
 
 .ei-feedback-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 0.9rem;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .ei-feedback-rate {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #ff4d1c;
+  color: var(--accent-primary);
   font-weight: 700;
   letter-spacing: 0.08em;
 }
@@ -821,9 +820,9 @@
 
 .ei-feedback-body p {
   margin: 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.7rem;
-  color: #6e6a60;
+  color: var(--muted);
   line-height: 1.5;
   letter-spacing: 0.04em;
 }
@@ -831,7 +830,7 @@
 .ei-feedback-rule strong,
 .ei-feedback-example strong,
 .ei-feedback-counter strong {
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 /* ═══════════════════════════════════════
@@ -840,7 +839,7 @@
 
 .lj-container {
   background: transparent;
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
@@ -855,28 +854,28 @@
 
 .lj-title {
   margin: 0;
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 1rem;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
   text-transform: lowercase;
   letter-spacing: -0.03em;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .lj-counter {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #2a2823;
+  color: var(--border-strong);
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
 
 .lj-message {
   margin: 0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.7rem;
-  color: #6e6a60;
+  color: var(--muted);
   line-height: 1.5;
   letter-spacing: 0.04em;
 }
@@ -888,7 +887,7 @@
 }
 
 .lj-checkpoint {
-  border: 1px solid #1f1d18;
+  border: 1px solid var(--border);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -914,51 +913,51 @@
 }
 
 .lj-checkpoint-title {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 0.85rem;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
 }
 
 .lj-checkpoint-desc {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
-  color: #6e6a60;
+  color: var(--muted);
   letter-spacing: 0.04em;
 }
 
 .lj-checkpoint-pct {
-  font-family: 'Inter Tight', sans-serif;
+  font-family: var(--font-ui);
   font-size: 1rem;
-  font-weight: 900;
+  font-weight: 600;
   font-style: italic;
-  color: #f4f1ea;
+  color: var(--text);
   white-space: nowrap;
   letter-spacing: -0.04em;
 }
 
 .lj-progress-bar {
   height: 2px;
-  background: #1f1d18;
+  background: var(--border);
   overflow: hidden;
 }
 
 .lj-progress-fill {
   height: 100%;
-  background: #ff4d1c;
+  background: var(--accent-primary);
   transition: width 0.3s ease;
 }
 
 .lj-completed .lj-progress-fill {
-  background: #7de9b8;
+  background: var(--accent-success);
 }
 
 .lj-action-btn {
   background: transparent;
-  border: 1px solid #1f1d18;
-  color: #6e6a60;
+  border: 1px solid var(--border);
+  color: var(--muted);
   padding: 0.45rem 0.85rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-ui);
   font-size: 0.65rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -969,8 +968,8 @@
 }
 
 .lj-action-btn:hover {
-  border-color: #ff4d1c;
-  color: #ff4d1c;
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
 }
 
 /* ═══════════════════════════════════════
@@ -988,11 +987,11 @@
 
   .summary-cell:nth-child(3),
   .summary-cell:nth-child(4) {
-    border-top: 1px solid #1f1d18;
+    border-top: 1px solid var(--border);
   }
 
   .summary-cell:nth-child(3) {
-    border-right: 1px solid #1f1d18;
+    border-right: 1px solid var(--border);
   }
 
   .summary-cell:nth-child(4) {

--- a/src/features/progress/session-card.css
+++ b/src/features/progress/session-card.css
@@ -15,7 +15,7 @@
 .session-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .session-card:active {
@@ -45,7 +45,7 @@
 }
 
 .session-card.in-progress:hover {
-  box-shadow: 3px 3px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 /* Session icon */
@@ -133,7 +133,7 @@
 
 .session-progress-fill {
   height: 100%;
-  background: #5ee6a5;
+  background: var(--accent-success);
   transition: width 0.3s ease;
 }
 
@@ -160,7 +160,7 @@
 
 .session-launch-btn:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -174,7 +174,7 @@
 }
 
 .session-launch-btn.in-progress:hover {
-  box-shadow: 3px 3px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .session-launch-btn img {

--- a/src/features/progress/srs-panel.css
+++ b/src/features/progress/srs-panel.css
@@ -108,7 +108,7 @@
 .toggle-details-btn:hover {
   border-color: #fff;
   color: var(--text);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -125,7 +125,7 @@
 .toggle-details-btn.secondary:hover {
   background: var(--accent-orange);
   color: #000;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 /* Loading */
@@ -179,7 +179,7 @@
 }
 
 .stat-indicator.ready-indicator {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .stat-indicator.scheduled-indicator {
@@ -249,7 +249,7 @@
 }
 
 .srs-stat-card.ready .progress-ring {
-  background: #5ee6a5;
+  background: var(--accent-success);
 }
 
 .srs-stat-card.scheduled .progress-ring {
@@ -302,7 +302,7 @@
 
 .srs-main-btn:hover {
   border-color: #fff;
-  box-shadow: 6px 6px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-4px, -4px);
 }
 
@@ -439,7 +439,7 @@
 
 .btn:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -461,7 +461,7 @@
 
 .btn-outline:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .btn-badge {
@@ -540,8 +540,8 @@
 
 .legend-item.urgent-medium {
   background: transparent;
-  border-color: #5ee6a5;
-  color: #5ee6a5;
+  border-color: var(--accent-success);
+  color: var(--accent-success);
 }
 
 .legend-item.urgent-low {
@@ -581,7 +581,7 @@
 }
 
 .srs-item.urgent-medium {
-  border-left: 4px solid #5ee6a5;
+  border-left: 4px solid var(--accent-success);
 }
 
 .srs-item.urgent-low {
@@ -661,17 +661,17 @@
 }
 
 .mastery-value.mastery-high {
-  color: #5ee6a5;
+  color: var(--accent-success);
   background: rgba(94, 230, 165, 0.06);
 }
 
 .mastery-value.mastery-medium {
-  color: #ffd166;
+  color: var(--accent-warning);
   background: rgba(255, 209, 102, 0.06);
 }
 
 .mastery-value.mastery-low {
-  color: #ff6b6b;
+  color: var(--accent-error);
   background: rgba(255, 107, 107, 0.06);
 }
 
@@ -701,7 +701,7 @@
 }
 
 .urgency-badge.urgent-medium {
-  background: #5ee6a5;
+  background: var(--accent-success);
   color: #000;
 }
 

--- a/src/features/progress/srs-review-queue.css
+++ b/src/features/progress/srs-review-queue.css
@@ -50,7 +50,7 @@
 
 .srs-review-queue__refresh:not(:disabled):hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -122,7 +122,7 @@
 
 .btn-action:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 
@@ -135,12 +135,12 @@
   background: #fff;
   border: 2px solid #fff;
   color: #000;
-  box-shadow: 4px 4px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn-action.primary:hover {
   transform: translate(-2px, -2px);
-  box-shadow: 6px 6px 0 var(--accent-orange);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn-action.primary:active {
@@ -227,7 +227,7 @@
 }
 
 .urgency-medium {
-  border-color: #5ee6a5;
+  border-color: var(--accent-success);
 }
 
 .urgency-low {
@@ -250,7 +250,7 @@
 
 .btn-item:hover {
   border-color: #fff;
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
   transform: translate(-2px, -2px);
 }
 

--- a/src/features/progress/verb-mastery-map.css
+++ b/src/features/progress/verb-mastery-map.css
@@ -126,7 +126,7 @@
 .tense-card:hover {
   border-color: #fff;
   transform: translate(-2px, -2px);
-  box-shadow: 3px 3px 0 #fff;
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-card:active {
@@ -141,8 +141,8 @@
 }
 
 .tense-card.mastery-excellent:hover {
-  border-color: #5ee6a5;
-  box-shadow: 3px 3px 0 #5ee6a5;
+  border-color: var(--accent-success);
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-card.mastery-good {
@@ -151,8 +151,8 @@
 }
 
 .tense-card.mastery-good:hover {
-  border-color: #5ee6a5;
-  box-shadow: 3px 3px 0 #5ee6a5;
+  border-color: var(--accent-success);
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-card.mastery-fair {
@@ -161,8 +161,8 @@
 }
 
 .tense-card.mastery-fair:hover {
-  border-color: #ffd166;
-  box-shadow: 3px 3px 0 #ffd166;
+  border-color: var(--accent-warning);
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-card.mastery-poor {
@@ -171,8 +171,8 @@
 }
 
 .tense-card.mastery-poor:hover {
-  border-color: #ff6b6b;
-  box-shadow: 3px 3px 0 #ff6b6b;
+  border-color: var(--accent-error);
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-card.mastery-none {
@@ -183,7 +183,7 @@
 .tense-card.mastery-none:hover {
   border-color: #555;
   opacity: 1;
-  box-shadow: 3px 3px 0 #555;
+  box-shadow: var(--shadow-soft);
 }
 
 .tense-name {
@@ -288,8 +288,8 @@
 }
 
 .legend-color.mastery-excellent {
-  background: #5ee6a5;
-  border-color: #5ee6a5;
+  background: var(--accent-success);
+  border-color: var(--accent-success);
 }
 
 .legend-color.mastery-good {
@@ -298,13 +298,13 @@
 }
 
 .legend-color.mastery-fair {
-  background: #ffd166;
-  border-color: #ffd166;
+  background: var(--accent-warning);
+  border-color: var(--accent-warning);
 }
 
 .legend-color.mastery-poor {
-  background: #ff6b6b;
-  border-color: #ff6b6b;
+  background: var(--accent-error);
+  border-color: var(--accent-error);
 }
 
 /* Responsive */

--- a/src/index.css
+++ b/src/index.css
@@ -11,36 +11,58 @@
 }
 
 :root {
-  /* Brutalist Dark Palette */
-  --bg: #000000;
-  --panel: #000000;
-  --text: #ffffff;
-  --muted: #888888;
-  --muted-2: #555555;
-  --border: #333333;
-  --border-active: #ffffff;
+  /* Minimalist Monochrome Dark Palette */
+  /* Surfaces — near-black (not pure) for an elegant, soft depth */
+  --bg: #0a0a0a;
+  --bg-raised: #111111;
+  --bg-raised-2: #161616;
+  --panel: #111111;
 
-  /* Accents - Minimal usage */
-  --accent-primary: #ffffff;
-  --accent-success: #00ff00;
-  --accent-error: #ff0000;
-  --accent-warning: #ffaa00;
-  --accent-orange: #ff5722;
+  /* Text ramp */
+  --text: #f2f2f0;
+  --text-secondary: #b8b8b4;
+  --muted: #8a8a86;
+  --muted-2: #5c5c58;
 
-  /* Mastery Levels */
-  --mastery-high: #5ee6a5;
-  --mastery-medium: #ffd166;
-  --mastery-low: #ff6b6b;
-  --mastery-none: #555555;
+  /* Borders — thin, subtle, multi-step */
+  --border: #222222;
+  --border-subtle: #1a1a1a;
+  --border-strong: #333333;
+  --border-active: #f2f2f0;
 
-  /* UI Elements */
-  --focus-ring: #ffffff;
-  --shadow-hard: 6px 6px 0px 0px #ffffff;
-  --shadow-hard-sm: 3px 3px 0px 0px #ffffff;
+  /* "Accent" = contrast, not hue (monochrome) */
+  --accent-primary: #f2f2f0;
+  --accent-orange: #f2f2f0; /* retargeted to white → removes orange app-wide via var */
 
-  /* Typography */
+  /* Functional state colors — desaturated, kept for usability */
+  --accent-success: #7fb89a;
+  --accent-error: #c97b7b;
+  --accent-warning: #c9b07b;
+
+  /* Mastery — luminance ramp (legible in grayscale) */
+  --mastery-high: #d8d8d4;
+  --mastery-medium: #8a8a86;
+  --mastery-low: #4a4a46;
+  --mastery-none: #242422;
+
+  /* Focus / shadows — soft, no brutalist offset */
+  --focus-ring: #f2f2f0;
+  --shadow-hard: 0 1px 0 0 var(--border);
+  --shadow-hard-sm: 0 1px 0 0 var(--border);
+  --shadow-soft: 0 8px 30px rgba(0, 0, 0, 0.5);
+
+  /* Spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 16px;
+  --space-4: 24px;
+  --space-5: 40px;
+  --space-6: 64px;
+
+  /* Typography — serif display + clean sans (mono collapsed to sans) */
+  --font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
   --font-ui: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-mono: 'Courier New', monospace;
+  --font-mono: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 body {
@@ -53,12 +75,6 @@ body {
   text-rendering: optimizeLegibility;
   background-color: var(--bg);
   color: var(--text);
-  /* Brutalist grid */
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-  background-size: 50px 50px;
-  background-position: center top;
 }
 
 #root {
@@ -67,7 +83,7 @@ body {
   background-color: transparent;
 }
 
-/* Global Brutalist Enforcements */
+/* Subtle, near-sharp corners for a refined minimalist feel */
 button,
 input,
 select,
@@ -79,7 +95,7 @@ textarea,
 .dialog,
 .modal,
 .toast {
-  border-radius: 0 !important;
+  border-radius: 2px;
 }
 
 h1,
@@ -88,7 +104,8 @@ h3,
 h4,
 h5,
 h6 {
-  text-transform: uppercase;
-  letter-spacing: -0.02em;
-  font-weight: 800;
+  font-family: var(--font-display);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  font-weight: 500;
 }


### PR DESCRIPTION
## Resumen

Rediseño visual completo de la app, reemplazando el tema "VERB/OS Dark Brutalist" por una estética **minimalista, monocroma y elegante** inspirada en [impacto-directo.vercel.app](https://impacto-directo.vercel.app/). Cubre **onboarding, drills, módulo learning y estadísticas/progreso**.

Decisiones acordadas con el usuario:
- **Monocromo**: negro profundo + rampa de grises + off-white, sin acento de color (el naranja se elimina; el acento es el contraste).
- **Tipografía**: serif display (**Fraunces**) para títulos + sans limpia (**Inter**) para cuerpo. Se elimina la monoespaciada técnica.
- **Más limpio/elegante**: fuera grillas de fondo, sombras duras con offset, efectos CRT/scan, mayúsculas omnipresentes y `border-radius:0` forzado.

## Cambios principales

- **Tokens globales** (`src/index.css`): nueva paleta de superficies casi-negras, rampa de texto en grises, bordes finos, sombras suaves, acento monocromo (naranja → blanco vía variable), estados funcionales desaturados y variables `--font-display`/`--font-ui`.
- **Fuentes** (`index.html`): se carga Fraunces; se quitan Inter Tight y JetBrains Mono.
- **Reconciliación de tokens scoped** (`DrillVerbos.css`, `OnboardingFlow.css`, `progress-streamlined.css`): ahora heredan el tema global; barrido de hex y fuentes hardcodeadas en CSS y estilos inline de JSX.
- **Decorativo**: se eliminan grids, viñetas, crosshairs y animaciones scan/blink; las sombras offset pasan a sombra suave.
- **Mastery/feedback**: colores mapeados a un set desaturado legible en escala de grises (success/warning/error).

## Verificación

- `npm run build` ✅ (build de producción OK)
- `npm run lint` ✅ (0 errores; solo warnings preexistentes)
- Pendiente recorrido visual manual: onboarding, sesión de drill, learning (`npm run dev:learning`), dashboard de progreso con heatmap + SRS, y anchos mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtvQPsmTAhHihY6oMMDx5u)_