### PR TITLE
Cortar la segunda animación que recargaba la tarjeta en cada ejercicio

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1622,8 +1622,17 @@ body {
 }
 
 
+/* `.drill-container` is deliberately not in this list. It is the only one of these
+   whose class list changes at runtime: Drill.jsx adds `fade-in` when an exercise
+   arrives and removes it 500ms later. While that class is on, the more specific
+   `.verbos-drill .fade-in` rule (DrillVerbos.css) wins with `vdLiftIn`; removing it
+   used to hand the element back to this rule, flipping animation-name to `fadeIn`
+   and making the browser restart the animation. The card faded in a second time,
+   half a second after the exercise appeared, on every single exercise — which read
+   as the drill reloading itself for no reason. Without this rule the class removal
+   sets animation-name to `none`, which stops rather than starts, and `vdLiftIn`
+   already ends on the element's natural state so nothing moves. */
 .option-card,
-.drill-container,
 .settings-panel {
   animation: fadeIn 0.3s ease;
 }

--- a/src/features/drill/drillContainerAnimation.test.js
+++ b/src/features/drill/drillContainerAnimation.test.js
@@ -1,0 +1,120 @@
+/**
+ * Guard against the drill card animating twice per exercise.
+ *
+ * `Drill.jsx` renders `<div className={`drill-container ${showAnimation ? 'fade-in' : ''}`}>`
+ * and drops the `fade-in` class 500ms after each exercise arrives. The entrance
+ * animation is supposed to come exclusively from `.verbos-drill .fade-in`
+ * (`vdLiftIn`, in DrillVerbos.css).
+ *
+ * The bug this covers: App.css also declared `animation: fadeIn 0.3s ease` on a
+ * bare `.drill-container` selector. That rule is less specific, so it lost while
+ * `fade-in` was on — but the moment the class came off, the element fell back to
+ * it, `animation-name` flipped `vdLiftIn` → `fadeIn`, and the browser *restarted*
+ * the animation. Every exercise faded in a second time half a second after it
+ * appeared, with identical content, which users read as the drill spontaneously
+ * reloading itself. Measured on the production build: two `animationstart` events
+ * per exercise, the second dropping the card back to opacity 0.04.
+ *
+ * The invariant: nothing may declare a running `animation` on a selector that
+ * matches the drill container by itself, because any such rule becomes the
+ * fallback that restarts when `fade-in` is toggled off. The entrance animation
+ * belongs on the toggled class only.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const CSS_FILES = [
+  'src/App.css',
+  'src/index.css',
+  'src/components/drill/DrillVerbos.css'
+]
+
+// Vitest runs with the repo root as cwd (vitest.config.js lives there).
+const repoPath = (relative) => path.resolve(process.cwd(), relative)
+
+/** Strip comments, then pull out every innermost `selectors { declarations }` block. */
+function parseRules(css) {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '')
+  const rules = []
+  // `[^{}]` cannot cross a brace, so this only ever matches blocks whose body has
+  // no nested block — i.e. real declaration blocks, including ones inside @media.
+  const blockPattern = /([^{}]+)\{([^{}]*)\}/g
+  let match
+  while ((match = blockPattern.exec(withoutComments)) !== null) {
+    rules.push({
+      selectors: match[1].split(',').map((s) => s.trim()).filter(Boolean),
+      declarations: match[2]
+    })
+  }
+  return rules
+}
+
+/** Does this selector match a `.drill-container` that is NOT wearing `fade-in`? */
+function targetsBareDrillContainer(selector) {
+  if (!selector.includes('.drill-container')) return false
+  // A rule that requires `fade-in` only applies while the class is on, so it can
+  // never be the fallback that restarts when the class is removed.
+  if (selector.includes('.fade-in')) return false
+  // Pseudo-element rules paint a separate box and do not carry the card's animation.
+  if (selector.includes('::')) return false
+  return true
+}
+
+/** `animation: none` / `animation-name: none` stop animations; they never start one. */
+function declaresRunningAnimation(declarations) {
+  const found = declarations.match(/(?:^|;)\s*animation(?:-name)?\s*:([^;]*)/gi)
+  if (!found) return null
+  const running = found
+    .map((d) => d.replace(/^[;\s]*animation(?:-name)?\s*:/i, '').trim())
+    .filter((value) => !/^none\b/i.test(value.replace(/!important/i, '').trim()))
+  return running.length > 0 ? running : null
+}
+
+describe('drill container entrance animation', () => {
+  const parsed = CSS_FILES.map((file) => ({
+    file,
+    rules: parseRules(readFileSync(repoPath(file), 'utf8'))
+  }))
+
+  it('parses the stylesheets it is supposed to guard', () => {
+    // Without this the assertions below could pass simply by finding nothing.
+    for (const { file, rules } of parsed) {
+      expect(rules.length, `${file} produced no CSS rules`).toBeGreaterThan(0)
+    }
+  })
+
+  it('is declared only on the toggled .fade-in class, never on .drill-container itself', () => {
+    const offenders = []
+
+    for (const { file, rules } of parsed) {
+      for (const rule of rules) {
+        const selectors = rule.selectors.filter(targetsBareDrillContainer)
+        if (selectors.length === 0) continue
+
+        const running = declaresRunningAnimation(rule.declarations)
+        if (running) {
+          offenders.push(`${file}: "${selectors.join(', ')}" declares animation: ${running.join(' / ')}`)
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      'a rule matching a bare .drill-container declares an animation; when Drill.jsx removes ' +
+        'the `fade-in` class 500ms after each exercise, animation-name flips to this one and the ' +
+        'browser restarts it, so the same exercise fades in twice and looks like a spontaneous reload'
+    ).toEqual([])
+  })
+
+  it('still gives the drill card its entrance animation via .verbos-drill .fade-in', () => {
+    const drillCss = parsed.find((entry) => entry.file.endsWith('DrillVerbos.css'))
+    const fadeInRule = drillCss.rules.find((rule) =>
+      rule.selectors.some((s) => s.includes('.fade-in'))
+    )
+
+    expect(fadeInRule, 'the drill entrance animation rule disappeared').toBeTruthy()
+    expect(declaresRunningAnimation(fadeInRule.declarations)).toBeTruthy()
+  })
+})

--- a/tests/e2e/drill-stability.e2e.js
+++ b/tests/e2e/drill-stability.e2e.js
@@ -14,7 +14,34 @@ import { test, expect } from '@playwright/test'
  * src/hooks/useDrillMode.generation-window.test.js, since it is a state-machine
  * race rather than something a browser test can provoke on demand. The "exercise is
  * not replaced" assertion below is the end-to-end smoke guard for it.
+ *
+ * A third defect hid from both of those for two releases, because the DOM state this
+ * file records looks perfectly healthy while it happens: the exercise never changes
+ * and the `fade-in` class is added and removed exactly when it should be. The card
+ * was simply animating *twice* — `vdLiftIn` on arrival, then `fadeIn` restarting
+ * 500ms later when the class came off and a bare `.drill-container` rule in App.css
+ * took over as the fallback. Same verb, same person, but the whole card dropped back
+ * to opacity 0.04 and faded in again, on every single exercise. Watching classes
+ * cannot see that; only the animations themselves can, hence OBSERVE_ANIMATIONS.
  */
+
+const OBSERVE_ANIMATIONS = () => {
+  window.__drillAnimations = []
+  document.addEventListener(
+    'animationstart',
+    (event) => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+      if (!target.classList.contains('drill-container')) return
+      window.__drillAnimations.push({
+        t: Math.round(performance.now()),
+        name: event.animationName,
+        lemma: document.querySelector('.verb-lemma')?.textContent || null
+      })
+    },
+    true
+  )
+}
 
 const OBSERVE_DRILL = () => {
   window.__drillStates = []
@@ -86,6 +113,35 @@ function firstStatePerExercise(states) {
   return firsts
 }
 
+/**
+ * Every exercise must run exactly one entrance animation. A second one on the same
+ * exercise is the card visibly reloading itself with identical content.
+ */
+async function expectOneAnimationPerExercise(page) {
+  const animations = await page.evaluate(() => window.__drillAnimations || [])
+
+  expect(
+    animations.length,
+    'no drill animations were recorded, so this assertion would pass vacuously'
+  ).toBeGreaterThan(0)
+
+  const byExercise = new Map()
+  for (const animation of animations) {
+    const list = byExercise.get(animation.lemma) || []
+    list.push(animation.name)
+    byExercise.set(animation.lemma, list)
+  }
+
+  const repeated = [...byExercise.entries()]
+    .filter(([, names]) => names.length > 1)
+    .map(([lemma, names]) => `${lemma}: ${names.join(' → ')}`)
+
+  expect(
+    repeated,
+    'an exercise animated more than once, so the card faded in again with the same content'
+  ).toEqual([])
+}
+
 function expectNoLateFadeIn(states) {
   expect(
     firstStatePerExercise(states).filter((state) => !state.fadeIn),
@@ -100,6 +156,7 @@ test.describe('Drill stability', () => {
   test('the first exercise is not replaced on its own', async ({ page, browserName }) => {
     await throttleCpu(page, browserName, 6)
     await page.addInitScript(OBSERVE_DRILL)
+    await page.addInitScript(OBSERVE_ANIMATIONS)
     await page.goto('/drill')
 
     const lemma = page.locator('.verb-lemma')
@@ -114,11 +171,13 @@ test.describe('Drill stability', () => {
     expect(await page.locator('.person-display').textContent()).toBe(firstPerson)
 
     expectNoLateFadeIn(await readDrillStates(page))
+    await expectOneAnimationPerExercise(page)
   })
 
   test('advancing to the next exercise does not flash the previous answer', async ({ page, browserName }) => {
     await throttleCpu(page, browserName, 6)
     await page.addInitScript(OBSERVE_DRILL)
+    await page.addInitScript(OBSERVE_ANIMATIONS)
     await page.goto('/drill')
 
     const input = page.locator('input#conjugation-input')
@@ -143,5 +202,6 @@ test.describe('Drill stability', () => {
     ).toEqual([])
 
     expectNoLateFadeIn(states)
+    await expectOneAnimationPerExercise(page)
   })
 })


### PR DESCRIPTION
## El problema

El conjugador se "recargaba solo" un instante después de mostrar el ejercicio. A diferencia de lo que asumieron los dos PRs anteriores (#194, #195), **el ejercicio no cambiaba**: aparecía el mismo verbo y la misma persona, y ~medio segundo después toda la tarjeta se desvanecía y volvía a entrar. Por eso era determinista, pasaba en **cada** ejercicio, y se veía igual en el sitio publicado (móvil y escritorio), en la PWA instalada y en `npm run dev`.

Los arreglos anteriores atacaban carreras en la generación de ítems. Eran defectos reales, pero de otro síntoma (aparecía *otro* ejercicio). Este es de CSS, y ningún PR anterior tocó CSS.

## Causa raíz

Dos reglas declaraban `animation` sobre el mismo elemento:

| Archivo | Selector | Especificidad |
|---|---|---|
| `App.css` | `.option-card, .drill-container, .settings-panel { animation: fadeIn 0.3s ease }` | (0,1,0) |
| `DrillVerbos.css` | `.verbos-drill .fade-in { animation: vdLiftIn 0.3s ... }` | (0,2,0) |

`Drill.jsx` **alterna** esa clase: la pone al llegar el ítem y la saca a los 500 ms.

- Mientras la clase está puesta gana `vdLiftIn` → la entrada deseada.
- Al sacarla, el elemento vuelve a matchear la regla suelta de `App.css`, `animation-name` pasa de `vdLiftIn` a `fadeIn`, y **cambiar el `animation-name` reinicia la animación**: la tarjeta arrancaba desde `opacity: 0` otra vez.

500 ms de espera + 300 ms de animación ≈ el segundo que se veía, en cada ejercicio. Los usuarios con `prefers-reduced-motion: reduce` nunca lo vieron, porque `App.css` anula todas las animaciones en ese caso.

## Medición

Registrando los eventos `animationstart` reales del contenedor sobre el **build de producción** (Chromium, Pixel 5, CPU x4):

**Antes**
```
t=1979ms  vdLiftIn   empezar   opacity=0.239
t=2454ms  fadeIn     empezar   opacity=0.039   ← la recarga
t=5028ms  vdLiftIn   vender    opacity=0.239
t=5519ms  fadeIn     vender    opacity=0.039   ← la recarga
3 de 3 ejercicios animados dos veces
```

**Después**
```
1 animación (vdLiftIn) por ejercicio · 0 de 3 repetidos
opacidad del contenedor estable en 1 desde t=400ms hasta t=1500ms
```

## El cambio

Sacar `.drill-container` de la regla global de `fadeIn` en `App.css`. Al quitar la clase, `animation-name` pasa a `none`, que **detiene** en vez de arrancar, y `vdLiftIn` ya termina en el estado natural del elemento, así que no se mueve nada. La animación de entrada queda intacta.

El otro consumidor de `.drill-container` (`NonfiniteGuidedDrill`) ya entra por `.page-transition`, que usa *transitions* y no depende de esta regla.

No hay cambios en `Drill.jsx`, `DrillMode.jsx`, `AppRouter.jsx` ni `useDrillMode.js`: lo de #194/#195 queda como está.

## Por qué no lo agarraron los tests

`drill-stability.e2e.js` observaba la clase `fade-in` y la identidad del ítem. Acá el ítem no cambia y la clase se saca justo cuando corresponde, así que las aserciones existentes pasaban igual. Verificado explícitamente: sin el arreglo siguen pasando, y solo falla la nueva.

Se agregan dos coberturas:

- **`src/features/drill/drillContainerAnimation.test.js`** — guard estático (Vitest, sin navegador) que falla si alguna regla que matchee un `.drill-container` suelto declara `animation`. Sin el arreglo falla señalando la regla exacta: `src/App.css: ".drill-container" declares animation: fadeIn 0.3s ease`.
- **`drill-stability.e2e.js`** — observador de `animationstart` y aserción de una sola animación por ejercicio. Sin el arreglo falla en los 5 ejercicios (`vdLiftIn → fadeIn`); con el arreglo pasan los 2 tests.

## Verificación

- `npm run lint` → 0 errores (153 warnings preexistentes)
- `npm run validate-integrity` → exit 0, 239 verbos
- `npm run test:run` → **sin regresiones**: los mismos 6 archivos que ya fallaban en `main` (`DrillMode.keyboard`, `navigationBack`, `ProgressDashboard.smoke`, `SyncMutex` y los 2 de `tests/server`), comparado corriendo la suite con y sin estos cambios
- e2e `drill-stability` en chromium → 2/2 pasan con el arreglo, 2/2 fallan sin él

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGqEPWuWCuzhcyiwWoRDAk)_