### PR TITLE
Búsqueda: mostrar la opción mixta (regulares + irregulares) en cada tema

### DIFF
--- a/src/lib/search/searchTopics.test.js
+++ b/src/lib/search/searchTopics.test.js
@@ -5,7 +5,6 @@ import { foldForSearch, tokenize, editDistanceWithin } from './searchText.js'
 
 const index = getTopicSearchIndex()
 const run = (query, options) => searchTopics(query, index, options)
-const labels = (query, options) => run(query, options).map(r => r.entry.label)
 const ids = (query, options) => run(query, options).map(r => r.entry.id)
 
 describe('searchText', () => {
@@ -17,8 +16,11 @@ describe('searchText', () => {
   it('preserves length so highlight ranges stay aligned', () => {
     const source = 'Pretérito pluscuamperfecto'
     expect(foldForSearch(source)).toHaveLength(source.length)
+    // foldedLabel offsets are applied straight to label, so it has to be a
+    // length-preserving fold of a label *prefix* (see finalize()).
     index.forEach(entry => {
-      expect(entry.foldedLabel, entry.id).toHaveLength(entry.label.length)
+      expect(entry.foldedLabel, entry.id).toHaveLength(entry.matchLabel.length)
+      expect(foldForSearch(entry.label).startsWith(entry.foldedLabel), entry.id).toBe(true)
     })
   })
 
@@ -49,19 +51,19 @@ describe('searchTopics', () => {
   })
 
   it('surfaces every perfect tense for "perfecto"', () => {
-    const found = labels('perfecto', { limit: 12 })
-    expect(found).toContain('pretérito perfecto')
-    expect(found).toContain('futuro compuesto')
-    expect(found).toContain('perfecto de subjuntivo')
-    expect(found).toContain('condicional compuesto')
+    const found = ids('perfecto', { limit: 12 })
+    expect(found).toContain('tense:indicative:pretPerf')
+    expect(found).toContain('tense:indicative:futPerf')
+    expect(found).toContain('tense:subjunctive:subjPerf')
+    expect(found).toContain('tense:conditional:condPerf')
   })
 
   it('surfaces every subjunctive tense for "subjuntivo"', () => {
-    const found = labels('subjuntivo', { limit: 12 })
-    expect(found).toContain('presente de subjuntivo')
-    expect(found).toContain('imperfecto de subjuntivo')
-    expect(found).toContain('perfecto de subjuntivo')
-    expect(found).toContain('pluscuamperfecto de subjuntivo')
+    const found = ids('subjuntivo', { limit: 12 })
+    expect(found).toContain('tense:subjunctive:subjPres')
+    expect(found).toContain('tense:subjunctive:subjImpf')
+    expect(found).toContain('tense:subjunctive:subjPerf')
+    expect(found).toContain('tense:subjunctive:subjPlusc')
   })
 
   it('narrows with a second token', () => {
@@ -81,6 +83,36 @@ describe('searchTopics', () => {
   it('prefers the plain tense when no verb type is mentioned', () => {
     expect(ids('presente')[0]).toBe('tense:indicative:pres')
     expect(ids('presente irregulares')[0]).toBe('verbType:indicative:pres:irregular')
+  })
+
+  describe('mixed regular + irregular option', () => {
+    it('offers it next to the two narrowed variants', () => {
+      const found = ids('gerundio', { limit: 8 })
+      expect(found).toContain('tense:nonfinite:ger')
+      expect(found).toContain('verbType:nonfinite:ger:regular')
+      expect(found).toContain('verbType:nonfinite:ger:irregular')
+      // The broad one has to lead: it is what a bare "gerundio" asks for.
+      expect(found[0]).toBe('tense:nonfinite:ger')
+    })
+
+    it('says so in the label, so it does not read as a bare heading', () => {
+      const mixed = run('gerundio')[0].entry
+      expect(mixed.label).toBe('gerundio · todos los verbos')
+      expect(mixed.payload.verbType).toBe('all')
+      expect(mixed.gloss).toContain('regulares e irregulares')
+    })
+
+    it('is reachable by asking for the mix directly', () => {
+      expect(ids('gerundio todos', { limit: 5 })[0]).toBe('tense:nonfinite:ger')
+      expect(ids('gerundio mezclado', { limit: 5 })[0]).toBe('tense:nonfinite:ger')
+      expect(ids('participio mixto', { limit: 5 })[0]).toBe('tense:nonfinite:part')
+      expect(ids('subjuntivo presente ambos', { limit: 5 })[0]).toBe('tense:subjunctive:subjPres')
+    })
+
+    it('still loses to the narrowed variant when a verb type is named', () => {
+      expect(ids('gerundio irregulares')[0]).toBe('verbType:nonfinite:ger:irregular')
+      expect(ids('gerundio regulares')[0]).toBe('verbType:nonfinite:ger:regular')
+    })
   })
 
   it('finds a CEFR level and its tenses', () => {

--- a/src/lib/search/topicSearchIndex.js
+++ b/src/lib/search/topicSearchIndex.js
@@ -118,6 +118,30 @@ const LEVEL_GLOSS = {
 
 const uniq = (values) => Array.from(new Set(values.filter(Boolean)))
 
+/**
+ * Suffix that marks the broad, unfiltered variant of a tense — the drill that
+ * mixes regular and irregular verbs. Without it the row reads as a bare tense
+ * name sitting above "· regulares" and "· irregulares", and nobody guesses it
+ * is the "both" option.
+ *
+ * Deliberately does NOT contain the word "irregulares": the label feeds the
+ * ranker, so a literal "regulares e irregulares" would make this entry beat
+ * `verbType:*:irregular` on a query like "participio irregulares".
+ */
+const MIXED_SUFFIX = 'todos los verbos'
+
+// Words a learner types when they mean "don't filter by verb type".
+const MIXED_KEYWORDS = [
+  ...VERB_TYPE_ALIASES.all,
+  'mezclado',
+  'mezclados',
+  'mezcla',
+  'ambos',
+  'ambas',
+  'completo',
+  'todos los verbos'
+]
+
 const MAX_FOCAL_LENGTH = 28
 
 /**
@@ -133,14 +157,29 @@ function shortenFocal(name) {
   return (lastSpace > 8 ? clipped.slice(0, lastSpace) : clipped).trim()
 }
 
-// Fold once at build time so matching never re-normalises the index.
+/**
+ * Fold once at build time so matching never re-normalises the index.
+ *
+ * `matchLabel` lets an entry be scored on a shorter label than the one it
+ * displays. It must be a **prefix** of `label`: computeHighlightRanges() maps
+ * offsets from foldedLabel straight onto label, and foldForSearch is
+ * length-preserving, so a prefix keeps every range aligned. It exists so the
+ * mixed-verb-type suffix can be added for the reader without demoting the entry
+ * from an exact-label match to a prefix match (and without the label-length
+ * penalty) — the broad entry has to stay above its own narrowed variants.
+ */
 function finalize(entry) {
   const keywords = uniq(entry.keywords.map(foldForSearch))
+  const matchLabel = entry.matchLabel || entry.label
+  if (!entry.label.startsWith(matchLabel)) {
+    throw new Error(`matchLabel must be a prefix of label (${entry.id})`)
+  }
   return {
     ...entry,
+    matchLabel,
     focal: entry.focal || entry.label,
     keywords,
-    foldedLabel: foldForSearch(entry.label),
+    foldedLabel: foldForSearch(matchLabel),
     haystack: `${foldForSearch(entry.label)} ${keywords.join(' ')}`
   }
 }
@@ -155,28 +194,6 @@ function tenseKeywords(mood, tense) {
   ]
 }
 
-function buildTenseEntries() {
-  const entries = []
-  Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
-    tenses.forEach(tense => {
-      const level = getFirstLevelForCombo(mood, tense)
-      entries.push(finalize({
-        id: `tense:${mood}:${tense}`,
-        kind: TOPIC_KINDS.TENSE,
-        label: TENSE_LABEL[tense],
-        focal: TENSE_FOCAL[tense],
-        tag: level || MOOD_TAG[mood],
-        gloss: getMoodLabel(mood).toLowerCase(),
-        ex: TENSE_EXAMPLE[tense],
-        level,
-        keywords: [...tenseKeywords(mood, tense), ...(level ? LEVEL_ALIASES[level] : [])],
-        payload: buildTopicPayload({ mood, tense })
-      }))
-    })
-  })
-  return entries
-}
-
 /**
  * Tenses whose "irregulares" variant has no forms at all and must not be
  * offered. Empty today: the compound tenses used to look empty only because
@@ -186,6 +203,48 @@ function buildTenseEntries() {
  * both directions.
  */
 export const TENSES_WITHOUT_IRREGULARS = Object.freeze([])
+
+/** A tense only gets a "mixed" reading when both verb types actually exist. */
+export function tenseHasBothVerbTypes(tense) {
+  return !TENSES_WITHOUT_IRREGULARS.includes(tense)
+}
+
+/**
+ * One entry per mood+tense, with no verb-type filter (`verbType: 'all'`).
+ *
+ * This is the row that mixes regular and irregular verbs. It is labelled as
+ * such whenever the tense has both, so it sits alongside its "· regulares" and
+ * "· irregulares" siblings as an obvious third choice rather than looking like
+ * a heading for them.
+ */
+function buildTenseEntries() {
+  const entries = []
+  Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
+    tenses.forEach(tense => {
+      const level = getFirstLevelForCombo(mood, tense)
+      const mixed = tenseHasBothVerbTypes(tense)
+      const moodLabel = getMoodLabel(mood).toLowerCase()
+      entries.push(finalize({
+        id: `tense:${mood}:${tense}`,
+        kind: TOPIC_KINDS.TENSE,
+        label: mixed ? `${TENSE_LABEL[tense]} · ${MIXED_SUFFIX}` : TENSE_LABEL[tense],
+        matchLabel: TENSE_LABEL[tense],
+        focal: TENSE_FOCAL[tense],
+        tag: level || MOOD_TAG[mood],
+        gloss: mixed ? `${moodLabel} · regulares e irregulares` : moodLabel,
+        ex: TENSE_EXAMPLE[tense],
+        level,
+        keywords: [
+          ...tenseKeywords(mood, tense),
+          ...(level ? LEVEL_ALIASES[level] : []),
+          ...(mixed ? MIXED_KEYWORDS : [])
+        ],
+        payload: buildTopicPayload({ mood, tense })
+      }))
+    })
+  })
+  return entries
+}
 
 /**
  * Families whose irregularity is purely orthographic — a tilde (envío,
@@ -211,9 +270,9 @@ function buildVerbTypeEntries() {
   Object.entries(MOOD_TENSES).forEach(([mood, tenses]) => {
     tenses.forEach(tense => {
       const level = getFirstLevelForCombo(mood, tense)
-      const verbTypes = TENSES_WITHOUT_IRREGULARS.includes(tense)
-        ? ['regular']
-        : ['regular', 'irregular']
+      const verbTypes = tenseHasBothVerbTypes(tense)
+        ? ['regular', 'irregular']
+        : ['regular']
       ;verbTypes.forEach(verbType => {
         const suffix = verbType === 'regular' ? 'regulares' : 'irregulares'
         entries.push(finalize({

--- a/src/lib/search/topicSearchIndex.test.js
+++ b/src/lib/search/topicSearchIndex.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getTopicSearchIndex, TOPIC_KINDS } from './topicSearchIndex.js'
+import { getTopicSearchIndex, TOPIC_KINDS, tenseHasBothVerbTypes } from './topicSearchIndex.js'
 import { getFamiliesForTense } from '../data/irregularFamilies.js'
 import { getSimplifiedGroupsForTense } from '../data/simplifiedFamilyGroups.js'
 
@@ -87,6 +87,35 @@ describe('topic search index', () => {
           ].map(f => f.id)
           expect(valid, entry.id).toContain(selectedFamily)
         })
+    })
+
+    it('offers an unfiltered mix for every tense that has both verb types', () => {
+      const tenseEntries = index.filter(e => e.kind === TOPIC_KINDS.TENSE)
+      expect(tenseEntries.length).toBeGreaterThan(0)
+
+      tenseEntries.forEach(entry => {
+        const { specificTense } = entry.payload
+        // The mix is exactly "no verb-type filter".
+        expect(entry.payload.verbType, entry.id).toBe('all')
+        expect(entry.payload.selectedFamily, entry.id).toBeNull()
+
+        if (!tenseHasBothVerbTypes(specificTense)) {
+          expect(entry.label, entry.id).not.toContain('todos los verbos')
+          return
+        }
+        // Both narrowed variants exist, so the broad one must announce itself
+        // as the third choice instead of looking like their heading.
+        expect(entry.label, entry.id).toContain('· todos los verbos')
+        expect(entry.gloss, entry.id).toContain('regulares e irregulares')
+        expect(
+          index.some(e => e.id === `verbType:${entry.payload.specificMood}:${specificTense}:regular`),
+          entry.id
+        ).toBe(true)
+        expect(
+          index.some(e => e.id === `verbType:${entry.payload.specificMood}:${specificTense}:irregular`),
+          entry.id
+        ).toBe(true)
+      })
     })
 
     it('keeps the level gate on for level entries', () => {


### PR DESCRIPTION
## El problema

Buscando "gerundio" en el menú principal aparecían tres filas:

```
gerundio                 [A2]
gerundio · regulares     [REGULARES]
gerundio · irregulares   [IRREGULARES]
```

La primera **ya era** el drill mixto (`verbType: 'all'`, lo mismo a lo que se llega a mano por los menús), pero con el nombre pelado del tiempo parecía un encabezado de las dos de abajo, no una tercera opción. No había forma de saber que ahí estaba "practicar todo".

## El cambio

La fila amplia ahora se anuncia como tal, para cada tiempo que efectivamente tenga las dos variantes:

```
gerundio · todos los verbos   [A2]
gerundio · regulares          [REGULARES]
gerundio · irregulares        [IRREGULARES]
```

- Sufijo `· todos los verbos` en el label y gloss `… · regulares e irregulares` en el panel focal.
- Palabras que un estudiante tipearía para pedir la mezcla: `todos`, `todo`, `mezclado`, `mixto`, `ambos`, `cualquiera`… Así `gerundio todos`, `participio mixto` o `subjuntivo presente ambos` caen en la fila correcta.
- Condicionado a `tenseHasBothVerbTypes(tense)` (extraído de `TENSES_WITHOUT_IRREGULARS`): si un tiempo no tuviera irregulares, no se etiqueta como mezcla.

No cambia ningún payload — la opción y el drill que lanza son los mismos de antes, solo se vuelven visibles.

## Dos detalles de ranking

El label alimenta al ranker, así que el sufijo no podía ser cualquiera:

1. **Por qué no dice "regulares e irregulares"**: la palabra `irregulares` dentro del label le daría a la fila amplia un `WORD_PREFIX` en la query `participio irregulares`, y pasaría por encima de `verbType:nonfinite:part:irregular`. `todos los verbos` no colisiona.
2. **`matchLabel`**: nuevo campo opcional con el prefijo del label que se puntúa. Sin él, `gerundio · todos los verbos` bajaba de `EXACT_LABEL` a `LABEL_PREFIX` y encima pagaba la penalización por largo, justo en la entrada que tiene que quedar arriba. `finalize()` valida que sea prefijo del label, que es lo que mantiene alineados los rangos de resaltado.

## Tests

- `src/lib/search/` completo: 53 passing (`npx vitest run src/lib/search/`).
- Nuevos: la tríada aparece junta y la amplia lidera; el label/gloss/payload de la mezcla; `gerundio todos` / `gerundio mezclado` / `participio mixto` / `subjuntivo presente ambos`; y que `gerundio irregulares` sigue ganándola la variante angosta.
- `topicSearchIndex.test.js`: cada entrada de tipo `tense` es `verbType: 'all'` y está etiquetada como mezcla si y solo si existen sus dos variantes `verbType`.
- Dos tests existentes pasaron de comparar labels a comparar ids (los labels cambiaron, el ranking no), y el de alineación de resaltado ahora asegura la invariante de prefijo en vez de igualdad de largo.
- `npm run validate-integrity`: OK, 0 errores.
- `navigationBack.test.jsx` tiene 1 test que falla, verificado como preexistente en `main` (sin relación con búsqueda).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdrB2cWvXsJKQAh1a7VrPN)_