### PR TITLE
Fix broken rendering on older browsers (learning + theme screens)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,11 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/uuid": "^10.0.0",
+        "@vitejs/plugin-legacy": "^7.2.1",
         "@vitejs/plugin-react": "^4.6.0",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
+        "autoprefixer": "^10.5.2",
         "axe-core": "^4.11.1",
         "eslint": "^9.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -44,10 +46,14 @@
         "jsdom": "^26.1.0",
         "lighthouse": "^12.8.2",
         "prettier": "^3.6.2",
+        "terser": "^5.49.0",
         "vite": "^7.0.4",
         "vite-bundle-analyzer": "^0.7.0",
         "vite-plugin-pwa": "^1.0.2",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4550,6 +4556,37 @@
         }
       }
     },
+    "node_modules/@vitejs/plugin-legacy": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-legacy/-/plugin-legacy-7.2.1.tgz",
+      "integrity": "sha512-CaXb/y0mlfu7jQRELEJJc2/5w2bX2m1JraARgFnvSB2yfvnCNJVWWlqAo6WjnKoepOwKx8gs0ugJThPLKCOXIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-dynamic-import": "^7.27.1",
+        "@babel/plugin-transform-modules-systemjs": "^7.27.1",
+        "@babel/preset-env": "^7.28.0",
+        "babel-plugin-polyfill-corejs3": "^0.13.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.5",
+        "browserslist": "^4.25.1",
+        "browserslist-to-esbuild": "^2.1.1",
+        "core-js": "^3.45.0",
+        "magic-string": "^0.30.17",
+        "regenerator-runtime": "^0.14.1",
+        "systemjs": "^6.15.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "peerDependencies": {
+        "terser": "^5.16.0",
+        "vite": "^7.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -4994,6 +5031,43 @@
         "when-exit": "^2.1.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5203,13 +5277,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.3.tgz",
-      "integrity": "sha512-8QdH6czo+G7uBsNo0GiUfouPN1lRzKdJTGnKXwe12gkFbnnOUaUKGN55dMkfy+mnxmvjwl9zcI4VncczcVXDhA==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-ftp": {
@@ -5270,9 +5347,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -5290,17 +5367,36 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/browserslist-to-esbuild": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist-to-esbuild/-/browserslist-to-esbuild-2.1.1.tgz",
+      "integrity": "sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "browserslist-to-esbuild": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "browserslist": "*"
       }
     },
     "node_modules/buffer-crc32": {
@@ -5407,9 +5503,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001759",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001759.tgz",
-      "integrity": "sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -5655,6 +5751,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.47.0",
@@ -6046,9 +6154,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.266",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.266.tgz",
-      "integrity": "sha512-kgWEglXvkEfMH7rxP5OSZZwnaDWT7J9EoZCujhnpLbfi0bbNtRkgdX2E3gt0Uer11c61qCYktB3hwkAS325sJg==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -6920,6 +7028,20 @@
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -8595,6 +8717,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8812,11 +8947,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -9298,6 +9436,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -9669,6 +9814,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -10936,6 +11088,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/systemjs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-6.15.1.tgz",
+      "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.15",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
@@ -11033,9 +11192,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-      "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -11521,9 +11680,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
-      "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "engines": {
     "node": "20.x"
   },
+  "browserslist": [
+    ">0.3%",
+    "last 4 years",
+    "Firefox ESR",
+    "not dead"
+  ],
   "scripts": {
     "android:sync": "npm run build && npx cap sync",
     "android:run": "npx cap run android",
@@ -75,9 +81,11 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/uuid": "^10.0.0",
+    "@vitejs/plugin-legacy": "^7.2.1",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
+    "autoprefixer": "^10.5.2",
     "axe-core": "^4.11.1",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
@@ -87,6 +95,7 @@
     "jsdom": "^26.1.0",
     "lighthouse": "^12.8.2",
     "prettier": "^3.6.2",
+    "terser": "^5.49.0",
     "vite": "^7.0.4",
     "vite-bundle-analyzer": "^0.7.0",
     "vite-plugin-pwa": "^1.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,9 @@
+import autoprefixer from 'autoprefixer'
+
+// Adds vendor prefixes automatically based on the `browserslist` field in package.json,
+// so older browsers get the `-webkit-`/`-moz-` variants of properties like
+// backdrop-filter, clip-path, position: sticky, user-select, etc. Modern browsers are
+// unaffected. Autoprefixer only adds prefixes; it does not change or remove any rules.
+export default {
+  plugins: [autoprefixer()]
+}

--- a/src/components/learning/LearnTenseFlow.css
+++ b/src/components/learning/LearnTenseFlow.css
@@ -270,13 +270,18 @@
   accent-color: #000000;
 }
 
