### PR TITLE
Buscador de temas en vivo en el menú principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="keywords" content="conjugación, verbos, español, gramática, aprender, practicar, subjuntivo, indicativo, imperativo" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- Performance: Preload critical font with font-display -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -499,6 +499,8 @@ function AppRouter() {
         getConjugationExample={onboardingFlow.getConjugationExample}
         onGoToProgress={handleGoToProgress}
         onStartLearningNewTense={handleStartLearningNewTense}
+        setOnboardingStep={onboardingFlow.setOnboardingStep}
+        startFromSearch={onboardingFlow.startFromSearch}
       />
     )
   }

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -241,6 +241,7 @@
 
 .vo-focal-word {
   font-family: var(--font-display);
+  font-size: var(--vo-focal-size, clamp(44px, 12vw, 180px));
   font-weight: 600;
   font-style: italic;
   letter-spacing: -0.03em;
@@ -293,7 +294,39 @@
   color: var(--border-strong);
 }
 
-.vo-options-list { display: flex; flex-direction: column; }
+/* With the search field present the panel is top-aligned and the counter
+   flows below the input instead of floating over it. */
+.vo-right.has-search {
+  justify-content: flex-start;
+  padding-top: 20px;
+}
+
+.vo-right.has-search .vo-options-label {
+  position: static;
+  margin: 0 0 6px;
+}
+
+/* Focal-word caret (was inline styles before the search refactor). */
+.vo-focal-cursor {
+  display: inline-block;
+  width: 0.07em;
+  height: 0.68em;
+  margin-left: 0.05em;
+  background: var(--accent-primary);
+  vertical-align: baseline;
+  transform: translateY(-0.05em);
+}
+
+.vo-options-list {
+  display: flex;
+  flex-direction: column;
+  /* Row sizing lives in custom properties rather than inline styles so the
+     mobile breakpoint can shrink it. */
+  --vo-pad-idle: 52px;
+  --vo-pad-active: 76px;
+  --vo-option-size: 26px;
+  --vo-row-pad: 14px;
+}
 
 .vo-option {
   position: relative;
@@ -302,8 +335,11 @@
   display: flex;
   align-items: baseline;
   gap: 14px;
+  padding: var(--vo-row-pad) 0 var(--vo-row-pad) var(--vo-pad-idle);
   transition: padding-left 0.18s cubic-bezier(0.2, 0.9, 0.3, 1);
 }
+
+.vo-option.is-active { padding-left: var(--vo-pad-active); }
 
 .vo-option:last-child { border-bottom: none; }
 
@@ -341,10 +377,11 @@
 
 .vo-option-label {
   font-family: var(--font-ui);
+  font-size: var(--vo-option-size);
   letter-spacing: -0.025em;
   text-transform: lowercase;
   line-height: 1.05;
-  transition: all 0.15s;
+  transition: color 0.15s, font-weight 0.15s;
   flex: 1;
   min-width: 0;
 }
@@ -493,10 +530,83 @@
 
   .vo-options-label { top: 8px; left: 20px; }
   .vo-right { padding-top: 36px; }
+  .vo-right.has-search { padding-top: 8px; }
 
   .vo-breadcrumb { display: none; }
 
   .vo-footer-hints { gap: 10px; }
+  /* The keyboard hints don't apply on touch; only the search cue survives. */
+  .vo-footer-hints span:not(.vo-hint-search) { display: none; }
 
   .vo-left-bottom { margin-top: 20px; }
