### PR TITLE
Evitar que el drill se recargue solo al entrar a practicar

### DIFF
--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -204,6 +204,15 @@ function AppRouter() {
   useEffect(() => {
     // Check if we're in drill mode
     if (currentMode === 'drill') {
+      // A generation is already running (an explicit regenerate, or a personalized
+      // session temporarily swapping practiceMode). Reacting to settings now would
+      // clear the item the in-flight generation is about to deliver and kick off a
+      // competing one — a visible reload right after the drill appears. Leave the
+      // snapshot untouched so the comparison below still runs once it settles.
+      if (drillMode.isGenerating) {
+        return;
+      }
+
       // CRITICAL: Always read fresh settings from store to avoid stale closures
       const LATEST_SETTINGS = useSettings.getState();
 
@@ -221,7 +230,7 @@ function AppRouter() {
       }
 
       // Generate new item if we don't have one (either new entry or after clearing)
-      if (!drillMode.currentItem && !drillMode.isGenerating) {
+      if (!drillMode.currentItem) {
         // Add a delay to ensure settings have fully propagated through all stores
         scheduleDrillGeneration(() => {
           const helpers = onboardingFlowRef.current
@@ -528,6 +537,7 @@ function AppRouter() {
           onNavigateToTimeline={handleStartTimelineMode}
           getGenerationStats={drillMode.getGenerationStats}
           isGenerationViable={drillMode.isGenerationViable}
+          isGenerating={drillMode.isGenerating}
         />
       </React.Suspense>
     )

--- a/src/components/drill/DrillMode.jsx
+++ b/src/components/drill/DrillMode.jsx
@@ -53,6 +53,7 @@
  * @param {Function} props.onNavigateToTimeline - Lanzar el modo línea de tiempo
  * @param {Function} props.getGenerationStats - Obtener estadísticas de generación (diagnóstico)
  * @param {Function} props.isGenerationViable - Verificar si la generación es viable
+ * @param {boolean} props.isGenerating - Si hay una generación de ítem en curso (evita reintentos que compiten con ella)
  * 
  * @requires Drill - Componente core de práctica de conjugaciones
  * @requires DrillHeader - Header con botones de navegación y paneles
@@ -79,6 +80,11 @@ import Drill from '../../features/drill/Drill.jsx'
 
 const logger = createLogger('drill:mode')
 
+// Only used when no generation is in flight, so it can afford to be patient:
+// a shorter window used to fire while the first generation was still loading the
+// verb dataset on slower (mobile) devices.
+const QUICK_RETRY_DELAY_MS = 1200
+
 /**
  * Componente principal del modo práctica rápida
  * 
@@ -101,7 +107,8 @@ function DrillMode({
   onNavigateToStory,
   onNavigateToTimeline,
   getGenerationStats,
-  isGenerationViable
+  isGenerationViable,
+  isGenerating = false
 }) {
   const [showQuickSwitch, setShowQuickSwitch] = useState(false)
   const [showAccentKeys, setShowAccentKeys] = useState(false)
@@ -296,54 +303,73 @@ function DrillMode({
     onRegenerateItem()
   }, [onPracticeModeChange, onRegenerateItem, settings])
 
+  // Keep the latest callbacks in refs so the safety-net timers below are not torn
+  // down and rescheduled on every parent render (their identities change each time,
+  // which used to make the retry clock restart unpredictably).
+  const canRegenerateItem = typeof onRegenerateItem === 'function'
+  const onRegenerateItemRef = React.useRef(onRegenerateItem)
+  const buildGenerationDiagnosticsRef = React.useRef(buildGenerationDiagnostics)
+  useEffect(() => {
+    onRegenerateItemRef.current = onRegenerateItem
+    buildGenerationDiagnosticsRef.current = buildGenerationDiagnostics
+  })
+
   // Enhanced safety net: if no item is present, trigger regeneration with escalating timeouts
   useEffect(() => {
-    if (!currentItem && typeof onRegenerateItem === 'function') {
-      // Clear any previous error states
-      setLoadingError(null)
-      setLoadingTimeout(false)
-      setGenerationIssue(null)
-
-      // First attempt after 300ms (quick retry)
-      const quickRetryId = setTimeout(() => {
-        try {
-          logger.debug('🔄 DrillMode: Quick retry for missing currentItem')
-          onRegenerateItem()
-        } catch (error) {
-          logger.error('Quick retry failed', error)
-        }
-      }, 300)
-
-      // Timeout warning after 8 seconds
-      const timeoutWarningId = setTimeout(() => {
-        if (!currentItem) {
-          logger.warn('Item generation taking longer than expected')
-          setLoadingTimeout(true)
-          buildGenerationDiagnostics().then(setGenerationIssue)
-        }
-      }, 8000)
-
-      // Final timeout and error after 15 seconds
-      const finalTimeoutId = setTimeout(() => {
-        if (!currentItem) {
-          logger.error('Item generation failed - timeout after 15 seconds')
-          setLoadingError('La generación de ejercicios está tardando más de lo esperado. Esto puede deberse a una configuración muy restrictiva.')
-          buildGenerationDiagnostics().then(setGenerationIssue)
-        }
-      }, 15000)
-
-      return () => {
-        clearTimeout(quickRetryId)
-        clearTimeout(timeoutWarningId)
-        clearTimeout(finalTimeoutId)
-      }
-    } else {
+    if (currentItem || !canRegenerateItem) {
       // Clear error states when we have an item
       setLoadingError(null)
       setLoadingTimeout(false)
       setGenerationIssue(null)
+      return
     }
-  }, [buildGenerationDiagnostics, currentItem, onRegenerateItem])
+
+    // Clear any previous error states
+    setLoadingError(null)
+    setLoadingTimeout(false)
+    setGenerationIssue(null)
+
+    // Timeout warning after 8 seconds
+    const timeoutWarningId = setTimeout(() => {
+      logger.warn('Item generation taking longer than expected')
+      setLoadingTimeout(true)
+      buildGenerationDiagnosticsRef.current().then(setGenerationIssue)
+    }, 8000)
+
+    // Final timeout and error after 15 seconds
+    const finalTimeoutId = setTimeout(() => {
+      logger.error('Item generation failed - timeout after 15 seconds')
+      setLoadingError('La generación de ejercicios está tardando más de lo esperado. Esto puede deberse a una configuración muy restrictiva.')
+      buildGenerationDiagnosticsRef.current().then(setGenerationIssue)
+    }, 15000)
+
+    // A generation is already running: it will deliver an item on its own. Firing a
+    // retry here would race it, and the loser overwrites the winner's item — that is
+    // what made the drill visibly reload itself a moment after the first render.
+    // This effect re-runs when `isGenerating` drops back to false, so a genuinely
+    // stuck generation still gets retried.
+    if (isGenerating) {
+      return () => {
+        clearTimeout(timeoutWarningId)
+        clearTimeout(finalTimeoutId)
+      }
+    }
+
+    const quickRetryId = setTimeout(() => {
+      try {
+        logger.debug('🔄 DrillMode: Quick retry for missing currentItem')
+        onRegenerateItemRef.current()
+      } catch (error) {
+        logger.error('Quick retry failed', error)
+      }
+    }, QUICK_RETRY_DELAY_MS)
+
+    return () => {
+      clearTimeout(quickRetryId)
+      clearTimeout(timeoutWarningId)
+      clearTimeout(finalTimeoutId)
+    }
+  }, [canRegenerateItem, currentItem, isGenerating])
 
   // Listen for navigation requests from ProgressDashboard
   useEffect(() => {

--- a/src/components/drill/DrillMode.regeneration.test.jsx
+++ b/src/components/drill/DrillMode.regeneration.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./DrillHeader.jsx', () => ({
+  default: () => <header />
+}))
+
+vi.mock('../../features/drill/Drill.jsx', () => ({
+  default: () => <div data-testid="drill-content">Drill Content</div>
+}))
+
+vi.mock('../../state/session.js', () => ({
+  useSessionStore: (selector) => selector({
+    startPersonalizedSession: vi.fn(),
+    setDrillRuntimeContext: vi.fn()
+  })
+}))
+
+vi.mock('../../lib/utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+import DrillMode from './DrillMode.jsx'
+
+const createProps = (overrides = {}) => ({
+  currentItem: null,
+  settings: {
+    practiceMode: 'mixed',
+    practicePronoun: 'all',
+    selectedFamily: null,
+    specificMood: null,
+    specificTense: null,
+    verbType: 'all',
+    set: vi.fn()
+  },
+  onDrillResult: vi.fn(),
+  onContinue: vi.fn(),
+  onHome: vi.fn(),
+  onRegenerateItem: vi.fn(),
+  onDialectChange: vi.fn(),
+  onPracticeModeChange: vi.fn(),
+  onStartSpecificPractice: vi.fn(),
+  getAvailableMoodsForLevel: vi.fn(() => ['indicative']),
+  getAvailableTensesForLevelAndMood: vi.fn(() => ['pres']),
+  onNavigateToProgress: vi.fn(),
+  onNavigateToStory: vi.fn(),
+  onNavigateToTimeline: vi.fn(),
+  getGenerationStats: vi.fn(async () => ({ totalForms: 1, eligibleForms: 1 })),
+  isGenerationViable: vi.fn(async () => true),
+  isGenerating: false,
+  ...overrides
+})
+
+describe('DrillMode regeneration safety net', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not retry generation while one is already in flight', () => {
+    const props = createProps({ isGenerating: true })
+
+    render(<DrillMode {...props} />)
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(props.onRegenerateItem).not.toHaveBeenCalled()
+  })
+
+  it('retries once generation stops without producing an item', () => {
+    const props = createProps({ isGenerating: true })
+    const { rerender } = render(<DrillMode {...props} />)
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(props.onRegenerateItem).not.toHaveBeenCalled()
+
+    rerender(<DrillMode {...props} isGenerating={false} />)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(props.onRegenerateItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry once an item is available', () => {
+    const props = createProps({
+      currentItem: { lemma: 'hablar', mood: 'indicative', tense: 'pres', person: '1s', value: 'hablo' }
+    })
+
+    render(<DrillMode {...props} />)
+
+    act(() => {
+      vi.advanceTimersByTime(20000)
+    })
+
+    expect(props.onRegenerateItem).not.toHaveBeenCalled()
+  })
+
+  it('keeps the retry clock stable when parent callbacks change identity', () => {
+    // AppRouter rebuilds every drill handler on each render, so the props DrillMode
+    // receives are new functions every time. The pending retry must survive that
+    // instead of being rescheduled from zero on each parent render.
+    let regenerateCalls = 0
+    const makeRegenerate = () => vi.fn(() => { regenerateCalls += 1 })
+
+    const props = createProps({ onRegenerateItem: makeRegenerate() })
+    const { rerender } = render(<DrillMode {...props} />)
+
+    for (let i = 0; i < 6; i++) {
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+      rerender(
+        <DrillMode
+          {...props}
+          onRegenerateItem={makeRegenerate()}
+          onContinue={vi.fn()}
+          getGenerationStats={vi.fn(async () => ({ totalForms: 1, eligibleForms: 1 }))}
+        />
+      )
+    }
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(regenerateCalls).toBe(1)
+  })
+})

--- a/src/hooks/modules/drillGenerationSignals.js
+++ b/src/hooks/modules/drillGenerationSignals.js
@@ -1,0 +1,22 @@
+/**
+ * drillGenerationSignals.js - Shared markers for drill generation outcomes
+ *
+ * `generateNextItem` used to return `null` both when generation genuinely failed
+ * and when a previous generation was still in flight. Callers cannot tell those
+ * apart, so a concurrent call would be treated as a failure and replaced with an
+ * emergency fallback item, producing a visible "reload" flash in the drill UI.
+ *
+ * This module lives outside `useDrillGenerator.js` on purpose: tests mock that
+ * hook module wholesale, so the marker has to come from somewhere that stays real.
+ */
+
+/** Returned when a generation request is dropped because another one is running. */
+export const GENERATION_SKIPPED = Object.freeze({ drillGenerationSkipped: true })
+
+/**
+ * @param {unknown} value - Value returned by a generation call
+ * @returns {boolean} - Whether the call was skipped because generation was busy
+ */
+export function isGenerationSkipped(value) {
+  return !!value && typeof value === 'object' && value.drillGenerationSkipped === true
+}

--- a/src/hooks/modules/useDrillGenerator.generateNextItem.test.js
+++ b/src/hooks/modules/useDrillGenerator.generateNextItem.test.js
@@ -159,6 +159,46 @@ describe('useDrillGenerator.generateNextItem integration', () => {
     })
   })
 
+  it('skips a concurrent request instead of reporting a failure', async () => {
+    let releasePool
+    resolveFormsPoolMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releasePool = () => resolve({
+        forms: [{ lemma: 'hablar', mood: 'indicative', tense: 'pres', person: '1s' }],
+        signature: 'sig',
+        reused: false,
+        durationMs: 10,
+        cache: { signature: 'sig', forms: [] }
+      })
+    }))
+
+    const { useDrillGenerator } = await import('./useDrillGenerator.js')
+    const { GENERATION_SKIPPED, isGenerationSkipped } = await import('./drillGenerationSignals.js')
+    const { result } = renderHook(() => useDrillGenerator())
+
+    let firstPromise
+    let secondResult
+    await act(async () => {
+      // Kick off a generation and, before it settles, fire a second one in the same
+      // tick — exactly what the DrillMode retry timer used to do.
+      firstPromise = result.current.generateNextItem()
+      secondResult = await result.current.generateNextItem()
+    })
+
+    expect(secondResult).toBe(GENERATION_SKIPPED)
+    expect(isGenerationSkipped(secondResult)).toBe(true)
+    // Crucially, it is distinguishable from a real failure.
+    expect(secondResult).not.toBeNull()
+
+    let firstItem
+    await act(async () => {
+      releasePool()
+      firstItem = await firstPromise
+    })
+
+    expect(firstItem).toMatchObject({ id: 'drill-1', lemma: 'hablar' })
+    expect(resolveFormsPoolMock).toHaveBeenCalledTimes(1)
+  })
+
   it('exposes last filtering report through getGenerationStats', async () => {
     getFilteringDiagnosticsMock.mockReturnValueOnce({
       filtered: [],

--- a/src/hooks/modules/useDrillGenerator.js
+++ b/src/hooks/modules/useDrillGenerator.js
@@ -53,6 +53,7 @@ import {
 } from './specificConstraints.js'
 import { selectNextForm } from './hierarchicalSelection.js'
 import { buildEligibleFormsKey, shouldCacheEligibleForms } from './drillCacheKey.js'
+import { GENERATION_SKIPPED } from './drillGenerationSignals.js'
 import { createLogger } from '../../lib/utils/logger.js'
 
 const logger = createLogger('useDrillGenerator')
@@ -66,6 +67,7 @@ export const useDrillGenerator = () => {
   const [isGenerating, setIsGenerating] = useState(false)
   const [lastGeneratedItem, setLastGeneratedItem] = useState(null)
   const [lastFilteringReport, setLastFilteringReport] = useState(null)
+  const isGeneratingRef = useRef(false)
   const lastFilteringReportRef = useRef(null)
   const formsPoolRef = useRef({ signature: null, forms: null })
   const eligibleFormsCacheRef = useRef({ key: null, forms: null })
@@ -105,9 +107,11 @@ export const useDrillGenerator = () => {
     getAvailableTensesForLevelAndMood,
     history = {}
   ) => {
-    if (isGenerating) {
+    // Ref-based guard: `isGenerating` state lags behind by a render, so two calls
+    // landing in the same tick would both get past a state-only check.
+    if (isGeneratingRef.current) {
       logger.warn('generateNextItem', 'Generation already in progress')
-      return null
+      return GENERATION_SKIPPED
     }
 
     // CRITICAL FIX: Read fresh settings directly from store to avoid stale closures
@@ -115,6 +119,7 @@ export const useDrillGenerator = () => {
 
     const { reviewSessionType, reviewSessionFilter } = getReviewSessionContext(FRESH_SETTINGS)
 
+    isGeneratingRef.current = true
     setIsGenerating(true)
 
     try {
@@ -395,9 +400,10 @@ export const useDrillGenerator = () => {
       setLastGeneratedItem(emergencyItem)
       return emergencyItem
     } finally {
+      isGeneratingRef.current = false
       setIsGenerating(false)
     }
-  }, [isGenerating])
+  }, [getNow])
 
   /**
    * Check if generation is currently possible

--- a/src/hooks/useDrillMode.js
+++ b/src/hooks/useDrillMode.js
@@ -17,6 +17,7 @@ import { useSessionStore } from '../state/session.js'
 import { useDrillGenerator } from './modules/useDrillGenerator.js'
 import { useDrillProgress } from './modules/useDrillProgress.js'
 import { useDrillValidation } from './modules/useDrillValidation.js'
+import { isGenerationSkipped } from './modules/drillGenerationSignals.js'
 
 // Import remaining functionality that wasn't modularized
 import { getMotivationalInsights } from '../lib/progress/personalizedCoaching.js'
@@ -154,7 +155,9 @@ export function useDrillMode() {
         history
       )
 
-      if (newItem) {
+      if (isGenerationSkipped(newItem)) {
+        logger.debug('handleSessionGeneration', 'Generation already in flight, keeping current item')
+      } else if (newItem) {
         const validation = validateItem(newItem)
         if (!validation.valid) {
           logger.warn('handleSessionGeneration', 'Generated session item failed validation', validation)
@@ -224,6 +227,13 @@ export function useDrillMode() {
         if (timeoutId) {
           clearTimeout(timeoutId)
         }
+      }
+
+      // Another generation owns the current request; bailing out keeps the item
+      // that generation is about to produce instead of flashing a fallback first.
+      if (isGenerationSkipped(newItem)) {
+        logger.debug('generateNormalItem', 'Generation already in flight, skipping duplicate request')
+        return
       }
     } catch (error) {
       logger.error('generateNormalItem', 'Generation failed or timed out', error)


### PR DESCRIPTION
## El problema

Al entrar al conjugador, el ejercicio aparecía y ~1 segundo después toda la pantalla se recargaba sola con otro ejercicio distinto, a veces dos o tres veces seguidas. Se nota sobre todo en móvil: el glitch depende de una carrera contra el tiempo de generación del primer ítem, y en desktop la generación suele ganar.

## La causa

`DrillMode` tenía una red de seguridad que, si no había ítem, disparaba una regeneración a los **300 ms**. Pero `AppRouter` ya espera 100 ms antes de arrancar la primera generación, así que quedaban ~200 ms para cargar el chunk de verbos (2,2 MB) y armar el pool de formas. En móvil eso nunca alcanza, con lo cual el reintento saltaba **siempre** y competía con la generación en curso.

Tres cosas más lo empeoraban:

1. El guard de concurrencia de `useDrillGenerator` devolvía `null`, exactamente igual que un fallo real. `useDrillMode` no podía distinguirlos, lo interpretaba como error y fabricaba un ítem de emergencia que pisaba al verdadero (en modo mixto ese ítem sale de los primeros 5 verbos, con cualquier modo/tiempo).
2. Ese guard se basaba en estado (`isGenerating`), que llega un render tarde: dos llamadas en el mismo tick lo atravesaban.
3. El efecto de `AppRouter` reaccionaba a cambios de settings hechos por la propia generación en vuelo (sesiones personalizadas que cambian `practiceMode` temporalmente, QuickSwitch), limpiando el ítem y arrancando otra generación encima.

## Los cambios

- **`DrillMode.jsx`**: la red de seguridad no reintenta mientras hay una generación en curso, y su reintento pasa de 300 ms a 1200 ms. El efecto vuelve a correr cuando `isGenerating` baja a `false`, así que una generación realmente colgada se sigue reintentando. Los callbacks del padre se guardan en refs para que los temporizadores no se reprogramen en cada render de `AppRouter`.
- **`drillGenerationSignals.js`** (nuevo): marcador `GENERATION_SKIPPED` + helper `isGenerationSkipped()`. Vive fuera de `useDrillGenerator.js` porque los tests mockean ese módulo entero.
- **`useDrillGenerator.js`**: el guard de concurrencia usa un ref (no estado) y devuelve `GENERATION_SKIPPED` en vez de `null`.
- **`useDrillMode.js`**: respeta ese marcador y conserva el ítem en curso en lugar de inventar uno de emergencia.
- **`AppRouter.jsx`**: no limpia ni regenera mientras hay una generación en vuelo, y deja intacto el snapshot de settings para que la comparación se haga bien una vez que termina.

## Verificación

Reproducido y verificado con Chromium (perfil Pixel 5, CPU throttling x3 y x6) contra el build de producción, midiendo cada repintado de `.verb-lemma` / `.conjugation-context`:

| | antes | después |
|---|---|---|
| ítems pintados por entrada al drill | hasta 4, con vueltas a "CARGANDO" en el medio | 1 |
| corridas estables | 0/3 | 8/8 |

El ciclo responder → continuar sigue avanzando correctamente en modo mixto, específico (`indicative/pres`) y específico + irregular (`subjunctive/subjPres`), respetando las restricciones de cada modo.

Tests nuevos:
- `DrillMode.regeneration.test.jsx` — no reintenta durante la generación, sí reintenta cuando termina sin ítem, no reintenta con ítem presente, y el reloj del reintento sobrevive a los cambios de identidad de los callbacks.
- `useDrillGenerator.generateNextItem.test.js` — una llamada concurrente devuelve `GENERATION_SKIPPED` y no vuelve a resolver el pool.

`npm run lint` (0 errores) y `npm run validate-integrity` (239 verbos, OK) pasan. Las 3 fallas en `navigationBack.test.jsx` y `DrillMode.keyboard.test.jsx` son previas a esta rama — verificado corriéndolas sobre el commit base.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGnxQ8kr7Th9i93higq6UY)_