-.learn-flow .radio-group label:has(input[type="radio"]:checked) {
-  background: var(--panel);
-  border-color: var(--border-active);
-  color: var(--text);
-  font-weight: 700;
-  box-shadow: var(--shadow-hard-sm);
-  transform: translate(-2px, -2px);
+/* Cosmetic highlight for the selected radio. Guarded with @supports because :has()
+   is unsupported on older browsers; there the radio is still usable (accent-color
+   marks the selection), it just doesn't get the extra emphasis. */
+@supports selector(:has(*)) {
+  .learn-flow .radio-group label:has(input[type="radio"]:checked) {
+    background: var(--panel);
+    border-color: var(--border-active);
+    color: var(--text);
+    font-weight: 700;
+    box-shadow: var(--shadow-hard-sm);
+    transform: translate(-2px, -2px);
+  }
 }
 
 /* Start learning button */

--- a/src/components/learning/NarrativeIntroduction.css
+++ b/src/components/learning/NarrativeIntroduction.css
@@ -722,6 +722,11 @@
 .ni-paradigm-header,
 .ni-paradigm-row {
   display: grid;
+  /* Static fallback first: some older engines cannot resolve a CSS variable used as
+     the count inside repeat(), which collapsed the grid and left the endings table
+     empty. Browsers that do support it override with the var() line below (up to 6
+     pronouns; the static line covers the rest as a safe max). */
+  grid-template-columns: 7rem repeat(6, minmax(4rem, 1fr));
   grid-template-columns: 7rem repeat(var(--pronoun-count, 6), minmax(4rem, 1fr));
   align-items: center;
   border-bottom: 1px solid var(--border);
@@ -926,6 +931,10 @@
   }
 
   .narrative-introduction .vo-grid {
+    top: 42px;
+    right: 0;
+    bottom: 0;
+    left: 0;
     inset: 42px 0 0 0;
   }
 
@@ -1090,6 +1099,7 @@
   .ni-paradigm-header,
   .ni-paradigm-row {
     min-width: max-content;
+    grid-template-columns: 3.5rem repeat(6, minmax(min-content, 1fr));
     grid-template-columns: 3.5rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr));
   }
   .ni-paradigm-pronoun { font-size: 7.5px; padding: 0.35rem 0.15rem; }