+
+  /* Smaller rows, but still a 44px touch target. */
+  .vo-options-list {
+    --vo-pad-idle: 34px;
+    --vo-pad-active: 46px;
+    --vo-option-size: clamp(17px, 5.2vw, 21px);
+    --vo-row-pad: 12px;
+  }
+
+  .vo-option { min-height: 44px; }
+  .vo-option-tick { width: 16px; }
+
+  /* While a query is active the search panel comes first and the focal panel
+     shrinks to a caption — on a phone the results are what matters. */
+  .vo-step.is-searching .vo-right { order: -1; }
+
+  .vo-step.is-searching .vo-left {
+    order: 1;
+    padding: 14px 20px 18px;
+    border-bottom: none;
+    border-top: 1px solid var(--border);
+  }
+
+  .vo-step.is-searching .vo-watermark,
+  .vo-step.is-searching .vo-step-tag,
+  .vo-step.is-searching .vo-aux,
+  .vo-step.is-searching .vo-prompt { display: none; }
+
+  .vo-step.is-searching .vo-left-bottom { margin-top: 0; }
+
+  .vo-step.is-searching .vo-focal-word {
+    font-size: clamp(24px, 8vw, 38px);
+    margin-bottom: 12px;
+  }
+}
+
+/* ── Safe areas (iOS notch / home indicator, incl. the Capacitor build) ──
+   Requires viewport-fit=cover on the viewport meta, otherwise every
+   env(safe-area-inset-*) resolves to 0 and these are no-ops. */
+.vo-header {
+  height: calc(44px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
+  padding-left: max(20px, env(safe-area-inset-left));
+  padding-right: max(20px, env(safe-area-inset-right));
+}
+
+.vo-footer {
+  height: calc(32px + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: max(20px, env(safe-area-inset-left));
+  padding-right: max(20px, env(safe-area-inset-right));
+}
+
+.vo-step {
+  top: calc(44px + env(safe-area-inset-top));
+  bottom: calc(32px + env(safe-area-inset-bottom));
+}
+
+.vo-placement-overlay {
+  top: calc(44px + env(safe-area-inset-top));
+  bottom: calc(32px + env(safe-area-inset-bottom));
+}
+
+@media (max-width: 680px) {
+  .vo-left { padding-left: max(20px, env(safe-area-inset-left)); }
+  .vo-right {
+    padding-left: max(20px, env(safe-area-inset-left));
+    padding-right: max(20px, env(safe-area-inset-right));
+    padding-bottom: max(20px, env(safe-area-inset-bottom));
+  }
 }

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import './OnboardingFlow.css'
 import PlacementTest from '../levels/PlacementTest.jsx'
+import StepView from './StepView.jsx'
+import { isTextEntryTarget } from './textEntry.js'
+import { getTopicSearchIndex } from '../../lib/search/topicSearchIndex.js'
+import { searchTopics } from '../../lib/search/searchTopics.js'
 import { getTensesForMood, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
 import { getFamiliesForMood, getFamiliesForTense } from '../../lib/data/irregularFamilies.js'
 import {
@@ -33,6 +37,9 @@ const VERB_TYPE_OPTS = [
 ]
 
 const THEME_ROOT_MOOD_OPTS = new Set(['subjunctive', 'imperative'])
+
+// The main menu — where the topic search lives.
+const SEARCH_STEP = 2
 
 function buildThemeTopicOptions({ selectMood, selectTense, themeSubMenu, setThemeSubMenu }) {
   if (themeSubMenu === 'condicional') {
@@ -561,172 +568,6 @@ function buildBreadcrumb(settings) {
   return items.slice(-3)
 }
 
-/* ──────────────────────────────
-   StepView — two-panel layout
-────────────────────────────── */
-function StepView({ stepConfig, animKey, onSelect }) {
-  const [focusIdx, setFocusIdx] = useState(0)
-  const { n, kicker, prompt, aux, options } = stepConfig
-
-  useEffect(() => { setFocusIdx(0) }, [animKey])
-
-  // Keyboard navigation
-  useEffect(() => {
-    const handle = (e) => {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        setFocusIdx(i => Math.min(options.length - 1, i + 1))
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        setFocusIdx(i => Math.max(0, i - 1))
-      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
-        e.preventDefault()
-        onSelect(options[focusIdx])
-      } else if (/^[1-9]$/.test(e.key)) {
-        const idx = parseInt(e.key, 10) - 1
-        if (idx < options.length) { setFocusIdx(idx); onSelect(options[idx]) }
-      }
-    }
-    window.addEventListener('keydown', handle)
-    return () => window.removeEventListener('keydown', handle)
-  }, [focusIdx, options, onSelect])
-
-  const focused = options[focusIdx] || options[0]
-
-  // Dynamic font size for focal word
-  const len = (focused?.label || '').length
-  const lenFactor = len <= 6 ? 1 : len <= 10 ? 0.78 : len <= 16 ? 0.58 : len <= 22 ? 0.44 : 0.34
-  const focalSize = `clamp(44px, ${Math.max(5, 12 * lenFactor)}vw, ${Math.round(180 * lenFactor)}px)`
-  const optionFontSize = '26px'
-
-  return (
-    <div key={animKey} className="vo-step vo-lift-in">
-      {/* LEFT: focal word display */}
-      <div className="vo-left">
-        <div className="vo-step-tag">──── {kicker}</div>
-
-        {/* Ghost step number watermark */}
-        <div className="vo-watermark" aria-hidden="true">{n}</div>
-
-        <div className="vo-left-bottom">
-          <div className="vo-aux">▸ {aux}</div>
-          <div className="vo-prompt">{prompt}</div>
-
-          {/* Focal option — huge italic */}
-          <div
-            key={focused?.id ?? 'x'}
-            className="vo-focal-word vo-scan-in"
-            style={{ fontSize: focalSize, color: ACCENT }}
-          >
-            {focused?.label}
-            <span
-              className="vo-cursor"
-              style={{
-                display: 'inline-block',
-                width: '0.07em',
-                height: '0.68em',
-                background: ACCENT,
-                marginLeft: '0.05em',
-                verticalAlign: 'baseline',
-                transform: 'translateY(-0.05em)',
-              }}
-            />
-          </div>
-
-          {/* Metadata strip */}
-          {focused && (
-            <div className="vo-meta">
-              <div className="vo-meta-item">
-                <span className="vo-meta-key">TAG</span>
-                <span className="vo-meta-val">{focused.tag}</span>
-              </div>
-              <div className="vo-meta-item">
-                <span className="vo-meta-key">TIPO</span>
-                <span className="vo-meta-val">{focused.gloss}</span>
-              </div>
-              {focused.ex && (
-                <div className="vo-meta-item vo-meta-right">
-                  <span className="vo-meta-key">EJEMPLO</span>
-                  <span className="vo-meta-val vo-meta-ex" style={{ color: ACCENT }}>{focused.ex}</span>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* RIGHT: option list */}
-      <div className="vo-right vo-noscroll">
-        <div className="vo-options-label">
-          OPCIONES · {String(options.length).padStart(2, '0')} ────
-        </div>
-
-        <div className="vo-options-list">
-          {options.map((opt, i) => {
-            const active = i === focusIdx
-            return (
-              <div
-                key={opt.id ?? i}
-                className="vo-option"
-                role="button"
-                tabIndex={0}
-                aria-label={opt.ariaLabel || opt.label}
-                style={{ paddingLeft: active ? 76 : 52, paddingTop: 14, paddingBottom: 14 }}
-                onMouseEnter={() => setFocusIdx(i)}
-                onClick={() => onSelect(opt)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    onSelect(opt)
-                  }
-                }}
-              >
-                {/* Number box */}
-                <div className="vo-option-num" style={{ color: active ? ACCENT : INK3 }}>
-                  <span className="vo-option-num-box" style={{ borderColor: active ? ACCENT : LINE }}>
-                    {i + 1}
-                  </span>
-                  {active && <span className="vo-option-tick" style={{ background: ACCENT }} />}
-                </div>
-
-                {/* Label */}
-                <div
-                  className="vo-option-label"
-                  style={{
-                    fontSize: optionFontSize,
-                    fontWeight: active ? 700 : 400,
-                    fontStyle: active ? 'italic' : 'normal',
-                    color: active ? INK : INK2,
-                  }}
-                >
-                  {opt.label}
-                </div>
-
-                {/* Tag */}
-                <div className="vo-option-tag" style={{ color: active ? ACCENT : INK3 }}>
-                  {opt.tag}
-                </div>
-
-                {/* Arrow */}
-                <div
-                  className="vo-option-arrow"
-                  style={{
-                    color: ACCENT,
-                    opacity: active ? 1 : 0,
-                    transform: active ? 'translateX(0)' : 'translateX(-6px)',
-                  }}
-                >
-                  →
-                </div>
-              </div>
-            )
-          })}
-        </div>
-      </div>
-    </div>
-  )
-}
-
 /* ────────────────────────────────────────────
    Corner crosshairs — purely decorative
 ──────────────────────────────────────────── */
@@ -846,6 +687,8 @@ function OnboardingFlow({
   getAvailableMoodsForLevel,
   getAvailableTensesForLevelAndMood,
   onGoToProgress,
+  setOnboardingStep,
+  startFromSearch,
 }) {
   const [showLevelTest, setShowLevelTest]             = useState(false)
   const [showPlacementSummary, setShowPlacementSummary] = useState(false)
@@ -853,6 +696,8 @@ function OnboardingFlow({
   const [reportSaved, setReportSaved]                   = useState(false)
   const [animKey, setAnimKey]                           = useState(0)
   const [themeSubMenu, setThemeSubMenu]                 = useState(null)
+  const [searchQuery, setSearchQuery]                   = useState('')
+  const searchInputRef                                  = useRef(null)
 
   // Bump animKey on step change to trigger animations
   const prevStep = useRef(onboardingStep)
@@ -861,6 +706,7 @@ function OnboardingFlow({
       prevStep.current = onboardingStep
       setAnimKey(k => k + 1)
       setThemeSubMenu(null)
+      setSearchQuery('')
     }
   }, [onboardingStep])
 
@@ -901,19 +747,39 @@ function OnboardingFlow({
     handleHome(setCurrentMode)
   }, [handleHome, setCurrentMode])
 
-  // Global back keyboard shortcut
+  // Global back keyboard shortcut.
+  // All three keys stand down while the user is typing: ArrowLeft moves the
+  // caret, Escape clears the search (handled by the field), and Backspace
+  // deletes a character.
   useEffect(() => {
     const fn = (e) => {
       if (showLevelTest) return
-      if (e.key === 'Escape' || e.key === 'ArrowLeft') {
-        e.preventDefault(); handleBack()
-      } else if (e.key === 'Backspace' && document.activeElement.tagName !== 'INPUT') {
+      if (isTextEntryTarget(document.activeElement)) return
+      if (e.key === 'Escape' || e.key === 'ArrowLeft' || e.key === 'Backspace') {
         e.preventDefault(); handleBack()
       }
     }
     window.addEventListener('keydown', fn)
     return () => window.removeEventListener('keydown', fn)
   }, [handleBack, showLevelTest])
+
+  // "/" from any step jumps to the main menu with the search focused.
+  useEffect(() => {
+    const fn = (e) => {
+      if (showLevelTest || e.key !== '/') return
+      if (isTextEntryTarget(e.target)) return
+      e.preventDefault()
+      if (onboardingStep === SEARCH_STEP) {
+        searchInputRef.current?.focus()
+      } else {
+        setOnboardingStep(SEARCH_STEP)
+        // The field mounts with the step, so focus after the commit.
+        setTimeout(() => searchInputRef.current?.focus(), 0)
+      }
+    }
+    window.addEventListener('keydown', fn)
+    return () => window.removeEventListener('keydown', fn)
+  }, [onboardingStep, setOnboardingStep, showLevelTest])
 
   const handlers = useMemo(() => ({
     selectDialect,
@@ -945,6 +811,48 @@ function OnboardingFlow({
   )
 
   const breadcrumb = useMemo(() => buildBreadcrumb(settings), [settings])
+
+  /* ── Topic search (main menu only) ── */
+  // Search entries that navigate somewhere instead of starting a drill.
+  const SECTION_ACTIONS = useMemo(() => ({
+    progress: onGoToProgress,
+    learning: onStartLearningNewTense,
+    placement: handleStartLevelTest
+  }), [onGoToProgress, onStartLearningNewTense, handleStartLevelTest])
+
+  const searchResults = useMemo(() => {
+    if (!searchQuery.trim()) return []
+    return searchTopics(searchQuery, getTopicSearchIndex())
+  }, [searchQuery])
+
+  // Search results are rendered by the same row component as the menu
+  // options, so each one is given the option shape the list expects.
+  const searchOptions = useMemo(() => searchResults.map(result => ({
+    ...result.entry,
+    ariaLabel: `${result.entry.label} — ${result.entry.gloss}`,
+    onSelect: () => {
+      if (result.entry.kind === 'section') {
+        SECTION_ACTIONS[result.entry.sectionId]?.()
+        return
+      }
+      startFromSearch?.(result.entry.payload, onStartPractice)
+    }
+  })), [searchResults, startFromSearch, onStartPractice, SECTION_ACTIONS])
+
+  const search = useMemo(() => ({
+    query: searchQuery,
+    onQueryChange: setSearchQuery,
+    results: searchResults.map((result, i) => ({ ...result, entry: searchOptions[i] })),
+    inputRef: searchInputRef,
+    onEscape: () => {
+      if (searchQuery) {
+        setSearchQuery('')
+      } else {
+        searchInputRef.current?.blur()
+        handleBack()
+      }
+    }
+  }), [searchQuery, searchResults, searchOptions, handleBack])
 
   const handleOptionSelect = useCallback((opt) => {
     opt.onSelect()
@@ -1009,6 +917,7 @@ function OnboardingFlow({
           stepConfig={stepConfig}
           animKey={animKey}
           onSelect={handleOptionSelect}
+          search={onboardingStep === SEARCH_STEP ? search : undefined}
         />
       ) : null}
 
@@ -1029,6 +938,7 @@ function OnboardingFlow({
           <span><em>↑↓</em> navegá</span>
           <span><em>↵ / →</em> seleccioná</span>
           <span><em>← / esc</em> volver</span>
+          <span className="vo-hint-search"><em>/</em> buscar</span>
         </div>
         <div style={{ color: INK2 }}>{stepConfig?.kicker}</div>
         <div>SISTEMA · OK</div>

--- a/src/components/onboarding/StepView.jsx
+++ b/src/components/onboarding/StepView.jsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import VoOptionRow from './VoOptionRow.jsx'
+import TopicSearch from './TopicSearch.jsx'
+import { isTextEntryTarget } from './textEntry.js'
+
+const ACCENT = 'var(--accent-primary)'
+const INK3 = 'var(--border-strong)'
+
+const LISTBOX_ID = 'vo-search-results'
+const SUGGESTIONS = ['presente', 'subjuntivo', 'participio', 'irregulares', 'a2']
+
+// Longer labels get a smaller focal word so the left panel never overflows.
+function focalSizeFor(label) {
+  const len = (label || '').length
+  const factor = len <= 6 ? 1 : len <= 10 ? 0.78 : len <= 16 ? 0.58 : len <= 22 ? 0.44 : 0.34
+  return `clamp(44px, ${Math.max(5, 12 * factor)}vw, ${Math.round(180 * factor)}px)`
+}
+
+/**
+ * Two-panel step: a giant focal word on the left, the option list on the right.
+ *
+ * When `search` is supplied (the main menu, step 2) the option list is
+ * replaced by live search results as soon as the user types, and the focal
+ * panel previews whichever result is focused. Everything else — keyboard
+ * navigation, the meta strip, the row markup — is shared between both modes.
+ */
+function StepView({ stepConfig, animKey, onSelect, search }) {
+  const [focusIdx, setFocusIdx] = useState(0)
+  const { n, kicker, prompt, aux, options } = stepConfig
+
+  const query = search?.query ?? ''
+  const hasQuery = Boolean(search && query.trim())
+  const results = hasQuery ? search.results : []
+  const noResults = hasQuery && results.length === 0
+
+  // In search mode the visible list is the results; otherwise the step options.
+  const visibleOptions = useMemo(
+    () => (hasQuery ? results.map(r => r.entry) : options),
+    [hasQuery, results, options]
+  )
+
+  useEffect(() => { setFocusIdx(0) }, [animKey])
+  // Results shrink on every keystroke, so the index must reset or it points
+  // past the end of the list and the focal panel goes blank.
+  useEffect(() => { setFocusIdx(0) }, [query])
+
+  const safeIdx = visibleOptions.length === 0
+    ? 0
+    : Math.min(focusIdx, visibleOptions.length - 1)
+  const focused = visibleOptions[safeIdx]
+
+  const moveFocus = useCallback((delta) => {
+    setFocusIdx(i => {
+      const max = visibleOptions.length - 1
+      if (max < 0) return 0
+      return Math.min(max, Math.max(0, Math.min(i, max) + delta))
+    })
+  }, [visibleOptions.length])
+
+  const commit = useCallback(() => {
+    const target = visibleOptions[Math.min(safeIdx, visibleOptions.length - 1)]
+    if (target) onSelect(target)
+  }, [visibleOptions, safeIdx, onSelect])
+
+  // Keyboard navigation for the list. Events originating in a text field are
+  // handled by the field itself (see TopicSearch), so they are skipped here —
+  // otherwise typing "a2" would trigger the digit shortcut for option 2.
+  useEffect(() => {
+    const handle = (e) => {
+      if (isTextEntryTarget(e.target)) return
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        moveFocus(1)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        moveFocus(-1)
+      } else if (e.key === 'Enter' || e.key === 'ArrowRight') {
+        e.preventDefault()
+        commit()
+      } else if (/^[1-9]$/.test(e.key)) {
+        const idx = parseInt(e.key, 10) - 1
+        if (idx < visibleOptions.length) {
+          setFocusIdx(idx)
+          onSelect(visibleOptions[idx])
+        }
+      } else if (e.key === '/' && search) {
+        e.preventDefault()
+        search.inputRef?.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', handle)
+    return () => window.removeEventListener('keydown', handle)
+  }, [moveFocus, commit, visibleOptions, onSelect, search])
+
+  const focalLabel = noResults ? 'sin resultados' : (focused?.focal || focused?.label || '')
+  const listLabel = hasQuery
+    ? `RESULTADOS · ${String(results.length).padStart(2, '0')} ────`
+    : `OPCIONES · ${String(options.length).padStart(2, '0')} ────`
+
+  return (
+    <div
+      key={animKey}
+      className={`vo-step vo-lift-in${hasQuery ? ' is-searching' : ''}`}
+    >
+      {/* LEFT: focal word display */}
+      <div className="vo-left">
+        <div className="vo-step-tag">──── {hasQuery ? 'BÚSQUEDA' : kicker}</div>
+
+        <div className="vo-watermark" aria-hidden="true">{n}</div>
+
+        <div className="vo-left-bottom">
+          <div className="vo-aux">▸ {hasQuery ? 'Resultados en vivo. Elegí uno y arrancás.' : aux}</div>
+          <div className="vo-prompt">{hasQuery ? 'Buscás...' : prompt}</div>
+
+          {/* Focal option — huge italic. In search mode the key is stable so
+              the scan-in animation doesn't retrigger on every keystroke. */}
+          <div
+            key={hasQuery ? 'search-focal' : (focused?.id ?? 'x')}
+            className="vo-focal-word vo-scan-in"
+            style={{ '--vo-focal-size': focalSizeFor(focalLabel), color: ACCENT }}
+          >
+            {focalLabel}
+            <span className="vo-cursor vo-focal-cursor" />
+          </div>
+
+          {focused && !noResults && (
+            <div className="vo-meta">
+              <div className="vo-meta-item">
+                <span className="vo-meta-key">TAG</span>
+                <span className="vo-meta-val">{focused.tag}</span>
+              </div>
+              <div className="vo-meta-item">
+                <span className="vo-meta-key">TIPO</span>
+                <span className="vo-meta-val">{focused.gloss}</span>
+              </div>
+              {focused.ex && (
+                <div className="vo-meta-item vo-meta-right">
+                  <span className="vo-meta-key">EJEMPLO</span>
+                  <span className="vo-meta-val vo-meta-ex" style={{ color: ACCENT }}>{focused.ex}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* RIGHT: search + option list */}
+      <div className={`vo-right vo-noscroll${search ? ' has-search' : ''}`}>
+        {search && (
+          <TopicSearch
+            query={query}
+            onQueryChange={search.onQueryChange}
+            resultCount={results.length}
+            hasQuery={hasQuery}
+            listboxId={LISTBOX_ID}
+            activeOptionId={focused ? `vo-opt-${focused.id}` : undefined}
+            inputRef={search.inputRef}
+            onArrow={moveFocus}
+            onCommit={commit}
+            onEscape={search.onEscape}
+          />
+        )}
+
+        <div className="vo-options-label" style={{ color: INK3 }} aria-hidden="true">
+          {listLabel}
+        </div>
+
+        {noResults ? (
+          <div className="vo-search-empty" role="status">
+            <p className="vo-search-empty-title">nada para «{query.trim()}»</p>
+            <div className="vo-search-suggestions">
+              {SUGGESTIONS.map(s => (
+                <button
+                  key={s}
+                  type="button"
+                  className="vo-search-suggestion"
+                  onClick={() => search.onQueryChange(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div
+            className="vo-options-list"
+            id={hasQuery ? LISTBOX_ID : undefined}
+            role={hasQuery ? 'listbox' : undefined}
+            aria-label={hasQuery ? 'Resultados de la búsqueda' : undefined}
+          >
+            {visibleOptions.map((opt, i) => (
+              <VoOptionRow
+                key={opt.id ?? i}
+                option={opt}
+                index={i}
+                active={i === safeIdx}
+                asListboxOption={hasQuery}
+                optionId={`vo-opt-${opt.id}`}
+                matchRanges={hasQuery ? results[i]?.ranges : null}
+                onFocus={setFocusIdx}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StepView

--- a/src/components/onboarding/TopicSearch.css
+++ b/src/components/onboarding/TopicSearch.css
@@ -1,0 +1,192 @@
+/* ──────────────────────────────────────────────
+   Topic search — main menu
+   Monochrome, sharp-cornered, underline-only field
+   so it reads as part of the vo-* system.
+────────────────────────────────────────────── */
+
+.vo-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.vo-search {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  background: var(--bg);
+  padding: 10px 0 12px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  transition: border-color 140ms ease;
+}
+
+.vo-search.is-focused {
+  border-bottom-color: var(--accent-primary);
+}
+
+.vo-search-field {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.vo-search-slash {
+  flex-shrink: 0;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--border-strong);
+  transition: color 140ms ease;
+  user-select: none;
+}
+
+.vo-search.is-focused .vo-search-slash {
+  color: var(--accent-primary);
+}
+
+.vo-search-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  outline: none;
+  padding: 2px 0;
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 18px;
+  font-weight: 300;
+  letter-spacing: -0.015em;
+  caret-color: var(--accent-primary);
+}
+
+.vo-search-input::placeholder {
+  color: var(--muted-2);
+  font-weight: 300;
+}
+
+/* Terminal-style blinking block while the field is idle and empty. */
+.vo-search-cursor {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 2px;
+  height: 18px;
+  margin-left: -8px;
+  background: var(--border-strong);
+  pointer-events: none;
+}
+
+.vo-search-clear {
+  flex-shrink: 0;
+  background: none;
+  border: 0;
+  padding: 8px;
+  margin: -8px -8px -8px 0;
+  color: var(--muted);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 120ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.vo-search-clear:hover,
+.vo-search-clear:focus-visible {
+  color: var(--accent-primary);
+}
+
+/* Matched substring inside a result label. The palette is monochrome, so the
+   highlight is an accent underline rather than a fill. */
+.vo-option-mark {
+  background: none;
+  color: inherit;
+  font-style: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  text-decoration-color: var(--accent-primary);
+}
+
+/* ── Empty state ── */
+.vo-search-empty {
+  padding: 24px 0 8px;
+}
+
+.vo-search-empty-title {
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-style: italic;
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.vo-search-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.vo-search-suggestion {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 8px 12px;
+  min-height: 36px;
+  color: var(--muted);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.vo-search-suggestion:hover,
+.vo-search-suggestion:focus-visible {
+  border-color: var(--accent-primary);
+  color: var(--text);
+}
+
+/* ── Mobile ── */
+@media (max-width: 680px) {
+  .vo-search {
+    padding: 8px 0 10px;
+  }
+
+  .vo-search-input {
+    /* Anything below 16px makes iOS Safari zoom on focus. */
+    font-size: 16px;
+  }
+
+  .vo-search-input::placeholder {
+    /* The long desktop placeholder overflows a phone; the ellipsis keeps it
+       readable without changing the string per breakpoint. */
+    text-overflow: ellipsis;
+  }
+
+  .vo-search-cursor {
+    height: 16px;
+  }
+
+  .vo-search-empty-title {
+    font-size: 17px;
+  }
+
+  .vo-search-suggestion {
+    min-height: 44px;
+    padding: 12px 14px;
+  }
+}

--- a/src/components/onboarding/TopicSearch.jsx
+++ b/src/components/onboarding/TopicSearch.jsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useRef, useState } from 'react'
+import './TopicSearch.css'
+
+const PLACEHOLDER = 'buscá un tema — participios, subjuntivo, a2, irregulares…'
+
+/**
+ * Live topic search field for the main menu.
+ *
+ * Controlled: the query and the results live in OnboardingFlow so the result
+ * list can reuse the existing option-list rendering and the focal panel.
+ * This component owns only the field itself and its keyboard handling.
+ */
+function TopicSearch({
+  query,
+  onQueryChange,
+  resultCount,
+  hasQuery,
+  listboxId,
+  activeOptionId,
+  inputRef,
+  onArrow,
+  onCommit,
+  onEscape
+}) {
+  const [focused, setFocused] = useState(false)
+  const [announcement, setAnnouncement] = useState('')
+  const localRef = useRef(null)
+  const ref = inputRef || localRef
+
+  // Announce the result count on a delay so screen readers aren't spammed
+  // once per keystroke while the list is still settling.
+  useEffect(() => {
+    if (!hasQuery) {
+      setAnnouncement('')
+      return undefined
+    }
+    const timer = setTimeout(() => {
+      setAnnouncement(`${resultCount} ${resultCount === 1 ? 'resultado' : 'resultados'}`)
+    }, 350)
+    return () => clearTimeout(timer)
+  }, [hasQuery, resultCount])
+
+  // Autofocus on desktop only. On touch devices this would pop the virtual
+  // keyboard the moment the menu opens and hide half the screen.
+  // Never let a missing or stubbed matchMedia take the whole menu down —
+  // failing closed just means no autofocus.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    let finePointer = false
+    try {
+      finePointer = window.matchMedia('(hover: hover) and (pointer: fine)')?.matches === true
+    } catch {
+      finePointer = false
+    }
+    if (finePointer) ref.current?.focus()
+  }, [ref])
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      onArrow(e.key === 'ArrowDown' ? 1 : -1)
+      return
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onCommit()
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onEscape()
+    }
+    // Everything else — arrows left/right, digits, backspace, home/end — is
+    // left to the browser. The window-level menu shortcuts skip text fields.
+  }
+
+  return (
+    <div className={`vo-search${focused ? ' is-focused' : ''}`}>
+      <label className="vo-visually-hidden" htmlFor="vo-search-input">
+        Buscar un tema, un nivel o una familia de verbos
+      </label>
+      <div className="vo-search-field">
+        <span className="vo-search-slash" aria-hidden="true">/</span>
+        <input
+          id="vo-search-input"
+          ref={ref}
+          className="vo-search-input"
+          type="text"
+          value={query}
+          placeholder={PLACEHOLDER}
+          role="combobox"
+          aria-expanded={hasQuery}
+          aria-controls={listboxId}
+          aria-activedescendant={hasQuery ? activeOptionId : undefined}
+          aria-autocomplete="list"
+          inputMode="search"
+          enterKeyHint="go"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onKeyDown={handleKeyDown}
+        />
+        {!query && !focused && <span className="vo-cursor vo-search-cursor" aria-hidden="true" />}
+        {query && (
+          <button
+            type="button"
+            className="vo-search-clear"
+            aria-label="Borrar búsqueda"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => {
+              onQueryChange('')
+              ref.current?.focus()
+            }}
+          >
+            borrar
+          </button>
+        )}
+      </div>
+
+      <p className="vo-visually-hidden" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </p>
+    </div>
+  )
+}
+
+export default TopicSearch

--- a/src/components/onboarding/TopicSearch.test.jsx
+++ b/src/components/onboarding/TopicSearch.test.jsx
@@ -1,0 +1,202 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import StepView from './StepView.jsx'
+import { getTopicSearchIndex } from '../../lib/search/topicSearchIndex.js'
+import { searchTopics } from '../../lib/search/searchTopics.js'
+
+/**
+ * These cover the two things that are easy to get wrong and invisible in unit
+ * tests: the window-level menu shortcuts fighting the input, and the ARIA
+ * combobox wiring.
+ */
+
+const STEP_CONFIG = {
+  n: '02',
+  kicker: 'ENTRADA',
+  prompt: 'Querés...',
+  aux: 'Cuatro accesos.',
+  options: [
+    { id: 'levels', label: 'practicar por nivel', tag: 'A1 → C2', gloss: 'cefr', ex: '', onSelect: vi.fn() },
+    { id: 'theme', label: 'practicar por tema', tag: 'FOCO', gloss: 'tiempo verbal', ex: '', onSelect: vi.fn() },
+    { id: 'learn', label: 'aprender', tag: 'GUIADO', gloss: 'lecciones', ex: '', onSelect: vi.fn() },
+    { id: 'progress', label: 'ver mi progreso', tag: 'DATA', gloss: 'analíticas', ex: '', onSelect: vi.fn() }
+  ]
+}
+
+// Mirrors how OnboardingFlow assembles the search prop.
+function Harness({ onSelect = vi.fn(), onEscape = vi.fn() }) {
+  const [query, setQuery] = React.useState('')
+  const inputRef = React.useRef(null)
+
+  const results = React.useMemo(() => {
+    if (!query.trim()) return []
+    return searchTopics(query, getTopicSearchIndex()).map(r => ({
+      ...r,
+      entry: { ...r.entry, onSelect: () => onSelect(r.entry) }
+    }))
+  }, [query, onSelect])
+
+  return (
+    <StepView
+      stepConfig={STEP_CONFIG}
+      animKey={0}
+      onSelect={(opt) => opt.onSelect()}
+      search={{ query, onQueryChange: setQuery, results, inputRef, onEscape }}
+    />
+  )
+}
+
+const input = () => screen.getByRole('combobox')
+
+beforeEach(() => {
+  // Deterministic: never autofocus in tests.
+  window.matchMedia = vi.fn().mockImplementation(q => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn()
+  }))
+})
+
+describe('TopicSearch in StepView', () => {
+  it('shows the normal menu options while the query is empty', () => {
+    render(<Harness />)
+    // scoped to the row: the focal panel renders the same words
+    expect(screen.getByRole('button', { name: 'practicar por nivel' })).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(input()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('replaces the options with live results as the user types, no Enter', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.type(input(), 'subjuntivo')
+
+    const listbox = screen.getByRole('listbox')
+    const options = within(listbox).getAllByRole('option')
+    expect(options.length).toBeGreaterThan(0)
+    expect(listbox).toHaveTextContent('presente de subjuntivo')
+    expect(screen.queryByRole('button', { name: 'practicar por nivel' })).not.toBeInTheDocument()
+    expect(input()).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('does not fire the digit shortcut while typing', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    // "2" would otherwise select (and navigate to) the second menu option.
+    await user.type(input(), 'a2')
+
+    expect(STEP_CONFIG.options[1].onSelect).not.toHaveBeenCalled()
+    expect(input()).toHaveValue('a2')
+    expect(screen.getByRole('listbox')).toHaveTextContent('nivel a2')
+  })
+
+  it('moves the active option with the arrow keys without losing input focus', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.type(input(), 'perfecto')
+
+    const first = input().getAttribute('aria-activedescendant')
+    expect(first).toBeTruthy()
+
+    fireEvent.keyDown(input(), { key: 'ArrowDown' })
+    const second = input().getAttribute('aria-activedescendant')
+
+    expect(second).not.toBe(first)
+    expect(document.activeElement).toBe(input())
+  })
+
+  it('launches the focused result on Enter', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<Harness onSelect={onSelect} />)
+
+    await user.type(input(), 'participio irregulares')
+    fireEvent.keyDown(input(), { key: 'Enter' })
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    const entry = onSelect.mock.calls[0][0]
+    expect(entry.payload).toMatchObject({
+      practiceMode: 'theme',
+      cameFromTema: true,
+      specificMood: 'nonfinite',
+      specificTense: 'part',
+      verbType: 'irregular'
+    })
+  })
+
+  it('launches a result on click', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<Harness onSelect={onSelect} />)
+
+    await user.type(input(), 'gerundio')
+    await user.click(within(screen.getByRole('listbox')).getAllByRole('option')[0])
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect.mock.calls[0][0].payload.specificTense).toBe('ger')
+  })
+
+  it('clears on Escape while typing, and only then delegates back-navigation', async () => {
+    const user = userEvent.setup()
+    const onEscape = vi.fn()
+    render(<Harness onEscape={onEscape} />)
+
+    await user.type(input(), 'presente')
+    fireEvent.keyDown(input(), { key: 'Escape' })
+
+    // The harness delegates to onEscape, which is what OnboardingFlow wires to
+    // "clear the query, or go back when it is already empty".
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers suggestions instead of a dead end when nothing matches', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.type(input(), 'zzzqqq')
+
+    expect(screen.getByText(/nada para/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'subjuntivo' })).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('recovers from a suggestion click', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.type(input(), 'zzzqqq')
+    await user.click(screen.getByRole('button', { name: 'participio' }))
+
+    expect(input()).toHaveValue('participio')
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('highlights the matched substring in the label', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<Harness />)
+
+    await user.type(input(), 'indefinido')
+
+    const marks = container.querySelectorAll('.vo-option-mark')
+    expect(marks.length).toBeGreaterThan(0)
+    expect(marks[0].textContent).toBe('indefinido')
+  })
+
+  it('keeps the focal panel in sync with the focused result', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<Harness />)
+
+    await user.type(input(), 'gerundio')
+
+    expect(container.querySelector('.vo-focal-word').textContent).toContain('gerundio')
+  })
+
+  it('does not autofocus on coarse pointers', () => {
+    render(<Harness />)
+    expect(document.activeElement).not.toBe(input())
+  })
+})

--- a/src/components/onboarding/VoOptionRow.jsx
+++ b/src/components/onboarding/VoOptionRow.jsx
@@ -1,0 +1,105 @@
+import React from 'react'
+
+/* ── Design tokens (mirrors OnboardingFlow.jsx) ── */
+const ACCENT = 'var(--accent-primary)'
+const INK = 'var(--text)'
+const INK2 = 'var(--muted)'
+const INK3 = 'var(--border-strong)'
+const LINE = 'var(--border)'
+
+/**
+ * Split a label into highlighted / plain segments.
+ * `ranges` are indices into the label, produced by computeHighlightRanges.
+ */
+function renderLabel(label, ranges) {
+  if (!ranges || ranges.length === 0) return label
+
+  const parts = []
+  let cursor = 0
+  ranges.forEach(([start, end], i) => {
+    if (start > cursor) parts.push(label.slice(cursor, start))
+    parts.push(
+      <mark key={`hit-${i}`} className="vo-option-mark">{label.slice(start, end)}</mark>
+    )
+    cursor = end
+  })
+  if (cursor < label.length) parts.push(label.slice(cursor))
+  return parts
+}
+
+/**
+ * A single row of the menu's option list.
+ *
+ * Used both by the normal step options (role="button") and by the search
+ * results (role="option" inside a listbox). The role must match the parent
+ * container's role, so it is passed in rather than hardcoded.
+ */
+function VoOptionRow({
+  option,
+  index,
+  active,
+  asListboxOption = false,
+  optionId,
+  matchRanges,
+  onFocus,
+  onSelect
+}) {
+  const listboxProps = asListboxOption
+    ? { role: 'option', 'aria-selected': active, id: optionId }
+    : { role: 'button', tabIndex: 0 }
+
+  return (
+    <div
+      className={`vo-option${active ? ' is-active' : ''}`}
+      aria-label={option.ariaLabel || option.label}
+      onMouseEnter={() => onFocus(index)}
+      onClick={() => onSelect(option)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onSelect(option)
+        }
+      }}
+      {...listboxProps}
+    >
+      {/* Number box */}
+      <div className="vo-option-num" style={{ color: active ? ACCENT : INK3 }}>
+        <span className="vo-option-num-box" style={{ borderColor: active ? ACCENT : LINE }}>
+          {index + 1}
+        </span>
+        {active && <span className="vo-option-tick" style={{ background: ACCENT }} />}
+      </div>
+
+      {/* Label */}
+      <div
+        className="vo-option-label"
+        style={{
+          fontWeight: active ? 700 : 400,
+          fontStyle: active ? 'italic' : 'normal',
+          color: active ? INK : INK2
+        }}
+      >
+        {renderLabel(option.label, matchRanges)}
+      </div>
+
+      {/* Tag */}
+      <div className="vo-option-tag" style={{ color: active ? ACCENT : INK3 }}>
+        {option.tag}
+      </div>
+
+      {/* Arrow */}
+      <div
+        className="vo-option-arrow"
+        style={{
+          color: ACCENT,
+          opacity: active ? 1 : 0,
+          transform: active ? 'translateX(0)' : 'translateX(-6px)'
+        }}
+      >
+        →
+      </div>
+    </div>
+  )
+}
+
+export default VoOptionRow

--- a/src/components/onboarding/textEntry.js
+++ b/src/components/onboarding/textEntry.js
@@ -1,0 +1,11 @@
+/**
+ * True when a keyboard event came from somewhere the user is typing.
+ *
+ * The menu binds several single-key shortcuts to `window` (digits 1-9 to pick
+ * an option, arrows to navigate, Escape/Backspace to go back). All of them
+ * must stand down while a text field has focus, or typing "a2" into the search
+ * box would fire the shortcut for option 2 and navigate away mid-keystroke.
+ */
+export function isTextEntryTarget(el) {
+  return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)
+}

--- a/src/hooks/useOnboardingFlow.js
+++ b/src/hooks/useOnboardingFlow.js
@@ -3,28 +3,13 @@ import { useSettings } from '../state/settings.js'
 import { getTensesForMood /* getTenseLabel, getMoodLabel */ } from '../lib/utils/verbLabels.js'
 import { getAllowedMoods as gateAllowedMoods, getAllowedTensesForMood as gateAllowedTensesForMood } from '../lib/core/eligibility.js'
 import { getFamiliesForTense } from '../lib/data/irregularFamilies.js'
-import { LEVELS } from '../lib/data/levels.js'
+import { buildLevelSettingsUpdate } from '../lib/core/levelSettingsPresets.js'
 import router from '../lib/routing/Router.js'
 import { ROUTES } from '../lib/routing/routeContract.js'
 import { createLogger } from '../lib/utils/logger.js'
 // import gates from '../data/curriculum.json'
 
 const logger = createLogger('useOnboardingFlow')
-
-// Helper function to get allowed lemmas from level configuration
-function getAllowedLemmasForLevel(level) {
-  const levelConfig = LEVELS[level]
-  if (!levelConfig || !levelConfig.verbPacks) {
-    return null // No restriction
-  }
-  
-  const allowedLemmas = new Set()
-  levelConfig.verbPacks.forEach(pack => {
-    pack.lemmas.forEach(lemma => allowedLemmas.add(lemma))
-  })
-  
-  return allowedLemmas
-}
 
 const ONBOARDING_ACTIONS = {
   SET_STEP: 'SET_STEP',
@@ -385,115 +370,9 @@ export function useOnboardingFlow() {
       logger.debug('ACTION: selectLevel', level);
     }
     closeTopPanelsAndFeatures()
-    // Apply level-specific policies
-    // DON'T set practiceMode here - let user choose in next step
-    const updates = {
-      level,
-      cameFromTema: false,
-      specificMood: null,
-      specificTense: null
-    }
-    if (level === 'A1') {
-      updates.strict = false
-      updates.accentTolerance = 'accept'
-      updates.requireDieresis = false
-      updates.blockNonNormativeSpelling = false
-      updates.cliticStrictness = 'off'
-      updates.impSubjVariantMode = 'accept_both'
-      updates.cliticsPercent = 0
-      updates.neutralizePronoun = false
-      updates.rotateSecondPerson = false
-      updates.timeMode = 'none'
-      updates.perItemMs = null
-      updates.medianTargetMs = null
-      updates.showPronouns = true
-      updates.practicePronoun = 'both'
-      updates.allowedLemmas = getAllowedLemmasForLevel('A1')
-    } else if (level === 'A2') {
-      updates.strict = false
-      updates.accentTolerance = 'warn'
-      updates.requireDieresis = false
-      updates.blockNonNormativeSpelling = false
-      updates.cliticStrictness = 'off'
-      updates.impSubjVariantMode = 'accept_both'
-      updates.cliticsPercent = 0
-      updates.neutralizePronoun = false
-      updates.rotateSecondPerson = false
-      updates.timeMode = 'soft'
-      updates.perItemMs = 8000
-      updates.medianTargetMs = null
-      updates.showPronouns = true
-      updates.allowedLemmas = getAllowedLemmasForLevel('A2')
-    } else if (level === 'B1') {
-      updates.strict = true
-      updates.accentTolerance = 'warn'
-      updates.requireDieresis = false
-      updates.blockNonNormativeSpelling = false
-      updates.cliticStrictness = 'low'
-      updates.impSubjVariantMode = 'accept_both'
-      updates.cliticsPercent = 0
-      updates.neutralizePronoun = false
-      updates.rotateSecondPerson = false
-      updates.timeMode = 'soft'
-      updates.perItemMs = 6000
-      updates.medianTargetMs = 3000
-      updates.allowedLemmas = getAllowedLemmasForLevel('B1')
-    } else if (level === 'B2') {
-      updates.strict = true
-      updates.accentTolerance = 'strict'
-      updates.requireDieresis = true
-      updates.blockNonNormativeSpelling = false
-      updates.cliticStrictness = 'low'
-      updates.impSubjVariantMode = 'accept_both'
-      updates.cliticsPercent = 10
-      updates.neutralizePronoun = false
-      updates.rotateSecondPerson = true
-      updates.timeMode = 'strict'
-      updates.perItemMs = 5000
-      updates.medianTargetMs = 2500
-      updates.allowedLemmas = getAllowedLemmasForLevel('B2')
-    } else if (level === 'C1') {
-      updates.strict = true
-      updates.accentTolerance = 'warn'
-      updates.requireDieresis = true
-      updates.blockNonNormativeSpelling = true
-      updates.cliticStrictness = 'high'
-      updates.cliticsPercent = 30
-      updates.neutralizePronoun = true
-      updates.rotateSecondPerson = false
-      updates.timeMode = 'strict'
-      updates.perItemMs = 3500
-      updates.medianTargetMs = 1800
-      updates.enableFuturoSubjRead = true
-      updates.enableFuturoSubjProd = false
-      updates.enableC2Conmutacion = false
-      updates.allowedLemmas = getAllowedLemmasForLevel('C1')
-    } else if (level === 'C2') {
-      updates.strict = true
-      updates.accentTolerance = 'strict'
-      updates.requireDieresis = true
-      updates.blockNonNormativeSpelling = true
-      updates.cliticStrictness = 'high'
-      updates.cliticsPercent = 60
-      updates.neutralizePronoun = true
-      updates.rotateSecondPerson = true
-      updates.timeMode = 'strict'
-      updates.perItemMs = 2500
-      updates.medianTargetMs = 1200
-      updates.enableFuturoSubjRead = true
-      updates.enableFuturoSubjProd = true
-      updates.enableC2Conmutacion = true
-      updates.burstSize = 16
-      updates.c2RareBoostLemmas = ['argüir','delinquir','henchir','agorar','cocer','esparcir','distinguir','tañer']
-      updates.allowedLemmas = getAllowedLemmasForLevel('C2')
-      // C2: Override region to 'global' to practice ALL dialect forms (tú, vos, vosotros)
-      updates.region = 'global'
-      updates.useTuteo = true
-      updates.useVoseo = true
-      updates.useVosotros = true
-      updates.practicePronoun = 'all'
-    }
-    settings.set(updates)
+    // Apply level-specific policies.
+    // DON'T set practiceMode here - let user choose in next step.
+    settings.set(buildLevelSettingsUpdate(level))
     setOnboardingStep(4) // Go to practice mode selection (mixed vs specific)
   }, [setOnboardingStep, settings])
 
@@ -680,6 +559,23 @@ export function useOnboardingFlow() {
     onStartPractice && onStartPractice()
   }, [settings])
 
+  /**
+   * Apply a settings payload produced by the menu topic search and jump
+   * straight into the drill, skipping the remaining onboarding steps.
+   *
+   * The payload is built by src/lib/search/searchPayloads.js and is already a
+   * complete, self-consistent settings patch — this only applies it.
+   */
+  const startFromSearch = useCallback((payload, onStartPractice) => {
+    if (import.meta.env.DEV) {
+      logger.debug('ACTION: startFromSearch', payload);
+    }
+    closeTopPanelsAndFeatures()
+    if (!payload) return
+    settings.set(payload)
+    onStartPractice && onStartPractice()
+  }, [settings])
+
   const goBack = useCallback(() => {
     if (import.meta.env.DEV) {
       logger.debug('ACTION: goBack');
@@ -735,6 +631,7 @@ export function useOnboardingFlow() {
     selectTense,
     selectVerbType,
     selectFamily,
+    startFromSearch,
     goBack,
     goToLevelDetails,
     handleHome,

--- a/src/lib/core/curriculumGate.js
+++ b/src/lib/core/curriculumGate.js
@@ -52,6 +52,30 @@ function canonicalizeTense(tense) {
   return map[tense] || tense;
 }
 
+const LEVEL_ORDER = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+
+let firstLevelByCombo = null;
+
+/**
+ * The earliest CEFR level at which a mood/tense combo is introduced.
+ * Accepts canonical or Spanish/long keys, same as the rest of this module.
+ *
+ * @returns {string|null} e.g. 'A2', or null when the combo is not in the curriculum
+ */
+export function getFirstLevelForCombo(mood, tense) {
+  if (!firstLevelByCombo) {
+    firstLevelByCombo = new Map();
+    gates.forEach(g => {
+      const key = `${canonicalizeMood(g.mood)}|${canonicalizeTense(g.tense)}`;
+      const known = firstLevelByCombo.get(key);
+      if (!known || LEVEL_ORDER.indexOf(g.level) < LEVEL_ORDER.indexOf(known)) {
+        firstLevelByCombo.set(key, g.level);
+      }
+    });
+  }
+  return firstLevelByCombo.get(`${canonicalizeMood(mood)}|${canonicalizeTense(tense)}`) || null;
+}
+
 export function getAllowedCombosForLevel(level) {
   if (!level) return new Set();
   // Build list with canonicalized mood/tense to match forms dataset

--- a/src/lib/core/levelSettingsPresets.js
+++ b/src/lib/core/levelSettingsPresets.js
@@ -1,0 +1,152 @@
+import { LEVELS } from '../data/levels.js'
+
+/**
+ * Pedagogy presets applied when a CEFR level is selected.
+ *
+ * Extracted from useOnboardingFlow.selectLevel so that any entry point that
+ * needs to drop the user into a level (the onboarding menu, the topic search)
+ * shares one definition of what a level means instead of duplicating the knobs.
+ */
+
+const C2_RARE_BOOST_LEMMAS = [
+  'argüir', 'delinquir', 'henchir', 'agorar', 'cocer', 'esparcir', 'distinguir', 'tañer'
+]
+
+// Flatten a level's verb packs into the set of lemmas the drill may use.
+export function getAllowedLemmasForLevel(level) {
+  const levelConfig = LEVELS[level]
+  if (!levelConfig || !levelConfig.verbPacks) {
+    return null // No restriction
+  }
+
+  const allowedLemmas = new Set()
+  levelConfig.verbPacks.forEach(pack => {
+    pack.lemmas.forEach(lemma => allowedLemmas.add(lemma))
+  })
+
+  return allowedLemmas
+}
+
+const LEVEL_POLICIES = {
+  A1: {
+    strict: false,
+    accentTolerance: 'accept',
+    requireDieresis: false,
+    blockNonNormativeSpelling: false,
+    cliticStrictness: 'off',
+    impSubjVariantMode: 'accept_both',
+    cliticsPercent: 0,
+    neutralizePronoun: false,
+    rotateSecondPerson: false,
+    timeMode: 'none',
+    perItemMs: null,
+    medianTargetMs: null,
+    showPronouns: true,
+    practicePronoun: 'both'
+  },
+  A2: {
+    strict: false,
+    accentTolerance: 'warn',
+    requireDieresis: false,
+    blockNonNormativeSpelling: false,
+    cliticStrictness: 'off',
+    impSubjVariantMode: 'accept_both',
+    cliticsPercent: 0,
+    neutralizePronoun: false,
+    rotateSecondPerson: false,
+    timeMode: 'soft',
+    perItemMs: 8000,
+    medianTargetMs: null,
+    showPronouns: true
+  },
+  B1: {
+    strict: true,
+    accentTolerance: 'warn',
+    requireDieresis: false,
+    blockNonNormativeSpelling: false,
+    cliticStrictness: 'low',
+    impSubjVariantMode: 'accept_both',
+    cliticsPercent: 0,
+    neutralizePronoun: false,
+    rotateSecondPerson: false,
+    timeMode: 'soft',
+    perItemMs: 6000,
+    medianTargetMs: 3000
+  },
+  B2: {
+    strict: true,
+    accentTolerance: 'strict',
+    requireDieresis: true,
+    blockNonNormativeSpelling: false,
+    cliticStrictness: 'low',
+    impSubjVariantMode: 'accept_both',
+    cliticsPercent: 10,
+    neutralizePronoun: false,
+    rotateSecondPerson: true,
+    timeMode: 'strict',
+    perItemMs: 5000,
+    medianTargetMs: 2500
+  },
+  C1: {
+    strict: true,
+    accentTolerance: 'warn',
+    requireDieresis: true,
+    blockNonNormativeSpelling: true,
+    cliticStrictness: 'high',
+    cliticsPercent: 30,
+    neutralizePronoun: true,
+    rotateSecondPerson: false,
+    timeMode: 'strict',
+    perItemMs: 3500,
+    medianTargetMs: 1800,
+    enableFuturoSubjRead: true,
+    enableFuturoSubjProd: false,
+    enableC2Conmutacion: false
+  },
+  C2: {
+    strict: true,
+    accentTolerance: 'strict',
+    requireDieresis: true,
+    blockNonNormativeSpelling: true,
+    cliticStrictness: 'high',
+    cliticsPercent: 60,
+    neutralizePronoun: true,
+    rotateSecondPerson: true,
+    timeMode: 'strict',
+    perItemMs: 2500,
+    medianTargetMs: 1200,
+    enableFuturoSubjRead: true,
+    enableFuturoSubjProd: true,
+    enableC2Conmutacion: true,
+    burstSize: 16,
+    c2RareBoostLemmas: C2_RARE_BOOST_LEMMAS,
+    // C2 practises ALL dialect forms (tú, vos, vosotros) regardless of the
+    // dialect chosen at step 1.
+    region: 'global',
+    useTuteo: true,
+    useVoseo: true,
+    useVosotros: true,
+    practicePronoun: 'all'
+  }
+}
+
+/**
+ * Build the settings patch for a CEFR level.
+ *
+ * Note it deliberately does NOT set practiceMode: the onboarding flow lets the
+ * user pick mixed vs specific in the next step, and the topic search overrides
+ * it explicitly.
+ *
+ * @param {string} level - A1..C2
+ * @returns {Object} settings patch ready for useSettings.set()
+ */
+export function buildLevelSettingsUpdate(level) {
+  return {
+    level,
+    cameFromTema: false,
+    specificMood: null,
+    specificTense: null,
+    ...(LEVEL_POLICIES[level] || {}),
+    allowedLemmas: getAllowedLemmasForLevel(level)
+  }
+}

--- a/src/lib/search/searchAliases.js
+++ b/src/lib/search/searchAliases.js
@@ -1,0 +1,121 @@
+/**
+ * Search vocabulary for the menu topic search.
+ *
+ * Pure data. These are the words a learner is likely to type that are NOT the
+ * canonical label — "perfecto", "pasado", "mandatos", "ando"… Everything here
+ * is folded at index-build time, so accents are optional but harmless.
+ */
+
+// mood key → extra words that should surface every tense of that mood
+export const MOOD_ALIASES = {
+  indicative: ['indicativo', 'indicativos', 'hechos', 'real', 'realidad'],
+  subjunctive: ['subjuntivo', 'subjuntivos', 'hipotesis', 'deseo', 'ojala', 'duda', 'emocion'],
+  imperative: ['imperativo', 'imperativos', 'mandato', 'mandatos', 'orden', 'ordenes', 'pedido'],
+  conditional: ['condicional', 'condicionales', 'cortesia', 'hipotesis', 'consejo'],
+  nonfinite: ['no conjugadas', 'no finitas', 'formas no personales', 'impersonales']
+}
+
+// tense key → extra words. The canonical label is added automatically.
+export const TENSE_ALIASES = {
+  pres: ['presente', 'presentes', 'hablo', 'ahora', 'rutina', 'habito'],
+  pretIndef: [
+    'preterito', 'preteritos', 'indefinido', 'indefinidos', 'pasado', 'pasados',
+    'perfecto simple', 'simple', 'hable', 'ayer'
+  ],
+  impf: ['imperfecto', 'imperfectos', 'copreterito', 'pasado', 'hablaba', 'antes', 'solia'],
+  pretPerf: [
+    'perfecto', 'perfectos', 'perfecto compuesto', 'compuesto', 'antepresente',
+    'pasado', 'he hablado', 'participio'
+  ],
+  plusc: [
+    'pluscuamperfecto', 'pluscuamperfectos', 'perfecto', 'compuesto', 'pasado',
+    'antecopreterito', 'habia hablado', 'participio'
+  ],
+  fut: ['futuro', 'futuros', 'futuro simple', 'hablare', 'manana'],
+  futPerf: [
+    'futuro perfecto', 'futuro compuesto', 'perfecto', 'compuesto', 'futuro',
+    'antefuturo', 'habre hablado', 'participio'
+  ],
+  subjPres: ['presente', 'subjuntivo presente', 'hable', 'ojala', 'que hable'],
+  subjImpf: [
+    'imperfecto', 'subjuntivo imperfecto', 'preterito imperfecto', 'pasado',
+    'hablara', 'hablase', 'si hablara'
+  ],
+  subjPerf: [
+    'perfecto', 'perfectos', 'compuesto', 'subjuntivo perfecto', 'haya hablado',
+    'participio'
+  ],
+  subjPlusc: [
+    'pluscuamperfecto', 'perfecto', 'compuesto', 'subjuntivo pluscuamperfecto',
+    'hubiera hablado', 'hubiese hablado', 'participio'
+  ],
+  impAff: ['afirmativo', 'imperativo afirmativo', 'mandato', 'orden', 'habla', 'hable'],
+  impNeg: ['negativo', 'imperativo negativo', 'mandato negativo', 'no hables', 'prohibicion'],
+  impMixed: ['mixto', 'mezclado', 'todas', 'imperativo mixto', 'afirmativo y negativo'],
+  cond: ['condicional', 'condicional simple', 'pospreterito', 'hablaria', 'cortesia'],
+  condPerf: [
+    'condicional compuesto', 'condicional perfecto', 'perfecto', 'compuesto',
+    'habria hablado', 'participio'
+  ],
+  ger: ['gerundio', 'gerundios', 'ando', 'iendo', 'yendo', 'hablando', 'progresivo'],
+  part: ['participio', 'participios', 'ado', 'ido', 'hablado', 'pasiva'],
+  nonfiniteMixed: ['no finitas', 'mixtas', 'mezcladas', 'gerundio y participio', 'todas']
+}
+
+export const VERB_TYPE_ALIASES = {
+  all: ['todos', 'todo', 'cualquiera', 'sin filtro', 'mixto'],
+  regular: ['regulares', 'regular', 'la regla', 'normales'],
+  irregular: ['irregulares', 'irregular', 'excepciones', 'raros', 'dificiles']
+}
+
+export const LEVEL_ALIASES = {
+  A1: ['a1', 'principiante', 'inicial', 'acceso', 'basico', 'cero', 'empezar'],
+  A2: ['a2', 'elemental', 'basico', 'plataforma'],
+  B1: ['b1', 'intermedio', 'umbral', 'medio'],
+  B2: ['b2', 'intermedio alto', 'avanzado', 'intermedio'],
+  C1: ['c1', 'avanzado', 'dominio operativo', 'alto'],
+  C2: ['c2', 'superior', 'maestria', 'nativo', 'experto', 'avanzado']
+}
+
+/**
+ * Words that describe the app's non-drill destinations.
+ * `id` matches the callback key the menu supplies.
+ */
+export const SECTION_ENTRIES = [
+  {
+    id: 'progress',
+    label: 'ver mi progreso',
+    focal: 'progreso',
+    tag: 'DATA',
+    gloss: 'analiticas',
+    ex: 'mapa de calor + srs',
+    keywords: [
+      'progreso', 'progresos', 'estadisticas', 'analiticas', 'datos', 'mapa de calor',
+      'heatmap', 'srs', 'dominio', 'mastery', 'racha', 'metricas'
+    ]
+  },
+  {
+    id: 'learning',
+    label: 'aprender un tiempo nuevo',
+    focal: 'aprender',
+    tag: 'GUIADO',
+    gloss: 'lecciones',
+    ex: 'explicacion + drill',
+    keywords: [
+      'aprender', 'aprendizaje', 'leccion', 'lecciones', 'estudiar', 'explicacion',
+      'teoria', 'guiado', 'tutorial', 'ensename'
+    ]
+  },
+  {
+    id: 'placement',
+    label: 'test de nivel',
+    focal: 'test de nivel',
+    tag: 'AUTO',
+    gloss: 'diagnostico adaptativo',
+    ex: '5 min · te ubica',
+    keywords: [
+      'test', 'test de nivel', 'nivel', 'examen', 'diagnostico', 'evaluacion',
+      'ubicacion', 'placement', 'que nivel tengo'
+    ]
+  }
+]

--- a/src/lib/search/searchPayloads.js
+++ b/src/lib/search/searchPayloads.js
@@ -1,0 +1,69 @@
+import { buildLevelSettingsUpdate } from '../core/levelSettingsPresets.js'
+
+/**
+ * Settings payloads produced by the menu topic search.
+ *
+ * Every key here must exist in SETTINGS_STATE_KEYS (src/state/settings.js) —
+ * the store's sanitizer drops unknown keys silently, so a typo would produce a
+ * quietly wrong drill. src/lib/search/searchPayloads.test.js guards that.
+ */
+
+// Same pedagogy defaults selectPracticeMode('theme') applies, so a drill
+// launched from search behaves exactly like one launched from "practicar por
+// tema".
+const THEME_POLICY = {
+  strict: true,
+  accentTolerance: 'warn',
+  requireDieresis: false,
+  blockNonNormativeSpelling: false,
+  cliticStrictness: 'low',
+  cliticsPercent: 0,
+  neutralizePronoun: false,
+  rotateSecondPerson: false,
+  timeMode: 'soft',
+  perItemMs: 6000,
+  medianTargetMs: 3000
+}
+
+/**
+ * Payload for a mood+tense topic, optionally narrowed by verb type or family.
+ *
+ * practiceMode MUST be 'theme'. It is the only value for which the family
+ * filter actually runs (src/lib/core/FormFilterService.js:371 and
+ * src/hooks/modules/DrillFormFilters.js:593) — under 'specific' a
+ * selectedFamily is accepted and then ignored. 'theme' also short-circuits the
+ * curriculum gate, which is what lets someone search "subjuntivo imperfecto"
+ * while their stored level is A1.
+ *
+ * Both mood and tense are required: buildSpecificConstraints only narrows when
+ * both are set, so a mood-only payload would silently drill everything.
+ */
+export function buildTopicPayload({ mood, tense, verbType = 'all', selectedFamily = null }) {
+  if (!mood || !tense) {
+    throw new Error(`buildTopicPayload requires both mood and tense (got ${mood}/${tense})`)
+  }
+
+  return {
+    ...THEME_POLICY,
+    practiceMode: 'theme',
+    cameFromTema: true,
+    level: null,
+    specificMood: mood,
+    specificTense: tense,
+    verbType,
+    selectedFamily,
+    // Clear any verb pack left behind by a previous level selection, otherwise
+    // a drill launched from A1 stays clamped to the A1 lemmas.
+    allowedLemmas: null
+  }
+}
+
+/** Payload for "practise everything at level X". Keeps the level gate on. */
+export function buildLevelPayload(level) {
+  return {
+    ...buildLevelSettingsUpdate(level),
+    practiceMode: 'mixed',
+    verbType: 'all',
+    selectedFamily: null
+  }
+}

--- a/src/lib/search/searchText.js
+++ b/src/lib/search/searchText.js
@@ -1,0 +1,83 @@
+/**
+ * Text primitives for the menu topic search.
+ *
+ * Everything here is pure and dependency-free so it can be unit tested in
+ * isolation and reused by both the index builder and the matcher.
+ */
+
+/**
+ * Lowercase + strip diacritics so "pretérito" and "preterito" match.
+ *
+ * IMPORTANT: this is length-preserving. Highlight ranges computed against the
+ * folded string are applied to the original label, so any transform that
+ * changed the character count (trimming, collapsing whitespace, dropping
+ * punctuation) would misalign the highlight. Only combining marks are removed,
+ * and those are separate code points introduced by NFD, not present in NFC
+ * source strings.
+ */
+export function foldForSearch(value) {
+  if (typeof value !== 'string') return ''
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}
+
+/** Split a raw query into folded, non-empty tokens. */
+export function tokenize(query) {
+  return foldForSearch(query)
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+}
+
+/**
+ * Bounded Levenshtein: true when `a` can be turned into `b` in `max` edits or
+ * fewer. Early-exits instead of computing the full matrix, which keeps the
+ * per-keystroke cost negligible across the whole index.
+ */
+export function editDistanceWithin(a, b, max = 1) {
+  if (a === b) return true
+  const lenA = a.length
+  const lenB = b.length
+  if (Math.abs(lenA - lenB) > max) return false
+  if (max < 1) return false
+
+  // Only max === 1 is needed today; a single scan handles all three edit kinds.
+  if (max === 1) {
+    let i = 0
+    let j = 0
+    let edits = 0
+    while (i < lenA && j < lenB) {
+      if (a[i] === b[j]) {
+        i++
+        j++
+        continue
+      }
+      if (++edits > max) return false
+      if (lenA === lenB) {
+        i++
+        j++
+      } else if (lenA > lenB) {
+        i++
+      } else {
+        j++
+      }
+    }
+    return edits + (lenA - i) + (lenB - j) <= max
+  }
+
+  // Generic fallback (unused today, kept correct rather than clever).
+  let prev = Array.from({ length: lenB + 1 }, (_, k) => k)
+  for (let i = 1; i <= lenA; i++) {
+    const row = [i]
+    let best = i
+    for (let j = 1; j <= lenB; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      row[j] = Math.min(row[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost)
+      if (row[j] < best) best = row[j]
+    }
+    if (best > max) return false
+    prev = row
+  }
+  return prev[lenB] <= max
+}

--- a/src/lib/search/searchTopics.js
+++ b/src/lib/search/searchTopics.js
@@ -1,0 +1,169 @@
+import { foldForSearch, tokenize, editDistanceWithin } from './searchText.js'
+import { TOPIC_KINDS } from './topicSearchIndex.js'
+
+/**
+ * Ranking for the menu topic search.
+ *
+ * Pure and synchronous. ~180 entries scored per keystroke is sub-millisecond,
+ * so there is deliberately no debounce — the results are supposed to feel like
+ * they are already there.
+ */
+
+const SCORE = {
+  EXACT_LABEL: 100,
+  LABEL_PREFIX: 70,
+  WORD_PREFIX: 50,
+  KEYWORD_EXACT: 42,
+  KEYWORD_PREFIX: 35,
+  SUBSTRING: 20,
+  FUZZY: 12
+}
+
+// Nudges so that, all else equal, the broad entry wins over the narrow one.
+// Family labels lead with the family name ("participios irregulares · …"),
+// which prefix-matches aggressively, so they need a real handicap or they
+// bury the plain tense they belong to.
+const KIND_BONUS = {
+  [TOPIC_KINDS.LEVEL]: 30,
+  [TOPIC_KINDS.TENSE]: 25,
+  [TOPIC_KINDS.SECTION]: 20,
+  [TOPIC_KINDS.VERB_TYPE]: 12,
+  [TOPIC_KINDS.FAMILY]: 0
+}
+
+// Cap so that a query like "irregulares" (which matches ~66 family entries)
+// still leaves room for the tense and verb-type rows.
+const MAX_FAMILY_RESULTS = 3
+
+/** Score one token against one entry. Returns 0 when the token doesn't match. */
+function scoreToken(entry, token) {
+  const label = entry.foldedLabel
+
+  if (label === token) return SCORE.EXACT_LABEL
+  if (label.startsWith(token)) return SCORE.LABEL_PREFIX
+  // Spanish plural of the whole label ("participios" → "participio"). Without
+  // this the plural drops to a keyword match and loses to any family whose
+  // name happens to start with the same word.
+  if (token.startsWith(label) && token.length - label.length <= 2) return SCORE.LABEL_PREFIX
+
+  // Prefix of any word inside the label ("indefinido" in "pretérito indefinido")
+  if (new RegExp(`(^|[^a-z0-9])${escapeRegExp(token)}`).test(label)) return SCORE.WORD_PREFIX
+
+  let best = 0
+  for (const keyword of entry.keywords) {
+    if (keyword === token) {
+      best = Math.max(best, SCORE.KEYWORD_EXACT)
+    } else if (keyword.startsWith(token)) {
+      best = Math.max(best, SCORE.KEYWORD_PREFIX)
+    } else if (keyword.includes(token)) {
+      best = Math.max(best, SCORE.SUBSTRING)
+    }
+    if (best === SCORE.KEYWORD_EXACT) break
+  }
+  if (best > 0) return best
+
+  if (label.includes(token)) return SCORE.SUBSTRING
+
+  // Typo tolerance, last resort and heavily penalised. Only worth attempting
+  // for tokens long enough that a single edit isn't ambiguous.
+  if (token.length >= 4) {
+    for (const word of entry.haystack.split(' ')) {
+      if (word.length >= 4 && editDistanceWithin(token, word, 1)) return SCORE.FUZZY
+    }
+  }
+
+  return 0
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Where each token matched inside the (unfolded) label, so the UI can
+ * highlight it. Safe because foldForSearch is length-preserving.
+ */
+export function computeHighlightRanges(entry, tokens) {
+  const ranges = []
+  tokens.forEach(token => {
+    let from = 0
+    for (;;) {
+      const at = entry.foldedLabel.indexOf(token, from)
+      if (at === -1) break
+      ranges.push([at, at + token.length])
+      from = at + token.length
+    }
+  })
+  if (ranges.length === 0) return ranges
+
+  // Merge overlaps so nested tokens don't produce split <mark> elements.
+  ranges.sort((a, b) => a[0] - b[0])
+  const merged = [ranges[0]]
+  for (let i = 1; i < ranges.length; i++) {
+    const last = merged[merged.length - 1]
+    if (ranges[i][0] <= last[1]) {
+      last[1] = Math.max(last[1], ranges[i][1])
+    } else {
+      merged.push(ranges[i])
+    }
+  }
+  return merged
+}
+
+/**
+ * @param {string} query - raw user input
+ * @param {Array} index - from getTopicSearchIndex()
+ * @param {{limit?: number}} options
+ * @returns {Array<{entry: Object, score: number, ranges: Array<[number, number]>}>}
+ */
+export function searchTopics(query, index, { limit = 8 } = {}) {
+  const tokens = tokenize(query)
+  if (tokens.length === 0) return []
+
+  const scored = []
+  for (let i = 0; i < index.length; i++) {
+    const entry = index[i]
+    let total = 0
+    let matchedAll = true
+
+    // AND across tokens: "participio irregulares" must hit the refined variant.
+    for (const token of tokens) {
+      const tokenScore = scoreToken(entry, token)
+      if (tokenScore === 0) {
+        matchedAll = false
+        break
+      }
+      total += tokenScore
+    }
+    if (!matchedAll) continue
+
+    total += KIND_BONUS[entry.kind] ?? 0
+    // Breaks ties among families only: the learner-facing group beats the
+    // technical family that it expands to.
+    if (entry.simplified) total += 4
+    // Shorter labels are more likely to be what a short query meant.
+    total -= Math.min(10, Math.floor(entry.foldedLabel.length / 6))
+
+    scored.push({ entry, score: total, order: i })
+  }
+
+  scored.sort((a, b) => (b.score - a.score) || (a.order - b.order))
+
+  const results = []
+  let familyCount = 0
+  for (const item of scored) {
+    if (item.entry.kind === TOPIC_KINDS.FAMILY) {
+      if (familyCount >= MAX_FAMILY_RESULTS) continue
+      familyCount++
+    }
+    results.push({
+      entry: item.entry,
+      score: item.score,
+      ranges: computeHighlightRanges(item.entry, tokens)
+    })
+    if (results.length >= limit) break
+  }
+  return results
+}
+
+export { foldForSearch, tokenize }

--- a/src/lib/search/searchTopics.test.js
+++ b/src/lib/search/searchTopics.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import { searchTopics, computeHighlightRanges } from './searchTopics.js'
+import { getTopicSearchIndex } from './topicSearchIndex.js'
+import { foldForSearch, tokenize, editDistanceWithin } from './searchText.js'
+
+const index = getTopicSearchIndex()
+const run = (query, options) => searchTopics(query, index, options)
+const labels = (query, options) => run(query, options).map(r => r.entry.label)
+const ids = (query, options) => run(query, options).map(r => r.entry.id)
+
+describe('searchText', () => {
+  it('folds accents and case', () => {
+    expect(foldForSearch('Pretérito')).toBe('preterito')
+    expect(foldForSearch('ÑOÑO')).toBe('nono')
+  })
+
+  it('preserves length so highlight ranges stay aligned', () => {
+    const source = 'Pretérito pluscuamperfecto'
+    expect(foldForSearch(source)).toHaveLength(source.length)
+    index.forEach(entry => {
+      expect(entry.foldedLabel, entry.id).toHaveLength(entry.label.length)
+    })
+  })
+
+  it('tokenizes on any non-alphanumeric run', () => {
+    expect(tokenize('  subjuntivo   imperfecto ')).toEqual(['subjuntivo', 'imperfecto'])
+    expect(tokenize('participio · irregulares')).toEqual(['participio', 'irregulares'])
+    expect(tokenize('   ')).toEqual([])
+  })
+
+  it('bounds the edit distance', () => {
+    expect(editDistanceWithin('presnte', 'presente', 1)).toBe(true)
+    expect(editDistanceWithin('presentte', 'presente', 1)).toBe(true)
+    expect(editDistanceWithin('presante', 'presente', 1)).toBe(true)
+    expect(editDistanceWithin('xyz', 'presente', 1)).toBe(false)
+    expect(editDistanceWithin('prsnte', 'presente', 1)).toBe(false)
+  })
+})
+
+describe('searchTopics', () => {
+  it('returns nothing for empty or meaningless queries', () => {
+    expect(run('')).toEqual([])
+    expect(run('   ')).toEqual([])
+    expect(run('zzzzqqq')).toEqual([])
+  })
+
+  it('is deterministic', () => {
+    expect(ids('perfecto')).toEqual(ids('perfecto'))
+  })
+
+  it('surfaces every perfect tense for "perfecto"', () => {
+    const found = labels('perfecto', { limit: 12 })
+    expect(found).toContain('pretérito perfecto')
+    expect(found).toContain('futuro compuesto')
+    expect(found).toContain('perfecto de subjuntivo')
+    expect(found).toContain('condicional compuesto')
+  })
+
+  it('surfaces every subjunctive tense for "subjuntivo"', () => {
+    const found = labels('subjuntivo', { limit: 12 })
+    expect(found).toContain('presente de subjuntivo')
+    expect(found).toContain('imperfecto de subjuntivo')
+    expect(found).toContain('perfecto de subjuntivo')
+    expect(found).toContain('pluscuamperfecto de subjuntivo')
+  })
+
+  it('narrows with a second token', () => {
+    expect(ids('subjuntivo imperfecto')[0]).toBe('tense:subjunctive:subjImpf')
+  })
+
+  it('finds participio, singular or plural', () => {
+    expect(ids('participio')[0]).toBe('tense:nonfinite:part')
+    expect(ids('participios')[0]).toBe('tense:nonfinite:part')
+  })
+
+  it('refines participio with a verb type in one query', () => {
+    expect(ids('participio irregulares')[0]).toBe('verbType:nonfinite:part:irregular')
+    expect(ids('participio regulares')[0]).toBe('verbType:nonfinite:part:regular')
+  })
+
+  it('prefers the plain tense when no verb type is mentioned', () => {
+    expect(ids('presente')[0]).toBe('tense:indicative:pres')
+    expect(ids('presente irregulares')[0]).toBe('verbType:indicative:pres:irregular')
+  })
+
+  it('finds a CEFR level and its tenses', () => {
+    const found = ids('a2', { limit: 12 })
+    expect(found[0]).toBe('level:A2')
+    expect(found).toContain('tense:indicative:pretIndef')
+  })
+
+  it('finds irregular families by the words that describe them', () => {
+    expect(ids('diptongan')[0]).toContain('STEM_CHANGES')
+    expect(ids('irregulares en yo')[0]).toContain('FIRST_PERSON_IRREGULAR')
+  })
+
+  it('caps family results so they never crowd out tenses', () => {
+    const found = run('irregulares', { limit: 8 })
+    const families = found.filter(r => r.entry.kind === 'family')
+    expect(families.length).toBeLessThanOrEqual(3)
+    expect(found.some(r => r.entry.kind === 'verbType')).toBe(true)
+  })
+
+  it('finds app sections', () => {
+    expect(ids('progreso')[0]).toBe('section:progress')
+    expect(ids('aprender')[0]).toBe('section:learning')
+    expect(ids('test de nivel')[0]).toBe('section:placement')
+  })
+
+  it('understands learner vocabulary, not just canonical labels', () => {
+    expect(ids('pasado', { limit: 12 })).toContain('tense:indicative:pretIndef')
+    expect(ids('mandatos', { limit: 12 })).toContain('tense:imperative:impAff')
+    expect(ids('ando', { limit: 12 })).toContain('tense:nonfinite:ger')
+    expect(ids('ojala', { limit: 12 })).toContain('tense:subjunctive:subjPres')
+  })
+
+  it('ignores accents in the query', () => {
+    expect(ids('preterito')).toEqual(ids('pretérito'))
+  })
+
+  it('tolerates a single typo', () => {
+    expect(ids('presnte', { limit: 5 })).toContain('tense:indicative:pres')
+    expect(ids('subjuntivio', { limit: 8 }).some(id => id.includes('subj'))).toBe(true)
+  })
+
+  it('respects the limit', () => {
+    expect(run('perfecto', { limit: 3 })).toHaveLength(3)
+  })
+})
+
+describe('computeHighlightRanges', () => {
+  const entry = index.find(e => e.id === 'tense:indicative:pretIndef')
+
+  it('locates the token inside the original label', () => {
+    const ranges = computeHighlightRanges(entry, ['indefinido'])
+    expect(ranges).toHaveLength(1)
+    const [start, end] = ranges[0]
+    expect(entry.label.slice(start, end)).toBe('indefinido')
+  })
+
+  it('maps through accented characters correctly', () => {
+    const ranges = computeHighlightRanges(entry, ['preterito'])
+    const [start, end] = ranges[0]
+    expect(entry.label.slice(start, end)).toBe('pretérito')
+  })
+
+  it('merges overlapping ranges', () => {
+    const ranges = computeHighlightRanges(entry, ['pret', 'preterito'])
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0]).toEqual([0, 9])
+  })
+
+  it('returns nothing when the match came from a keyword only', () => {
+    expect(computeHighlightRanges(entry, ['ayer'])).toEqual([])
+  })
+})

--- a/src/lib/search/topicSearchIndex.integrity.test.js
+++ b/src/lib/search/topicSearchIndex.integrity.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { getTopicSearchIndex, TOPIC_KINDS, TENSES_WITHOUT_IRREGULARS } from './topicSearchIndex.js'
+import { buildFormsForRegion } from '../core/eligibility.js'
+import { buildSpecificConstraints } from '../../hooks/modules/specificConstraints.js'
+import { applyComprehensiveFiltering } from '../../hooks/modules/DrillFormFilters.js'
+import { buildTopicPayload } from './searchPayloads.js'
+import { MOOD_TENSES } from '../utils/verbLabels.js'
+
+/**
+ * The contract that matters: every entry the search can offer must produce at
+ * least one drillable form. This runs the same pipeline useDrillGenerator does
+ * (build region forms → derive specific constraints → comprehensive filtering)
+ * rather than a proxy for it, so a payload that would leave the user staring
+ * at a "generando…" spinner fails here instead of in production.
+ */
+
+const REGIONS = ['la_general', 'rioplatense', 'peninsular']
+const index = getTopicSearchIndex()
+const drillEntries = index.filter(e => e.kind !== TOPIC_KINDS.SECTION)
+
+describe('topic search index — drillability', () => {
+  REGIONS.forEach(region => {
+    describe(region, () => {
+      let pool
+
+      it('builds a form pool for the region', async () => {
+        pool = await buildFormsForRegion(region, {})
+        expect(Array.isArray(pool)).toBe(true)
+        expect(pool.length).toBeGreaterThan(0)
+      })
+
+      it('leaves every entry with at least one eligible form', async () => {
+        const forms = pool || (await buildFormsForRegion(region, {}))
+        const empty = []
+
+        drillEntries.forEach(entry => {
+          const settings = { ...entry.payload, region }
+          const constraints = buildSpecificConstraints(settings)
+          const eligible = applyComprehensiveFiltering(forms, settings, constraints)
+          if (!eligible || eligible.length === 0) {
+            empty.push(`${entry.id} ("${entry.label}")`)
+          }
+        })
+
+        expect(empty, `entries with an empty form pool in ${region}:\n${empty.join('\n')}`)
+          .toEqual([])
+      })
+    })
+  })
+
+  // Guards TENSES_WITHOUT_IRREGULARS in the other direction: if the verb data
+  // ever grows an irregular form in one of these tenses, the exclusion becomes
+  // wrong and the entry should come back.
+  REGIONS.forEach(region => {
+    it(`excludes exactly the tenses with no irregular forms (${region})`, async () => {
+      const forms = await buildFormsForRegion(region, {})
+      const allTenses = Object.entries(MOOD_TENSES)
+        .flatMap(([mood, tenses]) => tenses.map(tense => ({ mood, tense })))
+
+      const actuallyEmpty = allTenses
+        .filter(({ mood, tense }) => {
+          const settings = { ...buildTopicPayload({ mood, tense, verbType: 'irregular' }), region }
+          const eligible = applyComprehensiveFiltering(
+            forms,
+            settings,
+            buildSpecificConstraints(settings)
+          )
+          return !eligible || eligible.length === 0
+        })
+        .map(({ tense }) => tense)
+
+      expect([...new Set(actuallyEmpty)].sort()).toEqual([...TENSES_WITHOUT_IRREGULARS].sort())
+    })
+  })
+})

--- a/src/lib/search/topicSearchIndex.js
+++ b/src/lib/search/topicSearchIndex.js
@@ -1,0 +1,321 @@
+import { MOOD_TENSES, getMoodLabel, getTenseLabel } from '../utils/verbLabels.js'
+import { getFirstLevelForCombo } from '../core/curriculumGate.js'
+import { getFamiliesForTense } from '../data/irregularFamilies.js'
+import { getSimplifiedGroupsForTense } from '../data/simplifiedFamilyGroups.js'
+import { foldForSearch } from './searchText.js'
+import {
+  MOOD_ALIASES,
+  TENSE_ALIASES,
+  VERB_TYPE_ALIASES,
+  LEVEL_ALIASES,
+  SECTION_ENTRIES
+} from './searchAliases.js'
+import { buildTopicPayload, buildLevelPayload } from './searchPayloads.js'
+
+/**
+ * Flat, searchable index of everything the main menu can take you to.
+ *
+ * Built lazily and memoised at module scope: the menu asks for it inside a
+ * useMemo, so it costs nothing until someone opens the menu and nothing again
+ * after that.
+ */
+
+export const TOPIC_KINDS = Object.freeze({
+  TENSE: 'tense',
+  VERB_TYPE: 'verbType',
+  FAMILY: 'family',
+  LEVEL: 'level',
+  SECTION: 'section'
+})
+
+// Menu-style labels. formatMoodTense() produces awkward duplicates for
+// conditional and nonfinite ("Condicional (Condicional)"), so the display
+// strings are spelled out here.
+const TENSE_LABEL = {
+  pres: 'presente',
+  pretPerf: 'pretérito perfecto',
+  pretIndef: 'pretérito indefinido',
+  impf: 'pretérito imperfecto',
+  plusc: 'pluscuamperfecto',
+  fut: 'futuro simple',
+  futPerf: 'futuro compuesto',
+  subjPres: 'presente de subjuntivo',
+  subjImpf: 'imperfecto de subjuntivo',
+  subjPerf: 'perfecto de subjuntivo',
+  subjPlusc: 'pluscuamperfecto de subjuntivo',
+  impAff: 'imperativo afirmativo',
+  impNeg: 'imperativo negativo',
+  impMixed: 'imperativo mixto',
+  cond: 'condicional simple',
+  condPerf: 'condicional compuesto',
+  ger: 'gerundio',
+  part: 'participio',
+  nonfiniteMixed: 'formas no finitas mixtas'
+}
+
+// Short word for the giant focal panel — the mood already shows in the tag.
+const TENSE_FOCAL = {
+  pres: 'presente',
+  pretPerf: 'pretérito perfecto',
+  pretIndef: 'indefinido',
+  impf: 'imperfecto',
+  plusc: 'pluscuamperfecto',
+  fut: 'futuro',
+  futPerf: 'futuro compuesto',
+  subjPres: 'presente',
+  subjImpf: 'imperfecto',
+  subjPerf: 'perfecto',
+  subjPlusc: 'pluscuamperfecto',
+  impAff: 'afirmativo',
+  impNeg: 'negativo',
+  impMixed: 'mixto',
+  cond: 'condicional',
+  condPerf: 'condicional compuesto',
+  ger: 'gerundio',
+  part: 'participio',
+  nonfiniteMixed: 'no finitas'
+}
+
+// Dialect-neutral sample forms of *hablar*.
+const TENSE_EXAMPLE = {
+  pres: 'yo hablo',
+  pretPerf: 'he hablado',
+  pretIndef: 'yo hablé',
+  impf: 'yo hablaba',
+  plusc: 'había hablado',
+  fut: 'yo hablaré',
+  futPerf: 'habré hablado',
+  subjPres: 'que yo hable',
+  subjImpf: 'si yo hablara',
+  subjPerf: 'haya hablado',
+  subjPlusc: 'hubiera hablado',
+  impAff: 'hablá · habla',
+  impNeg: 'no hables',
+  impMixed: 'hablá · no hables',
+  cond: 'yo hablaría',
+  condPerf: 'habría hablado',
+  ger: 'hablando',
+  part: 'hablado',
+  nonfiniteMixed: 'hablando · hablado'
+}
+
+const MOOD_TAG = {
+  indicative: 'IND',
+  subjunctive: 'SUBJ',
+  imperative: 'IMP',
+  conditional: 'COND',
+  nonfinite: 'NF'
+}
+
+const LEVEL_GLOSS = {
+  A1: 'presente y poco más',
+  A2: 'pasados y futuro',
+  B1: 'perfectos y subjuntivo',
+  B2: 'subjuntivo imperfecto',
+  C1: 'más exigencia, no más tiempos',
+  C2: 'máxima exigencia, no más tiempos'
+}
+
+const uniq = (values) => Array.from(new Set(values.filter(Boolean)))
+
+const MAX_FOCAL_LENGTH = 28
+
+/**
+ * The focal panel renders its word at up to 180px, so long family names blow
+ * up the layout. Drop the trailing parenthetical qualifier first (it is always
+ * a technical aside), then clip on a word boundary.
+ */
+function shortenFocal(name) {
+  const withoutQualifier = name.replace(/\s*\([^)]*\)\s*$/, '').trim() || name.trim()
+  if (withoutQualifier.length <= MAX_FOCAL_LENGTH) return withoutQualifier
+  const clipped = withoutQualifier.slice(0, MAX_FOCAL_LENGTH)
+  const lastSpace = clipped.lastIndexOf(' ')
+  return (lastSpace > 8 ? clipped.slice(0, lastSpace) : clipped).trim()
+}
+
+// Fold once at build time so matching never re-normalises the index.
+function finalize(entry) {
+  const keywords = uniq(entry.keywords.map(foldForSearch))
+  return {
+    ...entry,
+    focal: entry.focal || entry.label,
+    keywords,
+    foldedLabel: foldForSearch(entry.label),
+    haystack: `${foldForSearch(entry.label)} ${keywords.join(' ')}`
+  }
+}
+
+function tenseKeywords(mood, tense) {
+  return [
+    TENSE_LABEL[tense],
+    getTenseLabel(tense),
+    getMoodLabel(mood),
+    ...(TENSE_ALIASES[tense] || []),
+    ...(MOOD_ALIASES[mood] || [])
+  ]
+}
+
+function buildTenseEntries() {
+  const entries = []
+  Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
+    tenses.forEach(tense => {
+      const level = getFirstLevelForCombo(mood, tense)
+      entries.push(finalize({
+        id: `tense:${mood}:${tense}`,
+        kind: TOPIC_KINDS.TENSE,
+        label: TENSE_LABEL[tense],
+        focal: TENSE_FOCAL[tense],
+        tag: level || MOOD_TAG[mood],
+        gloss: getMoodLabel(mood).toLowerCase(),
+        ex: TENSE_EXAMPLE[tense],
+        level,
+        keywords: [...tenseKeywords(mood, tense), ...(level ? LEVEL_ALIASES[level] : [])],
+        payload: buildTopicPayload({ mood, tense })
+      }))
+    })
+  })
+  return entries
+}
+
+/**
+ * Compound tenses conjugate only *haber*, so their "irregulares" variant is
+ * whatever haber does in that tense. `he/has/ha` and `haya` are irregular, but
+ * `había`, `habré`, `hubiera` and `habría` are regular for their tense — those
+ * four variants have an empty form pool and must not be offered.
+ * topicSearchIndex.integrity.test.js asserts this list is exactly right, in
+ * both directions.
+ */
+export const TENSES_WITHOUT_IRREGULARS = Object.freeze(['plusc', 'futPerf', 'subjPlusc', 'condPerf'])
+
+function buildVerbTypeEntries() {
+  const entries = []
+  Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
+    tenses.forEach(tense => {
+      const level = getFirstLevelForCombo(mood, tense)
+      const verbTypes = TENSES_WITHOUT_IRREGULARS.includes(tense)
+        ? ['regular']
+        : ['regular', 'irregular']
+      ;verbTypes.forEach(verbType => {
+        const suffix = verbType === 'regular' ? 'regulares' : 'irregulares'
+        entries.push(finalize({
+          id: `verbType:${mood}:${tense}:${verbType}`,
+          kind: TOPIC_KINDS.VERB_TYPE,
+          label: `${TENSE_LABEL[tense]} · ${suffix}`,
+          focal: TENSE_FOCAL[tense],
+          tag: suffix.toUpperCase(),
+          gloss: `${getMoodLabel(mood).toLowerCase()} · ${suffix}`,
+          ex: TENSE_EXAMPLE[tense],
+          level,
+          keywords: [...tenseKeywords(mood, tense), ...VERB_TYPE_ALIASES[verbType]],
+          payload: buildTopicPayload({ mood, tense, verbType })
+        }))
+      })
+    })
+  })
+  return entries
+}
+
+function buildFamilyEntries() {
+  const entries = []
+  Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
+    tenses.forEach(tense => {
+      const level = getFirstLevelForCombo(mood, tense)
+      // Simplified groups are the learner-facing grouping and are ranked above
+      // the technical families; getFamiliesForTense() is used rather than
+      // IRREGULAR_FAMILIES because it hides families meant to stay out of menus.
+      const groups = (getSimplifiedGroupsForTense(tense) || []).map(g => ({
+        id: g.id,
+        name: g.name,
+        blurb: g.explanation || g.description || '',
+        ex: g.description || (g.exampleVerbs || []).join(' · '),
+        simplified: true
+      }))
+      const families = (getFamiliesForTense(tense) || []).map(f => ({
+        id: f.id,
+        name: f.name,
+        blurb: f.description || '',
+        ex: (f.examples || []).slice(0, 4).join(' · ') || f.description || '',
+        simplified: false
+      }))
+
+      ;[...groups, ...families].forEach(family => {
+        entries.push(finalize({
+          id: `family:${mood}:${tense}:${family.id}`,
+          kind: TOPIC_KINDS.FAMILY,
+          label: `${family.name.toLowerCase()} · ${TENSE_LABEL[tense]}`,
+          focal: shortenFocal(family.name.toLowerCase()),
+          tag: family.simplified ? 'GRUPO' : 'FAMILIA',
+          gloss: `${TENSE_LABEL[tense]} · irregulares`,
+          ex: family.ex,
+          level,
+          simplified: family.simplified,
+          keywords: [
+            family.name,
+            family.blurb,
+            family.ex,
+            ...tenseKeywords(mood, tense),
+            ...VERB_TYPE_ALIASES.irregular
+          ],
+          payload: buildTopicPayload({
+            mood,
+            tense,
+            verbType: 'irregular',
+            selectedFamily: family.id
+          })
+        }))
+      })
+    })
+  })
+  return entries
+}
+
+function buildLevelEntries() {
+  return Object.keys(LEVEL_ALIASES).map(level => finalize({
+    id: `level:${level}`,
+    kind: TOPIC_KINDS.LEVEL,
+    label: `nivel ${level.toLowerCase()} · todo mezclado`,
+    focal: level.toLowerCase(),
+    tag: 'NIVEL',
+    gloss: LEVEL_GLOSS[level],
+    ex: 'práctica mixta del nivel',
+    level,
+    keywords: [`nivel ${level}`, 'nivel', 'mezclado', 'mixto', ...LEVEL_ALIASES[level]],
+    payload: buildLevelPayload(level)
+  }))
+}
+
+function buildSectionEntries() {
+  return SECTION_ENTRIES.map(section => finalize({
+    id: `section:${section.id}`,
+    kind: TOPIC_KINDS.SECTION,
+    label: section.label,
+    focal: section.focal,
+    tag: section.tag,
+    gloss: section.gloss,
+    ex: section.ex,
+    level: null,
+    sectionId: section.id,
+    keywords: [section.label, ...section.keywords],
+    payload: null
+  }))
+}
+
+let cachedIndex = null
+
+export function getTopicSearchIndex() {
+  if (!cachedIndex) {
+    cachedIndex = [
+      ...buildTenseEntries(),
+      ...buildVerbTypeEntries(),
+      ...buildFamilyEntries(),
+      ...buildLevelEntries(),
+      ...buildSectionEntries()
+    ]
+  }
+  return cachedIndex
+}
+
+// Test-only escape hatch; production never needs to rebuild.
+export function resetTopicSearchIndex() {
+  cachedIndex = null
+}

--- a/src/lib/search/topicSearchIndex.test.js
+++ b/src/lib/search/topicSearchIndex.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { getTopicSearchIndex, TOPIC_KINDS } from './topicSearchIndex.js'
+import { getFamiliesForTense } from '../data/irregularFamilies.js'
+import { getSimplifiedGroupsForTense } from '../data/simplifiedFamilyGroups.js'
+
+const index = getTopicSearchIndex()
+
+// Mirrors createDefaultSettings() in src/state/settings.js. The store's
+// sanitizer drops unknown keys silently, so this list is the contract.
+const SETTINGS_KEYS = new Set([
+  'practiceMode', 'cameFromTema', 'level', 'specificMood', 'specificTense',
+  'verbType', 'selectedFamily', 'allowedLemmas', 'strict', 'accentTolerance',
+  'requireDieresis', 'blockNonNormativeSpelling', 'cliticStrictness',
+  'impSubjVariantMode', 'cliticsPercent', 'neutralizePronoun',
+  'rotateSecondPerson', 'timeMode', 'perItemMs', 'medianTargetMs',
+  'showPronouns', 'practicePronoun', 'enableFuturoSubjRead',
+  'enableFuturoSubjProd', 'enableC2Conmutacion', 'burstSize',
+  'c2RareBoostLemmas', 'region', 'useTuteo', 'useVoseo', 'useVosotros'
+])
+
+describe('topic search index', () => {
+  it('is non-empty and has unique ids', () => {
+    expect(index.length).toBeGreaterThan(100)
+    expect(new Set(index.map(e => e.id)).size).toBe(index.length)
+  })
+
+  it('gives every entry the fields the menu renders', () => {
+    index.forEach(entry => {
+      expect(entry.label, entry.id).toBeTruthy()
+      expect(entry.focal, entry.id).toBeTruthy()
+      expect(entry.tag, entry.id).toBeTruthy()
+      expect(entry.gloss, entry.id).toBeTruthy()
+      expect(entry.keywords.length, entry.id).toBeGreaterThan(0)
+      expect(entry.haystack, entry.id).toContain(entry.foldedLabel)
+    })
+  })
+
+  it('folds labels and keywords (no accents, no uppercase)', () => {
+    index.forEach(entry => {
+      expect(entry.haystack, entry.id).toBe(entry.haystack.toLowerCase())
+      expect(entry.haystack, entry.id).not.toMatch(/[áéíóúñü]/)
+    })
+  })
+
+  it('keeps focal words short enough for the focal panel', () => {
+    index.forEach(entry => {
+      expect(entry.focal.length, `${entry.id} → "${entry.focal}"`).toBeLessThanOrEqual(28)
+    })
+  })
+
+  describe('payloads', () => {
+    const drillEntries = index.filter(e => e.kind !== TOPIC_KINDS.SECTION)
+
+    it('only uses keys the settings store accepts', () => {
+      drillEntries.forEach(entry => {
+        Object.keys(entry.payload).forEach(key => {
+          expect(SETTINGS_KEYS.has(key), `${entry.id} → unknown settings key "${key}"`).toBe(true)
+        })
+      })
+    })
+
+    it('always sets both mood and tense for topic entries', () => {
+      index
+        .filter(e => e.kind === TOPIC_KINDS.TENSE || e.kind === TOPIC_KINDS.VERB_TYPE || e.kind === TOPIC_KINDS.FAMILY)
+        .forEach(entry => {
+          // buildSpecificConstraints only narrows when BOTH are set; a
+          // mood-only payload would silently drill everything.
+          expect(entry.payload.specificMood, entry.id).toBeTruthy()
+          expect(entry.payload.specificTense, entry.id).toBeTruthy()
+          expect(entry.payload.practiceMode, entry.id).toBe('theme')
+          expect(entry.payload.cameFromTema, entry.id).toBe(true)
+          expect(entry.payload.allowedLemmas, entry.id).toBeNull()
+        })
+    })
+
+    it('pairs every family with a tense it actually affects', () => {
+      index
+        .filter(e => e.kind === TOPIC_KINDS.FAMILY)
+        .forEach(entry => {
+          const { specificTense, selectedFamily, verbType } = entry.payload
+          // The family filter only runs for practiceMode 'theme' AND requires
+          // verbType 'irregular' for the pedagogical preterite branch.
+          expect(verbType, entry.id).toBe('irregular')
+          const valid = [
+            ...(getSimplifiedGroupsForTense(specificTense) || []),
+            ...(getFamiliesForTense(specificTense) || [])
+          ].map(f => f.id)
+          expect(valid, entry.id).toContain(selectedFamily)
+        })
+    })
+
+    it('keeps the level gate on for level entries', () => {
+      index
+        .filter(e => e.kind === TOPIC_KINDS.LEVEL)
+        .forEach(entry => {
+          expect(entry.payload.practiceMode, entry.id).toBe('mixed')
+          expect(entry.payload.cameFromTema, entry.id).toBe(false)
+          expect(entry.payload.level, entry.id).toMatch(/^[ABC][12]$/)
+          expect(entry.payload.specificMood, entry.id).toBeNull()
+        })
+    })
+
+    it('gives section entries a navigation id and no settings payload', () => {
+      const sections = index.filter(e => e.kind === TOPIC_KINDS.SECTION)
+      expect(sections.length).toBe(3)
+      sections.forEach(entry => {
+        expect(entry.payload, entry.id).toBeNull()
+        expect(entry.sectionId, entry.id).toBeTruthy()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Qué hace

Llegar a un drill concreto hoy exige recorrer hasta cinco pantallas encadenadas (dialecto → entrada → nivel → forma → tema → tiempo → tipo de verbo → familia). Este PR agrega un **buscador incremental** en el menú principal: se escribe y los resultados aparecen en vivo (sin Enter), y elegir uno entra directo al drill ya configurado.

Escribir `perfecto` trae todos los compuestos, `subjuntivo` los cuatro tiempos de subjuntivo, `participio irregulares` arranca filtrado en un solo toque, `a2` ofrece el nivel completo y los tiempos que entran en A2, `diptongan` entra a esa familia, `progreso` navega a las analíticas.

Además, `/` desde cualquier paso del onboarding lleva al menú con el campo enfocado.

## Diseño

El campo se renderiza **dentro del `StepView` que ya existía**, no como pantalla nueva. La palabra focal gigante en Fraunces itálica y el strip `TAG / TIPO / EJEMPLO` del panel izquierdo pasan a alimentarse del resultado enfocado, y las filas de resultados reusan el markup `.vo-option` (caja numerada, label, tag, flecha). El substring matcheado se marca con un subrayado en color de acento, no con un relleno — la paleta es monocroma. Sin dependencias nuevas.

En mobile (≤680px), mientras hay query el panel focal se reduce a un pie y los resultados suben al tope de la pantalla; el campo queda sticky, las filas respetan 44px de área táctil, y el input usa 16px para que iOS no haga zoom al enfocar.

## El índice

~180 entradas: los 19 combos modo×tiempo, sus variantes regulares/irregulares, familias irregulares y grupos simplificados por tiempo, los seis niveles CEFR, y los destinos progreso / aprender / test de nivel. El matching normaliza acentos, exige AND entre tokens, tolera un error de tipeo en palabras largas y entiende vocabulario de estudiante (`pasado`, `mandatos`, `ando`, `ojalá`) además de las etiquetas canónicas.

## Detalle importante: `practiceMode: 'theme'`

Los payloads de lanzamiento usan `'theme'`, no `'specific'`. Es el único modo donde el filtro por familia efectivamente corre (`FormFilterService.js`, `DrillFormFilters.js`); bajo `'specific'` un `selectedFamily` se acepta y después se ignora en silencio. También cortocircuita el gate de currículum, que es lo que permite buscar "subjuntivo imperfecto" teniendo `level: 'A1'` guardado. Se limpia `allowedLemmas` para que un drill lanzado desde A1 no quede acotado al pack de verbos de A1.

## Cambios de soporte

- **`levelSettingsPresets.js`**: se extraen los ~115 renglones de knobs por nivel de `selectLevel`, así el menú y el buscador comparten una sola definición de qué significa un nivel CEFR.
- **`StepView.jsx` / `VoOptionRow.jsx`**: extraídos de `OnboardingFlow.jsx`, que estaba por encima del límite de 500 líneas por módulo.
- **Dos conflictos de teclado** que el buscador dejó a la vista y que había que arreglar: los atajos numéricos globales disparaban mientras se tipeaba (escribir `a2` seleccionaba la opción 2 y navegaba), y `Escape`/`ArrowLeft` volvían atrás en medio de una edición. Ahora ambos se abstienen cuando el foco está en un campo de texto.
- **CSS**: el tamaño de fuente y el padding de las filas pasan de estilos inline a custom properties, para que el breakpoint mobile pueda achicarlos. Se agregan safe-area insets y `viewport-fit=cover` (el proyecto también corre como app Capacitor y no tenía ninguno).

## Tests

Cubren ranking, alineación de los rangos de resaltado, y el whitelist de claves del store (`sanitizeSettingsUpdate` descarta claves desconocidas sin error visible en producción).

El test más útil verifica que **cada entrada del índice produzca un pool de formas no vacío** atravesando el pipeline real del drill, en los tres dialectos. Encontró cuatro entradas muertas: las variantes irregulares de los compuestos cuyo auxiliar (`había`, `habré`, `hubiera`, `habría`) es regular para su tiempo. Quedan excluidas, con un test que guarda la lista en ambas direcciones para que no se pudra.

## Verificación

- `npm run lint` → 0 errores
- `npm run validate-integrity` → pasa (239 verbos)
- `npm run build` → pasa
- `npm test` → 1148 pasan. Las 5 fallas restantes son preexistentes y ajenas a este cambio (2 de teclado en `DrillMode`, 1 smoke de `ProgressDashboard`, 1 de performance sensible a timing, más 2 archivos de `tests/server` que necesitan la DB); verifiqué que fallan igual en `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014cck9nssXKAjhHdnyLy4nz)_