### PR TITLE
fix(learning): legible contrast for irregularity highlights

### DIFF
--- a/src/components/learning/EndingsDrill.css
+++ b/src/components/learning/EndingsDrill.css
@@ -158,10 +158,10 @@
 
 /* Stem vowel highlighting for diphthong verbs */
 .learning-drill .stem-vowel-highlight {
-    color: var(--accent-orange);
+    color: var(--highlight-emphasis);
     font-weight: 700;
     text-decoration: underline;
-    text-decoration-color: var(--accent-orange);
+    text-decoration-color: var(--highlight-emphasis);
     text-decoration-thickness: 2px;
     text-underline-offset: 3px;
 }

--- a/src/components/learning/IrregularEndingsDrill.css
+++ b/src/components/learning/IrregularEndingsDrill.css
@@ -87,9 +87,9 @@
 }
 
 .ending-value .irreg-frag {
-  color: var(--accent-warning);
-  background: rgba(255, 170, 0, 0.1);
-  border-bottom: 2px solid var(--accent-warning);
+  color: var(--highlight-emphasis);
+  background: rgba(232, 184, 90, 0.15);
+  border-bottom: 2px solid var(--highlight-emphasis);
   padding: 0 2px;
   border-radius: 0;
   font-weight: 700;
@@ -98,8 +98,8 @@
 
 /* Resalta toda la fila cuando la forma correspondiente es irregular */
 .ending-row.irregular {
-  background: rgba(255, 170, 0, 0.05);
-  border: 1px solid var(--accent-warning);
+  background: rgba(232, 184, 90, 0.08);
+  border: 1px solid var(--highlight-emphasis);
 }
 
 .ending-row.irregular .ending-person {

--- a/src/components/learning/IrregularRootDrill.css
+++ b/src/components/learning/IrregularRootDrill.css
@@ -17,8 +17,8 @@
 .ird-hint-block .root-line { display:flex; justify-content:space-between; align-items:center; gap:16px; }
 .ird-hint-block .hint-label { color:var(--border-strong); }
 .ird-hint-block .hint-value { color:var(--text); font-weight:700; }
-.ird-hint-block .root-highlight { color:#ffffff; background:var(--accent-primary); font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
-.ird-hint-block .nonfinite-highlight { color:#ffffff; background:var(--accent-primary); font-weight:700; padding:2px 8px; }
+.ird-hint-block .root-highlight { color:var(--highlight-on-fill); background:var(--highlight-fill); font-weight:700; padding:2px 8px; letter-spacing:0.06em; }
+.ird-hint-block .nonfinite-highlight { color:var(--highlight-on-fill); background:var(--highlight-fill); font-weight:700; padding:2px 8px; }
 .ird-hint-block .hint-note { color:var(--border-strong); font-size:10px; text-transform:none; font-style:italic; margin:0; }
 .ird-hint-block .hint-note.alternate { color:var(--muted); }
 
@@ -106,12 +106,12 @@
 .root-meta .root-highlight {
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--accent-orange);
+  color: var(--highlight-emphasis);
 }
 
 .nonfinite-highlight {
   font-weight: 700;
-  color: var(--accent-orange);
+  color: var(--highlight-emphasis);
   letter-spacing: 0.08em;
 }
 

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -124,8 +124,8 @@
 }
 
 .story-sentence .highlight {
-  color: #ffffff;
-  background: var(--accent-primary);
+  color: var(--highlight-on-fill);
+  background: var(--highlight-fill);
   font-weight: 700;
   padding: 0.1em 0.35em;
   font-family: var(--font-ui);
@@ -185,30 +185,32 @@
 .verb-deconstruction.irregular .conjugated-form { color: var(--text); }
 
 .verb-deconstruction.irregular .conjugated-form .irreg-frag {
-  color: var(--accent-primary);
+  color: var(--highlight-emphasis);
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: var(--accent-primary);
+  text-decoration-color: var(--highlight-emphasis);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
 
 .irreg-frag {
-  color: var(--accent-primary) !important;
+  color: var(--highlight-emphasis) !important;
   font-weight: 700;
   text-decoration: underline;
-  text-decoration-color: var(--accent-primary);
+  text-decoration-color: var(--highlight-emphasis);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 }
 
-/* Overrides inside orange backgrounds — keep white for underline consistency */
+/* Overrides inside light chips — dark text/underline so the fragment stays legible */
 .story-sentence .highlight .irreg-frag {
-  text-decoration-color: #ffffff;
+  color: var(--highlight-on-fill) !important;
+  text-decoration-color: var(--highlight-on-fill);
 }
 
 .yo-form-highlight .irreg-frag {
-  text-decoration-color: #ffffff;
+  color: var(--highlight-on-fill) !important;
+  text-decoration-color: var(--highlight-on-fill);
 }
 
 .verb-deconstruction.irregular .form-separator {
@@ -314,8 +316,8 @@
 .future-root-highlight {
   font-size: 1.3rem;
   font-weight: 800;
-  color: #ffffff;
-  background: var(--accent-primary);
+  color: var(--highlight-on-fill);
+  background: var(--highlight-fill);
   padding: 0.15rem 0.5rem;
   letter-spacing: 0.06em;
   font-family: var(--font-ui);
@@ -336,10 +338,11 @@
 .regular-ending-highlight {
   font-size: 1.1rem;
   font-weight: 700;
-  color: var(--accent-primary);
+  color: var(--highlight-emphasis);
   letter-spacing: 0.04em;
   text-decoration: underline;
-  text-decoration-color: rgba(242, 242, 240, 0.4);
+  text-decoration-color: var(--highlight-emphasis);
+  text-decoration-thickness: 2px;
   text-underline-offset: 3px;
 }
 
@@ -393,8 +396,8 @@
 
 .narrative-introduction .nonfinite-highlight {
   font-weight: 800;
-  color: #ffffff;
-  background: var(--accent-primary);
+  color: var(--highlight-on-fill);
+  background: var(--highlight-fill);
   padding: 0.15rem 0.45rem;
   letter-spacing: 0.05em;
   font-family: var(--font-ui);
@@ -414,8 +417,8 @@
 .group-label-large { color: var(--text); opacity: 0.45; font-weight: 800; }
 
 .stem-vowel-highlight-large {
-  color: #ffffff;
-  background: var(--accent-primary);
+  color: var(--highlight-on-fill);
+  background: var(--highlight-fill);
   font-weight: 800;
   font-size: 1.05em;
   padding: 0 0.12em;
@@ -530,8 +533,8 @@
 .irregular-yo-verb-complete .yo-form-highlight {
   font-size: 1.3rem;
   font-weight: 800;
-  color: #ffffff;
-  background: var(--accent-primary);
+  color: var(--highlight-on-fill);
+  background: var(--highlight-fill);
   padding: 0.4rem 0.85rem;
   font-family: var(--font-ui);
   text-transform: uppercase;

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,13 @@
   --accent-primary: #f2f2f0;
   --accent-orange: #f2f2f0; /* retargeted to white → removes orange app-wide via var */
 
+  /* Learning highlights — high contrast on the dark surface.
+     Filled chips invert (dark text on light fill); inline emphasis uses a
+     legible amber so highlighted fragments stand out from white body text. */
+  --highlight-fill: #f2f2f0;       /* near-white chip background */
+  --highlight-on-fill: #0a0a0a;    /* dark text on the chip */
+  --highlight-emphasis: #e8b85a;   /* amber for inline/underlined emphasis */
+
   /* Functional state colors — desaturated, kept for usability */
   --accent-success: #7fb89a;
   --accent-error: #c97b7b;


### PR DESCRIPTION
## Problema

En el rediseño brutalista minimalista, los resaltados del módulo de learning (para destacar terminaciones, raíces irregulares, vocales del stem, etc.) quedaban ilegibles. La causa raíz: el tema monocromo retargeteó los acentos a casi-blanco (`--accent-primary` y `--accent-orange` = `#f2f2f0`, igual que `--text`). Por eso:

- Los **chips rellenos** ponían texto blanco sobre fondo blanco → contraste ~1:1, invisible.
- Los **resaltados en línea** usaban el mismo color que el texto del cuerpo → no se distinguían.
- Algunos subrayados usaban `rgba(242,242,240,0.4)` → apenas visibles.

## Solución

Se añaden tokens dedicados de resaltado en `src/index.css`:

```css
--highlight-fill: #f2f2f0;     /* fondo claro del chip */
--highlight-on-fill: #0a0a0a;  /* texto oscuro sobre el chip */
--highlight-emphasis: #e8b85a; /* ámbar legible para énfasis en línea */
```

Y se aplican en los drills de learning:
- **Chips rellenos** ahora invierten: texto oscuro sobre fondo claro (alto contraste, coherente con el brutalismo).
- **Énfasis en línea / subrayados** usan un ámbar legible que destaca sobre el texto blanco del cuerpo.
- Los fragmentos `.irreg-frag` **dentro** de chips claros conservan texto/subrayado oscuro para no perderse sobre el fondo claro.

### Archivos tocados
- `src/index.css`
- `src/components/learning/NarrativeIntroduction.css`
- `src/components/learning/IrregularRootDrill.css`
- `src/components/learning/IrregularEndingsDrill.css`
- `src/components/learning/EndingsDrill.css`

Solo cambios de CSS; no se altera lógica ni estructura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011hLeaccJktfv9MBnuBmNNe)_