@@ -1101,6 +1111,7 @@
   .ni-paradigm-header,
   .ni-paradigm-row {
     min-width: max-content;
+    grid-template-columns: 3rem repeat(6, minmax(min-content, 1fr));
     grid-template-columns: 3rem repeat(var(--pronoun-count, 6), minmax(min-content, 1fr));
   }
   .ni-paradigm-lemma { font-size: 0.58rem; padding: 0.4rem 0.25rem; }

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -1,6 +1,13 @@
 
 .verbos-onboarding {
   position: fixed;
+  /* Longhand precedes the `inset` shorthand so browsers without `inset` support
+     (pre Chrome/Edge 87) still pin this fixed container to the viewport instead of
+     collapsing to zero size (which left only the near-black background visible). */
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
   background: var(--bg);
   color: var(--text);
@@ -375,6 +382,10 @@
 /* ── Placement report modal ── */
 .placement-report-overlay {
   position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   inset: 0;
   background: rgba(0, 0, 0, 0.85);
   display: flex;

--- a/src/hooks/modules/useDrillProgress.js
+++ b/src/hooks/modules/useDrillProgress.js
@@ -17,42 +17,16 @@ import { getCurrentUserId } from '../../lib/progress/userManager/index.js'
 import { validateDrillItemStructure } from './DrillItemGenerator.js'
 import { createLogger } from '../../lib/utils/logger.js'
 import { onProgressSystemReady, isProgressSystemReady } from '../../lib/progress/index.js'
-
-// Import progress system modules with error handling
-let processUserResponse = null
-let flowDetector = null
-let momentumTracker = null
-let confidenceEngine = null
-let dynamicGoalsSystem = null
-
-try {
-  const flowModule = await import('../../lib/progress/flowStateDetection.js')
-  processUserResponse = flowModule.processUserResponse
-  flowDetector = flowModule.flowDetector
-} catch (error) {
-  logger.warn('Flow detection module not available', error)
-}
-
-try {
-  const momentumModule = await import('../../lib/progress/momentumTracker.js')
-  momentumTracker = momentumModule.momentumTracker
-} catch (error) {
-  logger.warn('Momentum tracking module not available', error)
-}
-
-try {
-  const confidenceModule = await import('../../lib/progress/confidenceEngine.js')
-  confidenceEngine = confidenceModule.confidenceEngine
-} catch (error) {
-  logger.warn('Confidence engine module not available', error)
-}
-
-try {
-  const goalsModule = await import('../../lib/progress/dynamicGoals.js')
-  dynamicGoalsSystem = goalsModule.dynamicGoalsSystem
-} catch (error) {
-  logger.warn('Dynamic goals module not available', error)
-}
+// Emotional-intelligence progress modules. Imported statically (previously loaded via
+// top-level await) so these bindings are available synchronously when the hook runs —
+// exactly like before — while dropping the top-level await that forced an 'esnext'
+// build target. Removing it lets the bundle target older browsers; @vitejs/plugin-legacy
+// still covers pre-ESM ones. These are hard dependencies of the progress system, and
+// none import back into this hook, so a static import introduces no dependency cycle.
+import { processUserResponse, flowDetector } from '../../lib/progress/flowStateDetection.js'
+import { momentumTracker } from '../../lib/progress/momentumTracker.js'
+import { confidenceEngine } from '../../lib/progress/confidenceEngine.js'
+import { dynamicGoalsSystem } from '../../lib/progress/dynamicGoals.js'
 
 // NOTE: attempt persistence, mastery calculation and SRS scheduling are NOT done here.
 // They run once, in full, inside trackAttemptSubmitted (src/lib/progress/tracking.js),

--- a/src/lib/progress/ProgressSystemEvents.js
+++ b/src/lib/progress/ProgressSystemEvents.js
@@ -5,6 +5,7 @@
  * que notifica cuando el sistema de progreso está listo para su uso.
  */
 
+import { useState, useEffect } from 'react'
 import { createLogger } from '../utils/logger.js'
 
 const logger = createLogger('ProgressSystemEvents')
@@ -168,17 +169,10 @@ export function resetProgressSystemState() {
   logger.debug('Estado del sistema de progreso reseteado')
 }
 
-// Import React hooks for the React hook
-let useState, useEffect
-try {
-  const react = await import('react')
-  useState = react.useState
-  useEffect = react.useEffect
-} catch {
-  // En entornos no-React, proveer stubs
-  useState = () => [false, () => {}]
-  useEffect = () => {}
-}
+// React hooks are imported statically at the top of this module. The previous
+// top-level `await import('react')` was removed so the bundle can target older
+// browsers (top-level await requires a very recent engine); React is a hard
+// dependency of the app and always resolvable in app and test environments.
 
 // ===== EVENTOS DE PROGRESO PARA INICIALIZACIÓN POR LOTES =====
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import legacy from '@vitejs/plugin-legacy'
 import { VitePWA } from 'vite-plugin-pwa'
 // import { spawn, spawnSync } from 'node:child_process'
 // import { existsSync } from 'node:fs'
@@ -96,6 +97,17 @@ export default defineConfig(({ mode }) => ({
           { src: 'favicon.png', sizes: '512x512', type: 'image/png' }
         ]
       }
+    }),
+    // Emits a separate "legacy" bundle (transpiled + core-js polyfills) loaded via
+    // nomodule on older browsers, so machines with an outdated Chrome/Edge/Firefox
+    // still run the app. Modern browsers keep using the untouched module bundle.
+    // Must come after VitePWA so the generated legacy assets are picked up correctly.
+    // modernPolyfills also patches the modern bundle for browsers that support ES
+    // modules but lack newer runtime APIs (e.g. structuredClone, Array.prototype.at).
+    legacy({
+      targets: ['>0.3%', 'last 4 years', 'Firefox ESR', 'not dead'],
+      modernPolyfills: true,
+      renderLegacyChunks: true
     })
   ],
   build: {
@@ -139,7 +151,11 @@ export default defineConfig(({ mode }) => ({
         }
       }
     },
-    target: 'esnext',
+    // Baseline modern-browser syntax target. Kept broadly compatible (not 'esnext')
+    // so browsers a bit behind the latest release can still parse the module bundle;
+    // @vitejs/plugin-legacy handles anything older via the nomodule fallback.
+    // es2020 (not lower) keeps optional chaining / nullish coalescing native.
+    target: 'es2020',
     // Verb datasets are intentionally split but some single modules (legacy fallbacks)
     // remain heavy; raise limit to avoid noisy warnings while keeping code-splitting.
     chunkSizeWarningLimit: 3000,


### PR DESCRIPTION
## Problema

En computadoras con navegadores desactualizados (equipos corporativos con Chrome/Edge/Firefox viejos), el sitio se veía roto: el **módulo learning** aparecía casi en negro con la tabla de **TERMINACIONES vacía**, y la pantalla **"por tema"** con el layout cortado. En navegadores actualizados (y en móvil) se veía perfecto. La causa: se enviaba JS/CSS moderno **sin ningún fallback** para motores más viejos.

## Causas y arreglos

**Compatibilidad de JavaScript**
- El build usaba `target: 'esnext'` sin bundle de respaldo. Se agrega **`@vitejs/plugin-legacy`** (build dual `module`/`nomodule` + polyfills core-js) y un campo **`browserslist`** como base, para que los navegadores viejos reciban un bundle que sí puedan ejecutar.
- El `esnext` era necesario **solo** por dos `top-level await` (`await import()`). Se reemplazan por imports estáticos en `useDrillProgress.js` y un import estático de React en `ProgressSystemEvents.js` — misma semántica de carga, sin cambio de comportamiento — lo que permite bajar el target moderno a **`es2020`**.

**Compatibilidad de CSS**
- Se agrega **autoprefixer** (postcss) guiado por browserslist → prefijos automáticos (`backdrop-filter`, `clip-path`, etc.).
- `.verbos-onboarding` usaba el shorthand **`inset`** (no soportado antes de Chrome/Edge 87); el contenedor `fixed` colapsaba a tamaño cero y solo quedaba el fondo casi negro. Se agregan los longhand **`top/right/bottom/left`** como fallback (arregla la pantalla negra en learning y por tema).
- La tabla de terminaciones usaba `grid-template-columns: … repeat(var(--pronoun-count), …)`, que algunos motores viejos no resuelven → grilla colapsada → **tabla vacía**. Se agrega un fallback estático `repeat(6, …)` antes de la versión con `var()` en cada breakpoint.
- El realce del radio seleccionado con **`:has()`** se envuelve en `@supports` (mejora progresiva).

Los navegadores modernos **no se ven afectados**: siguen usando las rutas shorthand/`var()`/`module` sin cambios; los fallbacks y el bundle legacy solo actúan en motores viejos.

## Verificación

- ✅ `npm run build` compila y emite bundles `*-legacy-*.js` + `polyfills-legacy` con el patrón `module`/`nomodule` en `index.html`.
- ✅ Autoprefixer confirmado en el CSS construido (`-webkit-backdrop-filter`, `-webkit-clip-path`).
- ✅ `npm run lint`: 0 errores.
- ✅ `npm run test:run`: sin regresiones nuevas (los fallos preexistentes son idénticos con y sin estos cambios; el único test afectado por el refactor de imports —`useDrillProgress` `isSystemReady`— vuelve a pasar).
- ✅ Smoke test en Chromium: `/` y `/learning` cargan sin excepciones JS; la pantalla de selección por tema renderiza correctamente (sin regresión visual).

Pendiente: reabrir el sitio desplegado en la computadora del trabajo para confirmar el arreglo en el navegador afectado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJnsCmtwf94gCoGzxQdAfg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJnsCmtwf94gCoGzxQdAfg)_