### PR TITLE
Hacer que el hover táctil siga al dedo durante todo el barrido

### DIFF
--- a/src/components/onboarding/OnboardingFlow.css
+++ b/src/components/onboarding/OnboardingFlow.css
@@ -333,6 +333,14 @@
   --vo-row-pad: 14px;
 }
 
+/* A finger dragged over the rows previews them (see useTouchHover), so the
+   browser must not read that same drag as a scroll and pull the list out from
+   under it. Two-finger zoom stays available; scrolling past the fold is handled
+   by the hook, which pulls the list along when the finger reaches either end. */
+@media (pointer: coarse) {
+  .vo-options-list { touch-action: pinch-zoom; }
+}
+
 .vo-option {
   position: relative;
   border-bottom: 1px solid var(--border);

--- a/src/hooks/useTouchHover.js
+++ b/src/hooks/useTouchHover.js
@@ -7,10 +7,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 const INDEX_ATTR = 'data-touch-hover-index'
 const ITEM_SELECTOR = `[${INDEX_ATTR}]`
 
-/** How long the finger must rest before a drag scrubs instead of scrolling. */
-const HOLD_MS = 180
-/** Finger jitter tolerated while waiting for the hold to elapse. */
+/** Finger travel beyond this reads as a scrub, so the release must not select. */
 const MOVE_TOLERANCE_PX = 10
+/** Band at each end of the scroller where a scrub keeps pulling the list along. */
+const EDGE_ZONE_PX = 56
+/** Peak auto-scroll speed inside that band, in pixels per frame. */
+const EDGE_SPEED_PX = 14
 
 /** Props every hoverable row must spread so the hook can identify it. */
 export function touchHoverItemProps(index) {
@@ -25,17 +27,44 @@ function indexAtPoint(x, y) {
 }
 
 /**
- * A drag can only be mistaken for a scroll when something around the list can
- * actually scroll. When nothing can, scrubbing may start on contact.
+ * Nearest ancestor that actually scrolls. The scrub owns the finger, so this is
+ * what has to be moved for rows past the fold to come within reach.
  */
-function hasScrollableAncestor(node) {
-  for (let el = node; el && el !== document.body; el = el.parentElement) {
+function scrollParentOf(node) {
+  for (let el = node?.parentElement; el && el !== document.body; el = el.parentElement) {
     const { overflowY } = window.getComputedStyle(el)
     const scrollable = overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
-    if (scrollable && el.scrollHeight > el.clientHeight + 1) return true
+    if (scrollable && el.scrollHeight > el.clientHeight + 1) return el
   }
   const root = document.scrollingElement
-  return root ? root.scrollHeight > root.clientHeight + 1 : false
+  return root && root.scrollHeight > root.clientHeight + 1 ? root : null
+}
+
+/** Where the scroller sits on screen, which is what the finger is measured against. */
+function scrollerBounds(scroller) {
+  if (scroller === document.scrollingElement) {
+    return { top: 0, bottom: window.innerHeight || 0 }
+  }
+  const rect = scroller.getBoundingClientRect()
+  return { top: rect.top, bottom: rect.bottom }
+}
+
+/**
+ * How far to scroll for a finger held at `y`: nothing in the middle of the
+ * scroller, ramping up to `EDGE_SPEED_PX` as it reaches either end.
+ */
+function edgeDelta(scroller, y) {
+  const { top, bottom } = scrollerBounds(scroller)
+  if (bottom - top < EDGE_ZONE_PX * 2) return 0
+  if (y < top + EDGE_ZONE_PX) {
+    const depth = Math.min(1, (top + EDGE_ZONE_PX - y) / EDGE_ZONE_PX)
+    return -EDGE_SPEED_PX * depth
+  }
+  if (y > bottom - EDGE_ZONE_PX) {
+    const depth = Math.min(1, (y - (bottom - EDGE_ZONE_PX)) / EDGE_ZONE_PX)
+    return EDGE_SPEED_PX * depth
+  }
+  return 0
 }
 
 /**
@@ -44,9 +73,14 @@ function hasScrollableAncestor(node) {
  * so the highlight animation and the preview panel follow the finger.
  *
  * Touch devices fire no `mouseenter` while the finger travels, so the position
- * is resolved from the touch point on every move. Scrolling is preserved by
- * only taking over the gesture once the finger has rested for `HOLD_MS` — a
- * drag that starts moving right away is a scroll and is left to the browser.
+ * is resolved from the touch point on every move. A touch that lands on a row
+ * takes the gesture straight away — waiting for the finger to settle first only
+ * loses the swipes that start moving at once, which is most of them. The list
+ * therefore does not scroll under the finger (see the `touch-action` rule on
+ * `.vo-options-list`); instead, holding the finger against either end of the
+ * scroller pulls the list along so rows past the fold stay reachable. A touch
+ * that starts anywhere else — the padding, the panel around the list — is left
+ * to the browser and scrolls as usual.
  *
  * @param {(index: number) => void} onHover called with the row under the finger
  * @returns {{ containerRef: (el: HTMLElement|null) => void, shouldIgnoreSelect: () => boolean }}
@@ -68,67 +102,93 @@ export default function useTouchHover(onHover) {
     if (!container) return undefined
 
     let gesture = null
-    let holdTimer = null
+    let frame = null
 
-    const clearHold = () => {
-      if (holdTimer) {
-        clearTimeout(holdTimer)
-        holdTimer = null
+    const stopAutoScroll = () => {
+      if (frame !== null) {
+        cancelAnimationFrame(frame)
+        frame = null
       }
     }
 
+    // Rows the finger never left are skipped, so a scrub only re-renders the
+    // step when the focused row actually changes.
     const hoverAt = (x, y) => {
       const index = indexAtPoint(x, y)
-      if (index >= 0) onHoverRef.current?.(index)
+      if (index < 0 || index === gesture?.index) return
+      if (gesture) gesture.index = index
+      onHoverRef.current?.(index)
+    }
+
+    // While the finger rests against an end of the scroller the list keeps
+    // coming, and each step brings a new row under the (stationary) finger.
+    const autoScrollStep = () => {
+      frame = null
+      if (!gesture?.scroller) return
+      const delta = edgeDelta(gesture.scroller, gesture.y)
+      if (!delta) return
+      const before = gesture.scroller.scrollTop
+      gesture.scroller.scrollTop = before + delta
+      if (gesture.scroller.scrollTop === before) return // reached the end
+      hoverAt(gesture.x, gesture.y)
+      frame = requestAnimationFrame(autoScrollStep)
+    }
+
+    const syncAutoScroll = () => {
+      if (!gesture?.scroller) return
+      if (frame === null && edgeDelta(gesture.scroller, gesture.y)) {
+        frame = requestAnimationFrame(autoScrollStep)
+      }
     }
 
     const handleStart = (e) => {
-      clearHold()
-      if (e.touches.length !== 1) {
-        gesture = null
-        return
-      }
+      stopAutoScroll()
+      gesture = null
+      if (e.touches.length !== 1) return
+
       const touch = e.touches[0]
+      const index = indexAtPoint(touch.clientX, touch.clientY)
+      // Off the rows the list has no business with the gesture: let it scroll.
+      if (index < 0) return
+
       suppressSelectRef.current = false
-      gesture = { x: touch.clientX, y: touch.clientY, scrubbing: false, abandoned: false }
+      gesture = {
+        startX: touch.clientX,
+        startY: touch.clientY,
+        x: touch.clientX,
+        y: touch.clientY,
+        index: -1,
+        scroller: scrollParentOf(container)
+      }
 
       // Contact alone already reads as the pointer arriving on the row.
       hoverAt(touch.clientX, touch.clientY)
-
-      if (!hasScrollableAncestor(container)) {
-        gesture.scrubbing = true
-        return
-      }
-      holdTimer = setTimeout(() => {
-        holdTimer = null
-        if (gesture && !gesture.abandoned) gesture.scrubbing = true
-      }, HOLD_MS)
     }
 
     const handleMove = (e) => {
       if (!gesture || e.touches.length !== 1) return
       const touch = e.touches[0]
-      const travelled =
-        Math.abs(touch.clientX - gesture.x) > MOVE_TOLERANCE_PX ||
-        Math.abs(touch.clientY - gesture.y) > MOVE_TOLERANCE_PX
+      gesture.x = touch.clientX
+      gesture.y = touch.clientY
 
-      if (!gesture.scrubbing) {
-        // Moving before the hold elapsed means the user is scrolling.
-        if (travelled) {
-          gesture.abandoned = true
-          clearHold()
-        }
-        return
+      if (
+        Math.abs(touch.clientX - gesture.startX) > MOVE_TOLERANCE_PX ||
+        Math.abs(touch.clientY - gesture.startY) > MOVE_TOLERANCE_PX
+      ) {
+        suppressSelectRef.current = true
       }
 
-      // The list owns the gesture now, so the page must not scroll under it.
+      // The list owns the gesture, so the page must not scroll under it. CSS
+      // `touch-action` already says as much; this covers the browsers that
+      // only honour the event.
       if (e.cancelable) e.preventDefault()
-      if (travelled) suppressSelectRef.current = true
+
       hoverAt(touch.clientX, touch.clientY)
+      syncAutoScroll()
     }
 
     const handleEnd = () => {
-      clearHold()
+      stopAutoScroll()
       gesture = null
     }
 
@@ -139,7 +199,7 @@ export default function useTouchHover(onHover) {
     container.addEventListener('touchcancel', handleEnd, { passive: true })
 
     return () => {
-      clearHold()
+      stopAutoScroll()
       container.removeEventListener('touchstart', handleStart)
       container.removeEventListener('touchmove', handleMove)
       container.removeEventListener('touchend', handleEnd)

--- a/src/hooks/useTouchHover.test.js
+++ b/src/hooks/useTouchHover.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import useTouchHover, { touchHoverItemProps } from './useTouchHover.js'
+
+const ROW_HEIGHT = 50
+const ROWS = 10
+const CONTENT_HEIGHT = ROWS * ROW_HEIGHT
+
+let scroller
+let list
+let viewport
+let originalElementFromPoint
+
+/**
+ * Mirrors the mobile layout: the list of rows lives inside a panel that
+ * scrolls, which is what made the gesture ambiguous in the first place.
+ * jsdom has no layout, so scrolling and hit testing are both faked — rows are
+ * stacked from the top of the content, and a point maps to one by its y.
+ */
+function buildLayout() {
+  scroller = document.createElement('div')
+  scroller.style.overflowY = 'auto'
+  Object.defineProperty(scroller, 'scrollHeight', { value: CONTENT_HEIGHT, configurable: true })
+  Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true })
+  let scrollTop = 0
+  Object.defineProperty(scroller, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: (value) => { scrollTop = Math.max(0, Math.min(CONTENT_HEIGHT - 200, value)) }
+  })
+  scroller.getBoundingClientRect = () => ({ top: viewport.top, bottom: viewport.bottom })
+
+  list = document.createElement('div')
+  for (let i = 0; i < ROWS; i++) {
+    const row = document.createElement('div')
+    const [attr, value] = Object.entries(touchHoverItemProps(i))[0]
+    row.setAttribute(attr, String(value))
+    row.appendChild(document.createElement('span'))
+    list.appendChild(row)
+  }
+  scroller.appendChild(list)
+  document.body.appendChild(scroller)
+}
+
+function stubElementFromPoint() {
+  document.elementFromPoint = (_x, y) => {
+    const index = Math.floor((y + scroller.scrollTop) / ROW_HEIGHT)
+    if (index < 0 || index >= ROWS) return scroller
+    // The deepest element at the point is the content inside the row.
+    return list.children[index].firstChild
+  }
+}
+
+function touch(type, y, x = 10) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  event.touches = type === 'touchend' || type === 'touchcancel'
+    ? []
+    : [{ clientX: x, clientY: y }]
+  list.dispatchEvent(event)
+  return event
+}
+
+function mount(onHover) {
+  const hook = renderHook(() => useTouchHover(onHover))
+  act(() => hook.result.current.containerRef(list))
+  return hook
+}
+
+beforeEach(() => {
+  // Far enough off screen that the edge bands sit outside the points these
+  // tests use; the auto-scroll test narrows it deliberately.
+  viewport = { top: -1000, bottom: 1000 }
+  buildLayout()
+  originalElementFromPoint = document.elementFromPoint
+  stubElementFromPoint()
+})
+
+afterEach(() => {
+  document.elementFromPoint = originalElementFromPoint
+  scroller.remove()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useTouchHover', () => {
+  it('focuses the row under the finger on contact', () => {
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 25)
+
+    expect(onHover).toHaveBeenCalledWith(0)
+  })
+
+  it('follows the finger across rows as it moves', () => {
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 25)
+    touch('touchmove', 75)
+    touch('touchmove', 125)
+    touch('touchmove', 175)
+
+    expect(onHover.mock.calls.map(([index]) => index)).toEqual([0, 1, 2, 3])
+  })
+
+  it('follows a swipe that starts moving right away', () => {
+    // The list sits in a scrolling panel, which used to mean the gesture was
+    // only taken once the finger had rested — so a swipe, which starts moving
+    // at once, never got past the row it landed on.
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 25)
+    touch('touchmove', 160)
+
+    expect(onHover).toHaveBeenLastCalledWith(3)
+  })
+
+  it('reports a row only when it changes', () => {
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 10)
+    touch('touchmove', 20)
+    touch('touchmove', 40)
+
+    expect(onHover).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the panel still while the finger scrubs', () => {
+    mount(vi.fn())
+
+    touch('touchstart', 25)
+    const move = touch('touchmove', 125)
+
+    expect(move.defaultPrevented).toBe(true)
+  })
+
+  it('leaves a touch that misses the rows to the browser', () => {
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', CONTENT_HEIGHT + 20)
+    const move = touch('touchmove', 25)
+
+    expect(onHover).not.toHaveBeenCalled()
+    expect(move.defaultPrevented).toBe(false)
+  })
+
+  it('pulls the list along while the finger rests against the bottom edge', () => {
+    vi.useFakeTimers()
+    viewport = { top: 0, bottom: 200 }
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 25)
+    touch('touchmove', 190) // inside the bottom band
+    const beforeScroll = onHover.mock.calls.at(-1)[0]
+
+    vi.advanceTimersByTime(200)
+
+    expect(scroller.scrollTop).toBeGreaterThan(0)
+    expect(onHover.mock.calls.at(-1)[0]).toBeGreaterThan(beforeScroll)
+  })
+
+  it('stops pulling the list once the finger lifts', () => {
+    vi.useFakeTimers()
+    viewport = { top: 0, bottom: 200 }
+    mount(vi.fn())
+
+    touch('touchstart', 25)
+    touch('touchmove', 190)
+    touch('touchend', 190)
+    const resting = scroller.scrollTop
+
+    vi.advanceTimersByTime(200)
+
+    expect(scroller.scrollTop).toBe(resting)
+  })
+
+  it('ignores the release that ends a scrub, but not a tap', () => {
+    const { result } = mount(vi.fn())
+
+    touch('touchstart', 25)
+    touch('touchmove', 125)
+    touch('touchend', 125)
+    expect(result.current.shouldIgnoreSelect()).toBe(true)
+
+    touch('touchstart', 25)
+    touch('touchmove', 27)
+    touch('touchend', 27)
+    expect(result.current.shouldIgnoreSelect()).toBe(false)
+  })
+
+  it('drops the gesture when a second finger lands', () => {
+    const onHover = vi.fn()
+    mount(onHover)
+
+    touch('touchstart', 25)
+    onHover.mockClear()
+
+    const second = new Event('touchstart', { bubbles: true, cancelable: true })
+    second.touches = [{ clientX: 10, clientY: 25 }, { clientX: 40, clientY: 25 }]
+    list.dispatchEvent(second)
+    touch('touchmove', 125)
+
+    expect(onHover).not.toHaveBeenCalled()
+  })
+
+  it('stops listening once the list unmounts', () => {
+    const onHover = vi.fn()
+    const hook = mount(onHover)
+
+    act(() => hook.result.current.containerRef(null))
+    touch('touchstart', 25)
+
+    expect(onHover).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## El problema

El hover táctil de #197 enfocaba la fila del contacto inicial y ahí se quedaba: al barrer o deslizar el dedo por la lista, ni la animación ni el panel de preview seguían al dedo.

La causa está en el portón de espera de `useTouchHover`: el gesto se tomaba recién cuando el dedo llevaba `HOLD_MS` (180 ms) quieto, y cualquier movimiento previo de más de 10 px lo marcaba como `abandoned`, sin manera de recuperarlo durante el resto del gesto. En mobile la lista vive dentro de `.vo-step`, que es `overflow-y: auto`, así que `hasScrollableAncestor()` daba siempre `true` y la espera se pedía siempre. Un barrido —que por definición arranca moviéndose— nunca la superaba.

## El cambio

- **El toque que aterriza sobre una fila toma el gesto en el acto.** El enfoque sigue al dedo fila por fila, resuelto con `elementFromPoint` en cada `touchmove`, y solo se avisa al consumidor cuando la fila efectivamente cambia.
- **La lista deja de scrollear bajo el dedo**: `touch-action: pinch-zoom` sobre `.vo-options-list` en punteros gruesos, que corta el pan de un dedo y conserva el zoom de dos.
- **Las filas fuera de pantalla siguen alcanzables**: apoyar el dedo contra el borde superior o inferior del panel que scrollea lo arrastra a velocidad proporcional y va enfocando lo que va apareciendo.
- **El toque que cae fuera de las filas** (el padding, el panel alrededor) queda para el navegador y scrollea como siempre.
- El toque simple sigue seleccionando; soltar después de barrer no selecciona.

## Archivos

- `src/hooks/useTouchHover.js` — reescritura del ciclo del gesto: sin espera, con auto-scroll de borde y `scrollParentOf()` en lugar de `hasScrollableAncestor()`.
- `src/components/onboarding/OnboardingFlow.css` — regla `touch-action` bajo `@media (pointer: coarse)`.
- `src/hooks/useTouchHover.test.js` — nuevo.

## Pruebas

- `npx vitest run src/hooks/useTouchHover.test.js` — 11 en verde. El arnés reproduce el layout mobile (lista dentro de un panel que scrollea), que es lo que hacía ambiguo el gesto; contra la implementación anterior el test del barrido falla con `[0]`, o sea el síntoma reportado.
- `npx vitest run src/hooks/ src/components/onboarding/` — 109 en verde. Falla `navigationBack.test.jsx`, que ya fallaba igual en `main` (verificado con los cambios guardados aparte) y no toca este código.
- `npm run validate-integrity` — sin errores.
- `npx eslint` sobre los archivos tocados — limpio.

Falta la verificación en un teléfono real: los eventos táctiles acá están simulados en jsdom, que no tiene layout ni scroll de verdad.

---
_Generated by [Claude Code](https://claude.ai/code/session_016ctwTjryYvDZAe2zZyndnj)_