### PR TITLE
Cortar las dos recargas del drill al mostrar un ejercicio

### DIFF
--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -243,6 +243,11 @@ function AppRouter() {
             helpers.getAvailableTensesForLevelAndMood
           )
         }, 100);
+      } else {
+        // We have an item, so any generation still sitting in the 100 ms delay was
+        // queued back when we had none. Letting it fire would swap the exercise the
+        // user is already reading for a different one a beat later.
+        clearDrillGenerationTimeout();
       }
 
       // Update previous settings reference with LATEST settings
@@ -263,7 +268,8 @@ function AppRouter() {
     settings.specificTense,
     settings.verbType,
     settings.selectedFamily,
-    scheduleDrillGeneration
+    scheduleDrillGeneration,
+    clearDrillGenerationTimeout
   ])
 
   useEffect(() => {

--- a/src/features/drill/Drill.jsx
+++ b/src/features/drill/Drill.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { grade } from '../../lib/core/grader.js';
 import { stripAccents } from '../../lib/utils/accentUtils.js';
 import { PERSON_LABELS } from '../../lib/utils/verbLabels.js';
@@ -64,7 +64,14 @@ export default function Drill({
     };
   };
 
-  useEffect(() => {
+  // useLayoutEffect, not useEffect: this reset has to be part of the same paint as
+  // the new item. With a passive effect the browser painted the new verb once while
+  // it still carried the previous answer (its feedback box, the old input text) and
+  // without the `fade-in` class — i.e. fully opaque — and only afterwards did the
+  // effect clear everything and re-add `fade-in`, sending the card back to opacity 0
+  // to animate in a second time. That double paint is what looked like the drill
+  // reloading itself for no reason, and it got worse the slower the device.
+  useLayoutEffect(() => {
     setInput('');
     setSecondInput('');
     setResult(null);

--- a/src/features/drill/ReverseInputs.jsx
+++ b/src/features/drill/ReverseInputs.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useLayoutEffect, useState, useRef } from 'react'
 import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
 
 /**
@@ -26,7 +26,10 @@ export default function ReverseInputs({
   const showMoodField = !inSpecific
   const showTenseField = !inSpecific
 
-  useEffect(() => {
+  // Layout effect for the same reason as Drill's reset: clearing the guesses after
+  // paint let the browser show the new item for a frame with the previous answers
+  // still typed in.
+  useLayoutEffect(() => {
     setInfinitiveGuess('')
     setPersonGuess('')
     setMoodGuess('')

--- a/src/hooks/useDrillMode.generation-window.test.js
+++ b/src/hooks/useDrillMode.generation-window.test.js
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDrillMode } from './useDrillMode.js'
+
+// Regression coverage for the drill reloading itself a beat after showing an
+// exercise. `useDrillGenerator` lowers its own `isGenerating` as soon as the
+// generator function returns, but `useDrillMode` only commits the item a few
+// microtasks later. React can commit a render inside that gap, and both safety nets
+// (AppRouter's effect and DrillMode's retry timer) read "no item + not generating"
+// as permission to start another generation. The second one then overwrote the
+// exercise the user was already reading.
+//
+// The generator mock below always reports `isGenerating: false`, i.e. the worst
+// case: the only thing that can keep the window closed is useDrillMode's own flag.
+
+const { useSettingsMock, mockGenerateNextItem } = vi.hoisted(() => {
+  const state = {
+    set: vi.fn(),
+    currentSession: null,
+    verbType: 'all',
+    selectedFamily: null,
+    level: 'A1',
+    useVoseo: false,
+    useVosotros: false,
+    practiceMode: 'mixed',
+    specificMood: null,
+    specificTense: null,
+    region: 'la_general'
+  }
+
+  const useSettings = vi.fn((selector) => (selector ? selector(state) : state))
+  useSettings.getState = () => state
+
+  return { useSettingsMock: useSettings, mockGenerateNextItem: vi.fn() }
+})
+
+vi.mock('../state/settings.js', () => ({ useSettings: useSettingsMock }))
+
+vi.mock('./modules/useDrillGenerator.js', () => ({
+  useDrillGenerator: vi.fn(() => ({
+    generateNextItem: mockGenerateNextItem,
+    isGenerationViable: vi.fn(() => true),
+    getGenerationStats: vi.fn(() => ({})),
+    // Deliberately never true: the fix must not depend on the generator's own flag.
+    isGenerating: false
+  }))
+}))
+
+vi.mock('./modules/useDrillProgress.js', () => ({
+  useDrillProgress: vi.fn(() => ({
+    handleResponse: vi.fn(),
+    handleHintShown: vi.fn(),
+    getProgressInsights: vi.fn(() => ({})),
+    resetProgressStats: vi.fn(),
+    isProcessing: false
+  }))
+}))
+
+vi.mock('./modules/useDrillValidation.js', () => ({
+  useDrillValidation: vi.fn(() => ({
+    validateItem: vi.fn(() => ({ valid: true })),
+    validateSettings: vi.fn(() => ({ valid: true })),
+    getValidationInsights: vi.fn(() => ({})),
+    isValidating: false
+  }))
+}))
+
+vi.mock('../lib/progress/personalizedCoaching.js', () => ({
+  getMotivationalInsights: vi.fn(() => Promise.resolve([]))
+}))
+
+vi.mock('../lib/core/prioritizer/index.js', () => ({
+  debugLevelPrioritization: vi.fn()
+}))
+
+vi.mock('../lib/progress/flowStateDetection.js', () => ({
+  getCurrentFlowState: vi.fn(() => 'neutral')
+}))
+
+vi.mock('../lib/progress/sessionManager.js', () => ({
+  sessionManager: {
+    hasActiveSession: vi.fn(() => false),
+    startSession: vi.fn(),
+    getCurrentActivity: vi.fn(() => null),
+    recordItemResult: vi.fn(),
+    shouldAutoAdvance: vi.fn(() => false),
+    shouldConsiderAdvancing: vi.fn(() => false),
+    nextActivity: vi.fn(() => null),
+    endSession: vi.fn(),
+    getSessionProgress: vi.fn(() => ({}))
+  }
+}))
+
+vi.mock('../lib/utils/logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}))
+
+const ITEM = {
+  lemma: 'hablar',
+  mood: 'indicative',
+  tense: 'pres',
+  person: '1s',
+  form: { value: 'hablo' }
+}
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((res) => { resolve = res })
+  return { promise, resolve }
+}
+
+/** Renders the hook while recording the (item, isGenerating) pair of every commit. */
+const renderRecordingDrillMode = () => {
+  const commits = []
+  const hook = renderHook(() => {
+    const drillMode = useDrillMode()
+    commits.push({
+      hasItem: !!drillMode.currentItem,
+      isGenerating: drillMode.isGenerating
+    })
+    return drillMode
+  })
+  return { ...hook, commits }
+}
+
+describe('useDrillMode generation window', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports a generation in flight before the first await', async () => {
+    const gate = deferred()
+    mockGenerateNextItem.mockReturnValue(gate.promise)
+
+    const { result } = renderRecordingDrillMode()
+    expect(result.current.isGenerating).toBe(false)
+
+    let pending
+    act(() => {
+      pending = result.current.generateNextItem(null, vi.fn(), vi.fn())
+    })
+
+    expect(result.current.isGenerating).toBe(true)
+    expect(result.current.currentItem).toBeNull()
+
+    await act(async () => {
+      gate.resolve(ITEM)
+      await pending
+    })
+
+    expect(result.current.currentItem).toMatchObject({ lemma: 'hablar' })
+    expect(result.current.isGenerating).toBe(false)
+  })
+
+  it('never commits "no item and nothing generating" while an item is on its way', async () => {
+    const gate = deferred()
+    mockGenerateNextItem.mockReturnValue(gate.promise)
+
+    const { result, rerender, commits } = renderRecordingDrillMode()
+    const commitsBeforeRequest = commits.length
+
+    let pending
+    act(() => {
+      pending = result.current.generateNextItem(null, vi.fn(), vi.fn())
+    })
+
+    // AppRouter re-renders constantly while a generation is in flight (settings
+    // writes, session store updates). Force one so the in-flight window is actually
+    // observed by a commit, the way it is in the app.
+    act(() => {
+      rerender()
+    })
+
+    await act(async () => {
+      gate.resolve(ITEM)
+      await pending
+    })
+
+    // Every commit from the request onwards must either show the item or advertise
+    // that a generation is running. Anything else is the gap that made AppRouter and
+    // DrillMode queue a competing generation.
+    const gapCommits = commits
+      .slice(commitsBeforeRequest)
+      .filter((commit) => !commit.hasItem && !commit.isGenerating)
+
+    expect(gapCommits).toEqual([])
+  })
+
+  it('keeps the flag up until the last of several overlapping generations settles', async () => {
+    const first = deferred()
+    const second = deferred()
+    mockGenerateNextItem
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const { result } = renderRecordingDrillMode()
+
+    let firstPending
+    let secondPending
+    act(() => {
+      firstPending = result.current.generateNextItem(null, vi.fn(), vi.fn())
+      secondPending = result.current.generateNextItem(null, vi.fn(), vi.fn())
+    })
+
+    expect(result.current.isGenerating).toBe(true)
+
+    await act(async () => {
+      first.resolve(ITEM)
+      await firstPending
+    })
+
+    expect(result.current.isGenerating).toBe(true)
+
+    await act(async () => {
+      second.resolve(ITEM)
+      await secondPending
+    })
+
+    expect(result.current.isGenerating).toBe(false)
+  })
+
+  it('lowers the flag when generation throws so the safety nets can retry', async () => {
+    mockGenerateNextItem.mockRejectedValue(new Error('boom'))
+
+    const { result } = renderRecordingDrillMode()
+
+    await act(async () => {
+      await result.current.generateNextItem(null, vi.fn(), vi.fn())
+    })
+
+    expect(result.current.isGenerating).toBe(false)
+  })
+})

--- a/src/hooks/useDrillMode.js
+++ b/src/hooks/useDrillMode.js
@@ -8,7 +8,7 @@
  * - Improves testability and maintainability
  */
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useSettings } from '../state/settings.js'
 import { useSessionStore } from '../state/session.js'
@@ -35,6 +35,16 @@ const logger = createLogger('useDrillMode')
 export function useDrillMode() {
   const [currentItem, setCurrentItem] = useState(null)
   const [history, setHistory] = useState({})
+  // `useDrillGenerator`'s own `isGenerating` drops the moment the generator function
+  // returns, but the item only reaches `setCurrentItem` a few microtasks later (the
+  // Promise.race unwrap, then validation). React commits a render inside that gap
+  // where there is no item AND nothing looks like it is generating — exactly the
+  // state AppRouter and DrillMode's safety net read as "nobody is working on this,
+  // start a generation". They queued a second one that landed about a second after
+  // the first item and silently replaced it on screen. This flag stays up until the
+  // item has actually been handed over, so that window never becomes observable.
+  const [isDeliveringItem, setIsDeliveringItem] = useState(false)
+  const pendingGenerationsRef = useRef(0)
   const settings = useSettings(
     useShallow((state) => ({
       set: state.set,
@@ -61,8 +71,12 @@ export function useDrillMode() {
     generateNextItem: generateNextItemInternal,
     isGenerationViable,
     getGenerationStats,
-    isGenerating
+    isGenerating: isGeneratorRunning
   } = useDrillGenerator()
+
+  // What consumers must branch on: true from the moment a generation is requested
+  // until its item has been committed, not just while the generator itself runs.
+  const isGenerating = isGeneratorRunning || isDeliveringItem
 
   const {
     handleResponse,
@@ -290,17 +304,31 @@ export function useDrillMode() {
     getAvailableMoodsForLevel,
     getAvailableTensesForLevelAndMood
   ) => {
-    // Handle personalized session mode
-    if (settings.practiceMode === 'personalized_session') {
-      return await handleSessionGeneration(
-        itemToExclude,
-        getAvailableMoodsForLevel,
-        getAvailableTensesForLevelAndMood
-      )
-    }
+    // Raised synchronously, before the first await, so a caller in the same tick
+    // already sees the request as in flight.
+    pendingGenerationsRef.current += 1
+    setIsDeliveringItem(true)
 
-    // Default to normal generation
-    return await generateNormalItem(itemToExclude, getAvailableMoodsForLevel, getAvailableTensesForLevelAndMood)
+    try {
+      // Handle personalized session mode
+      if (settings.practiceMode === 'personalized_session') {
+        return await handleSessionGeneration(
+          itemToExclude,
+          getAvailableMoodsForLevel,
+          getAvailableTensesForLevelAndMood
+        )
+      }
+
+      // Default to normal generation
+      return await generateNormalItem(itemToExclude, getAvailableMoodsForLevel, getAvailableTensesForLevelAndMood)
+    } finally {
+      pendingGenerationsRef.current = Math.max(0, pendingGenerationsRef.current - 1)
+      if (pendingGenerationsRef.current === 0) {
+        // Same tick as the `setCurrentItem` above, so React commits both together and
+        // no render ever shows "no item, nothing generating".
+        setIsDeliveringItem(false)
+      }
+    }
   }
 
   /**

--- a/tests/e2e/drill-stability.e2e.js
+++ b/tests/e2e/drill-stability.e2e.js
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Regression cover for "the drill reloads itself right after showing an exercise".
+ *
+ * Each exercise used to be painted twice: once at full opacity, still carrying the
+ * previous answer's feedback and the text the user had typed, and then again from
+ * opacity 0 once the per-item state reset finally ran. On a phone the gap between
+ * those two paints is wide enough to read as the whole screen reloading itself.
+ * The CPU is throttled here (chromium only) to keep that gap observable.
+ *
+ * The companion defect — a second generation replacing the exercise about a second
+ * after it appeared — is covered deterministically in
+ * src/hooks/useDrillMode.generation-window.test.js, since it is a state-machine
+ * race rather than something a browser test can provoke on demand. The "exercise is
+ * not replaced" assertion below is the end-to-end smoke guard for it.
+ */
+
+const OBSERVE_DRILL = () => {
+  window.__drillStates = []
+  const read = () => {
+    const container = document.querySelector('.drill-container')
+    if (!container) return null
+    return {
+      t: Math.round(performance.now()),
+      lemma: document.querySelector('.verb-lemma')?.textContent || null,
+      person: document.querySelector('.person-display')?.textContent || null,
+      fadeIn: container.classList.contains('fade-in'),
+      hasResult: !!document.querySelector('.result'),
+      input: document.querySelector('#conjugation-input')?.value ?? ''
+    }
+  }
+
+  let last = null
+  const record = () => {
+    const state = read()
+    if (!state) return
+    const key = JSON.stringify({ ...state, t: undefined })
+    if (key === last) return
+    last = key
+    window.__drillStates.push(state)
+  }
+
+  const start = () => {
+    new MutationObserver(record).observe(document.body, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true
+    })
+    record()
+  }
+
+  // The init script runs before <body> exists on a fresh navigation.
+  if (document.body) start()
+  else document.addEventListener('DOMContentLoaded', start)
+}
+
+async function throttleCpu(page, browserName, rate) {
+  if (browserName !== 'chromium') return
+  const client = await page.context().newCDPSession(page)
+  await client.send('Emulation.setCPUThrottlingRate', { rate })
+}
+
+async function readDrillStates(page) {
+  const states = await page.evaluate(() => window.__drillStates || [])
+  // Guard against the observer silently failing to install, which would make every
+  // assertion below pass vacuously.
+  expect(states.length, 'no drill states were recorded').toBeGreaterThan(0)
+  return states
+}
+
+/** The states in which each distinct exercise was first rendered. */
+function firstStatePerExercise(states) {
+  const firsts = []
+  let previousLemma = null
+
+  for (const state of states) {
+    if (!state.lemma) continue
+    if (state.lemma !== previousLemma) {
+      previousLemma = state.lemma
+      firsts.push(state)
+    }
+  }
+
+  return firsts
+}
+
+function expectNoLateFadeIn(states) {
+  expect(
+    firstStatePerExercise(states).filter((state) => !state.fadeIn),
+    'an exercise was painted before its entrance animation was applied, so it appeared and then faded in again'
+  ).toEqual([])
+}
+
+test.describe('Drill stability', () => {
+  // CPU throttling stretches item generation well past the default per-test budget.
+  test.setTimeout(120000)
+
+  test('the first exercise is not replaced on its own', async ({ page, browserName }) => {
+    await throttleCpu(page, browserName, 6)
+    await page.addInitScript(OBSERVE_DRILL)
+    await page.goto('/drill')
+
+    const lemma = page.locator('.verb-lemma')
+    await expect(lemma).toBeVisible({ timeout: 60000 })
+    const firstExercise = await lemma.textContent()
+    const firstPerson = await page.locator('.person-display').textContent()
+
+    // The competing generation used to land ~1.2s after the first item.
+    await page.waitForTimeout(4000)
+
+    expect(await lemma.textContent()).toBe(firstExercise)
+    expect(await page.locator('.person-display').textContent()).toBe(firstPerson)
+
+    expectNoLateFadeIn(await readDrillStates(page))
+  })
+
+  test('advancing to the next exercise does not flash the previous answer', async ({ page, browserName }) => {
+    await throttleCpu(page, browserName, 6)
+    await page.addInitScript(OBSERVE_DRILL)
+    await page.goto('/drill')
+
+    const input = page.locator('input#conjugation-input')
+    await expect(input).toBeVisible({ timeout: 60000 })
+
+    for (let round = 0; round < 3; round += 1) {
+      await input.fill('zzz')
+      await page.locator('.action-buttons .btn').click()
+      await expect(page.locator('.result')).toBeVisible()
+      await page.locator('.action-buttons .btn').click()
+      await expect(page.locator('.result')).toBeHidden()
+      await page.waitForTimeout(1500)
+    }
+
+    const states = await readDrillStates(page)
+
+    // No frame may show a freshly generated exercise still wearing the previous
+    // answer's feedback or the text the user typed for it.
+    expect(
+      firstStatePerExercise(states).filter((state) => state.hasResult || state.input !== ''),
+      'a new exercise was painted with the previous answer still on screen'
+    ).toEqual([])
+
+    expectNoLateFadeIn(states)
+  })
+})


### PR DESCRIPTION
El conjugador seguía "recargándose solo" un instante después de mostrar el ejercicio, sobre todo en móvil. Eran **dos defectos distintos**, ninguno cubierto por el PR anterior (#194).

## 1) Cada ejercicio se pintaba dos veces

El reset por ítem de `Drill` vivía en un `useEffect`, que corre **después** del pintado. El navegador pintaba primero el verbo nuevo todavía con la respuesta anterior (su cartel de resultado y el texto tipeado) y sin la clase `fade-in` — o sea, opaco. Recién entonces el efecto limpiaba todo y agregaba `fade-in`, devolviendo la tarjeta a `opacity: 0` para animarla de nuevo.

Medido en Chromium (Pixel 5, CPU x6) sobre el build de producción, muestreando por frame:

```
t=812  lemma "pedir"  opacity 1.00  fade-in:no   result:sí  input:"xxx"   ← ejercicio nuevo, respuesta vieja
t=838  lemma "pedir"  opacity 0.00  fade-in:sí   result:no  input:""      ← vuelve a 0 y entra otra vez
t=1149 lemma "pedir"  opacity 1.00                                        ← 300 ms de animación
```

Pasar el reset a `useLayoutEffect` lo mete en el mismo pintado que el ítem. Mismo arreglo en `ReverseInputs`, que arrastraba las respuestas anteriores por un frame.

## 2) Una segunda generación pisaba el ejercicio ~1 s después

`useDrillGenerator` baja su `isGenerating` apenas la función generadora retorna, pero el ítem recién llega a `setCurrentItem` unos microtasks más tarde (el unwrap de `Promise.race` y la validación). React commitea un render en ese hueco donde **no hay ítem y nada parece estar generando** — justo el estado que el efecto de `AppRouter` y la red de seguridad de `DrillMode` leen como "no hay nadie trabajando, arrancá una generación".

Traza instrumentada con CPU x10 sobre el build de producción:

```
t=281   gen-start                              generación #1 arranca
t=5259  router-effect  item:false gen:true     sale por el guard, bien
t=6536  router-effect  item:false gen:false    ← el hueco
t=6536  router-schedule                        ← encola la generación #2
t=6580  set-item "comer"                       ← la #1 entrega su ítem
t=6723  gen-start                              ← el timer dispara igual
t=7789  set-item "obligar"                     ← pisa el ejercicio 1,1 s después
```

`useDrillMode` ahora mantiene su propia bandera desde que se pide la generación hasta que el ítem quedó entregado, y la expone como `isGenerating`. Se baja en el mismo tick que `setCurrentItem`, así que ese render nunca se commitea. Además `AppRouter` cancela la generación que quedó esperando su delay de 100 ms si mientras tanto apareció un ítem.

## Verificación

En Chromium (Pixel 5) sobre el build de producción:

- Entrada al drill con CPU x10 y x20: el ítem queda estable en **4/4 y 4/4** corridas (antes cambiaba solo en 2/4 a x10).
- Ciclo responder → continuar: cada ejercicio entra directo con `fade-in`, sin frame intermedio con la respuesta anterior.
- Las mismas comprobaciones fallan **3/3** contra un build con los arreglos revertidos.
- Probado en modo mixto y en específico (`indicativo/presente`).

## Tests

- `src/hooks/useDrillMode.generation-window.test.js` (nuevo): fija la invariante de que nunca se commitea "sin ítem y sin generación en curso". 3 de sus 4 casos fallan sin el arreglo.
- `tests/e2e/drill-stability.e2e.js` (nuevo): invariantes visuales con CPU throttling — el ejercicio no se reemplaza solo, ninguno se pinta antes de su animación de entrada, ninguno aparece con la respuesta previa en pantalla.
- `npm run lint`: 0 errores (153 warnings preexistentes).
- `npm run validate-integrity`: pasa, exit 0.
- `npm run test:run`: 1184 pasan. Los 4 tests que fallan (`DrillMode.keyboard` ×2, `navigationBack`, `ProgressDashboard.smoke`) y los 2 archivos de `tests/server` que no cargan fallan idénticamente con el árbol limpio en `main` — son preexistentes y ajenos a este cambio.

Nota: la suite e2e no se pudo ejecutar con su propio harness en este entorno (`global-setup` falla esperando `#root > *` visible, porque `.app-container` mide 0 de alto; también preexistente). Las aserciones del archivo nuevo se validaron corriéndolas con un runner de Playwright equivalente contra ambos builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pd3c1YhHBM1APVsa6aHCcu)_