### PR TITLE
Hacer que el dedo se comporte como el mouse en los menúes de onboarding

### DIFF
--- a/src/components/learning/LearningStepView.jsx
+++ b/src/components/learning/LearningStepView.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import '../onboarding/OnboardingFlow.css'
+import useTouchHover, { touchHoverItemProps } from '../../hooks/useTouchHover.js'
 
 const ACCENT = 'var(--accent-primary)'
 const INK    = 'var(--text)'
@@ -48,6 +49,14 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
     window.addEventListener('keydown', handle)
     return () => window.removeEventListener('keydown', handle)
   }, [focusIdx, options, onSelect])
+
+  // Sliding a finger over the rows focuses them like a mouse would. The
+  // release that ends such a scrub must not count as a tap on the last row.
+  const { containerRef: listRef, shouldIgnoreSelect } = useTouchHover(setFocusIdx)
+  const handleSelect = useCallback((opt) => {
+    if (shouldIgnoreSelect()) return
+    onSelect(opt)
+  }, [shouldIgnoreSelect, onSelect])
 
   const focused = options[focusIdx] || options[0]
 
@@ -115,7 +124,7 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
           OPCIONES · {String(options.length).padStart(2, '0')} ────
         </div>
 
-        <div className="vo-options-list">
+        <div className="vo-options-list" ref={listRef}>
           {options.map((opt, i) => {
             const active = i === focusIdx
             const selected = selectedId != null && opt.id === selectedId
@@ -128,8 +137,9 @@ function StepPanel({ stepConfig, onSelect, selectedId }) {
                 aria-label={opt.label}
                 style={{ paddingLeft: active ? 76 : 52, paddingTop: 14, paddingBottom: 14 }}
                 onMouseEnter={() => setFocusIdx(i)}
-                onClick={() => onSelect(opt)}
+                onClick={() => handleSelect(opt)}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onSelect(opt) }}
+                {...touchHoverItemProps(i)}
               >
                 <div className="vo-option-num" style={{ color: active || selected ? ACCENT : INK2 }}>
                   <span

--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -101,6 +101,11 @@
 .vo-footer-hints { display: flex; gap: 16px; }
 .vo-footer-hints span { white-space: nowrap; }
 .vo-footer-hints em { font-style: normal; color: var(--muted); }
+/* Cue for the drag-to-preview gesture — pointless without a finger. */
+.vo-hint-touch { display: none; }
+@media (hover: none) and (pointer: coarse) {
+  .vo-hint-touch { display: inline; }
+}
 
 .vo-header-left {
   display: flex;
@@ -332,6 +337,12 @@
   position: relative;
   border-bottom: 1px solid var(--border);
   cursor: pointer;
+  /* Dragging a finger across the rows previews them (see useTouchHover), so
+     the press must not raise a selection, a callout or the tap flash. */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
   display: flex;
   align-items: baseline;
   gap: 14px;
@@ -536,7 +547,9 @@
 
   .vo-footer-hints { gap: 10px; }
   /* The keyboard hints don't apply on touch; only the search cue survives. */
-  .vo-footer-hints span:not(.vo-hint-search) { display: none; }
+  .vo-footer-hints span:not(.vo-hint-search):not(.vo-hint-touch) { display: none; }
+  /* The touch cue needs the room, and the kicker already leads the left panel. */
+  .vo-footer-kicker { display: none; }
 
   .vo-left-bottom { margin-top: 20px; }
 

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -912,8 +912,9 @@ function OnboardingFlow({
           <span><em>↵ / →</em> seleccioná</span>
           <span><em>← / esc</em> volver</span>
           <span className="vo-hint-search"><em>/</em> buscar</span>
+          <span className="vo-hint-touch"><em>↕</em> deslizá</span>
         </div>
-        <div style={{ color: INK2 }}>{stepConfig?.kicker}</div>
+        <div className="vo-footer-kicker" style={{ color: INK2 }}>{stepConfig?.kicker}</div>
         <div>SISTEMA · OK</div>
       </footer>
     </div>

--- a/src/components/onboarding/StepView.jsx
+++ b/src/components/onboarding/StepView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import VoOptionRow from './VoOptionRow.jsx'
 import TopicSearch from './TopicSearch.jsx'
 import { isTextEntryTarget } from './textEntry.js'
+import useTouchHover from '../../hooks/useTouchHover.js'
 
 const ACCENT = 'var(--accent-primary)'
 const INK3 = 'var(--border-strong)'
@@ -61,6 +62,14 @@ function StepView({ stepConfig, animKey, onSelect, search }) {
     const target = visibleOptions[Math.min(safeIdx, visibleOptions.length - 1)]
     if (target) onSelect(target)
   }, [visibleOptions, safeIdx, onSelect])
+
+  // Sliding a finger over the rows focuses them like a mouse would. The
+  // release that ends such a scrub must not count as a tap on the last row.
+  const { containerRef: listRef, shouldIgnoreSelect } = useTouchHover(setFocusIdx)
+  const handleSelect = useCallback((option) => {
+    if (shouldIgnoreSelect()) return
+    onSelect(option)
+  }, [shouldIgnoreSelect, onSelect])
 
   // Keyboard navigation for the list. Events originating in a text field are
   // handled by the field itself (see TopicSearch), so they are skipped here —
@@ -183,6 +192,7 @@ function StepView({ stepConfig, animKey, onSelect, search }) {
           </div>
         ) : (
           <div
+            ref={listRef}
             className="vo-options-list"
             id={hasQuery ? LISTBOX_ID : undefined}
             role={hasQuery ? 'listbox' : undefined}
@@ -198,7 +208,7 @@ function StepView({ stepConfig, animKey, onSelect, search }) {
                 optionId={`vo-opt-${opt.id}`}
                 matchRanges={hasQuery ? results[i]?.ranges : null}
                 onFocus={setFocusIdx}
-                onSelect={onSelect}
+                onSelect={handleSelect}
               />
             ))}
           </div>

--- a/src/components/onboarding/VoOptionRow.jsx
+++ b/src/components/onboarding/VoOptionRow.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { touchHoverItemProps } from '../../hooks/useTouchHover.js'
 
 /* ── Design tokens (mirrors OnboardingFlow.jsx) ── */
 const ACCENT = 'var(--accent-primary)'
@@ -61,6 +62,7 @@ function VoOptionRow({
         }
       }}
       {...listboxProps}
+      {...touchHoverItemProps(index)}
     >
       {/* Number box */}
       <div className="vo-option-num" style={{ color: active ? ACCENT : INK3 }}>

--- a/src/hooks/useTouchHover.js
+++ b/src/hooks/useTouchHover.js
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Attribute a row carries so a touch point can be mapped back to its index.
+ * Applied through `touchHoverItemProps` rather than by hand.
+ */
+const INDEX_ATTR = 'data-touch-hover-index'
+const ITEM_SELECTOR = `[${INDEX_ATTR}]`
+
+/** How long the finger must rest before a drag scrubs instead of scrolling. */
+const HOLD_MS = 180
+/** Finger jitter tolerated while waiting for the hold to elapse. */
+const MOVE_TOLERANCE_PX = 10
+
+/** Props every hoverable row must spread so the hook can identify it. */
+export function touchHoverItemProps(index) {
+  return { [INDEX_ATTR]: index }
+}
+
+function indexAtPoint(x, y) {
+  const row = document.elementFromPoint(x, y)?.closest?.(ITEM_SELECTOR)
+  if (!row) return -1
+  const index = Number(row.getAttribute(INDEX_ATTR))
+  return Number.isInteger(index) ? index : -1
+}
+
+/**
+ * A drag can only be mistaken for a scroll when something around the list can
+ * actually scroll. When nothing can, scrubbing may start on contact.
+ */
+function hasScrollableAncestor(node) {
+  for (let el = node; el && el !== document.body; el = el.parentElement) {
+    const { overflowY } = window.getComputedStyle(el)
+    const scrollable = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
+    if (scrollable && el.scrollHeight > el.clientHeight + 1) return true
+  }
+  const root = document.scrollingElement
+  return root ? root.scrollHeight > root.clientHeight + 1 : false
+}
+
+/**
+ * Gives a list of rows the same hover behaviour on touch that it has with a
+ * mouse: sliding a finger across the rows focuses whichever one is underneath,
+ * so the highlight animation and the preview panel follow the finger.
+ *
+ * Touch devices fire no `mouseenter` while the finger travels, so the position
+ * is resolved from the touch point on every move. Scrolling is preserved by
+ * only taking over the gesture once the finger has rested for `HOLD_MS` — a
+ * drag that starts moving right away is a scroll and is left to the browser.
+ *
+ * @param {(index: number) => void} onHover called with the row under the finger
+ * @returns {{ containerRef: (el: HTMLElement|null) => void, shouldIgnoreSelect: () => boolean }}
+ *   `containerRef` goes on the element wrapping the rows; `shouldIgnoreSelect`
+ *   is consumed by the row's click handler so a scrub does not select.
+ */
+export default function useTouchHover(onHover) {
+  const [container, setContainer] = useState(null)
+  const containerRef = useCallback((el) => setContainer(el), [])
+
+  const onHoverRef = useRef(onHover)
+  useEffect(() => { onHoverRef.current = onHover })
+
+  // Set while the finger travels across rows, so the release that ends the
+  // scrub does not read as a tap on whichever row it happened to land on.
+  const suppressSelectRef = useRef(false)
+
+  useEffect(() => {
+    if (!container) return undefined
+
+    let gesture = null
+    let holdTimer = null
+
+    const clearHold = () => {
+      if (holdTimer) {
+        clearTimeout(holdTimer)
+        holdTimer = null
+      }
+    }
+
+    const hoverAt = (x, y) => {
+      const index = indexAtPoint(x, y)
+      if (index >= 0) onHoverRef.current?.(index)
+    }
+
+    const handleStart = (e) => {
+      clearHold()
+      if (e.touches.length !== 1) {
+        gesture = null
+        return
+      }
+      const touch = e.touches[0]
+      suppressSelectRef.current = false
+      gesture = { x: touch.clientX, y: touch.clientY, scrubbing: false, abandoned: false }
+
+      // Contact alone already reads as the pointer arriving on the row.
+      hoverAt(touch.clientX, touch.clientY)
+
+      if (!hasScrollableAncestor(container)) {
+        gesture.scrubbing = true
+        return
+      }
+      holdTimer = setTimeout(() => {
+        holdTimer = null
+        if (gesture && !gesture.abandoned) gesture.scrubbing = true
+      }, HOLD_MS)
+    }
+
+    const handleMove = (e) => {
+      if (!gesture || e.touches.length !== 1) return
+      const touch = e.touches[0]
+      const travelled =
+        Math.abs(touch.clientX - gesture.x) > MOVE_TOLERANCE_PX ||
+        Math.abs(touch.clientY - gesture.y) > MOVE_TOLERANCE_PX
+
+      if (!gesture.scrubbing) {
+        // Moving before the hold elapsed means the user is scrolling.
+        if (travelled) {
+          gesture.abandoned = true
+          clearHold()
+        }
+        return
+      }
+
+      // The list owns the gesture now, so the page must not scroll under it.
+      if (e.cancelable) e.preventDefault()
+      if (travelled) suppressSelectRef.current = true
+      hoverAt(touch.clientX, touch.clientY)
+    }
+
+    const handleEnd = () => {
+      clearHold()
+      gesture = null
+    }
+
+    container.addEventListener('touchstart', handleStart, { passive: true })
+    // Non-passive: scrubbing has to be able to cancel the scroll.
+    container.addEventListener('touchmove', handleMove, { passive: false })
+    container.addEventListener('touchend', handleEnd, { passive: true })
+    container.addEventListener('touchcancel', handleEnd, { passive: true })
+
+    return () => {
+      clearHold()
+      container.removeEventListener('touchstart', handleStart)
+      container.removeEventListener('touchmove', handleMove)
+      container.removeEventListener('touchend', handleEnd)
+      container.removeEventListener('touchcancel', handleEnd)
+    }
+  }, [container])
+
+  const shouldIgnoreSelect = useCallback(() => {
+    if (!suppressSelectRef.current) return false
+    suppressSelectRef.current = false
+    return true
+  }, [])
+
+  return { containerRef, shouldIgnoreSelect }
+}


### PR DESCRIPTION
## Problema

Los menúes de onboarding muestran la información de cada opción —la palabra focal gigante, y `TAG` / `TIPO` / `EJEMPLO` del panel izquierdo— únicamente cuando el mouse se posa sobre la fila. Ese hover es estado de JS (`onMouseEnter` → `focusIdx` en `StepView.jsx`), no CSS.

En touch no existe hover, así que en mobile esa información nunca llegaba a verse: el toque disparaba `mouseenter` y `click` en la misma ráfaga y el paso avanzaba en el acto. Campos como `gloss` y `ex` (por ejemplo `'hipótesis · deseo · matiz'`, `'vos tenés / vos hablás'`) eran inalcanzables desde un teléfono.

## Solución

Deslizar el dedo sobre la lista enfoca la fila que queda debajo, con las mismas animaciones y el mismo panel de preview que produce el mouse. Como el navegador no emite `mouseenter` mientras el dedo viaja, la posición se resuelve con `document.elementFromPoint` en cada `touchmove`.

Para no romper el scroll, el gesto se toma recién cuando el dedo estuvo quieto 180 ms: un arrastre que arranca moviéndose es scroll y queda para el navegador. Cuando no hay nada que scrollear, el barrido arranca al contacto. El toque simple sigue seleccionando; soltar después de barrer no selecciona.

## Cambios

- **`src/hooks/useTouchHover.js`** (nuevo): el hook. Devuelve `containerRef` para el contenedor de filas y `shouldIgnoreSelect()` para que el click posterior a un barrido no seleccione. Listeners nativos con `{ passive: false }` en `touchmove`, porque React registra ese evento como pasivo y ahí `preventDefault()` no tendría efecto.
- **`StepView.jsx`** y **`VoOptionRow.jsx`**: conectan el hook. Cubren los 8 pasos del onboarding y los resultados de búsqueda, ya que todos pasan por la misma fila compartida.
- **`LearningStepView.jsx`**: mismo tratamiento; duplica el markup de las filas en vez de importar `VoOptionRow`.
- **`OnboardingFlow.css`**: `user-select` / `-webkit-touch-callout` / `-webkit-tap-highlight-color` en `.vo-option` para que mantener el dedo apoyado no levante selección de texto ni el flash del tap.
- **`OnboardingFlow.jsx`** + CSS: pista `↕ deslizá` en el footer, visible sólo en `(hover: none) and (pointer: coarse)`. El kicker del footer se oculta en mobile para dejarle lugar.

## Verificación

Probado con Chromium bajo emulación de touch (iPhone 13, eventos táctiles reales vía CDP), sobre `npm run dev`:

| Gesto | Resultado |
|---|---|
| Barrer con el dedo por la lista | La fila activa, la palabra focal y `TAG`/`TIPO`/`EJEMPLO` siguen al dedo (`vos` → `tú` → `tú · vosotros` → `todos`) |
| Soltar después de barrer | No selecciona |
| Toque simple | Selecciona y avanza, como antes |
| Arrastre rápido en lista scrolleable | Scrollea (`scrollTop` 0 → 64) y el foco no se mueve |
| Mantener + arrastrar en lista scrolleable | Barre (`A1` → `C1`) sin scrollear |
| Flujo de aprender (`/learning`) | Mismo comportamiento sobre sus 8 filas |

Desktop sin cambios: hover, click y navegación por teclado siguen igual, y la pista táctil queda oculta.

Checks del repo:
- `npm run lint` → 0 errores (153 warnings, todos preexistentes)
- `npm run validate-integrity` → pasa (239 verbos)
- `npx vitest run src/components/` → 54 pasan, 3 fallan; los 3 fallan idénticamente en `main` (`DrillMode.keyboard.test.jsx` ×2, `navigationBack.test.jsx` ×1) y no tocan este código

---
_Generated by [Claude Code](https://claude.ai/code/session_011qbxzd3NREQdCyhcpW87V8)_