### PR TITLE
Menú 4: "un tema puntual" en lugar de "un bloque puntual"

### DIFF
--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -427,7 +427,7 @@ function buildStep(step, settings, handlers) {
         prompt: 'Querés trabajar...', aux: 'Mezcla amplia o foco quirúrgico.',
         options: [
           { id: 'mixed',    label: 'todo mezclado',     tag: 'AMPLIO',  gloss: 'panorama', ex: 'todos los modos y tiempos', onSelect: () => selectPracticeMode('mixed', onStartPractice) },
-          { id: 'specific', label: 'un bloque puntual', tag: 'PRECISO', gloss: 'foco',     ex: 'un modo, un tiempo',        onSelect: () => selectPracticeMode('specific') },
+          { id: 'specific', label: 'un tema puntual', tag: 'PRECISO', gloss: 'foco',     ex: 'un modo, un tiempo',        onSelect: () => selectPracticeMode('specific') },
         ],
       }
 

--- a/src/components/onboarding/navigationBack.test.jsx
+++ b/src/components/onboarding/navigationBack.test.jsx
@@ -170,7 +170,7 @@ describe('Navegación y Back (flujo actual)', () => {
       await user.click(nivelC1)
     })
 
-    // Paso 4: práctica mezclada / bloque puntual
+    // Paso 4: práctica mezclada / tema puntual
     await screen.findByRole('button', { name: /todo mezclado/i })
 
     // Back → paso 3 (level selection)
@@ -186,8 +186,8 @@ describe('Navegación y Back (flujo actual)', () => {
     const nivelB1 = await screen.findByRole('button', { name: /Seleccionar nivel B1/i })
     await user.click(nivelB1)
 
-    // Paso 4: elegir "un bloque puntual"
-    const especificas = await screen.findByRole('button', { name: /un bloque puntual/i })
+    // Paso 4: elegir "un tema puntual"
+    const especificas = await screen.findByRole('button', { name: /un tema puntual/i })
     await user.click(especificas)
 
     // Paso 5: selección de modo (Indicativo/Subjuntivo...)


### PR DESCRIPTION
## Cambio

En el paso 04 del onboarding (`OnboardingFlow.jsx`, case 4), la opción de práctica específica decía **"un bloque puntual"**. Ahora dice **"un tema puntual"**.

## Archivos tocados

- `src/components/onboarding/OnboardingFlow.jsx` — etiqueta de la opción `specific` en el menú 04.
- `src/components/onboarding/navigationBack.test.jsx` — el test buscaba el botón por ese texto (`findByRole('button', { name: /un bloque puntual/i })`), así que se actualizó el matcher y un comentario.

Solo cambia el texto visible; la lógica de selección (`selectPracticeMode('specific')`) queda igual.

## Verificación

- `npx vitest run src/components/onboarding/navigationBack.test.jsx`: 8 pasan, 1 falla. Esa falla ya existía antes del cambio (verificado corriendo la suite con los cambios stasheados: mismo resultado 1 fallo / 8 pasan) y es ajena a este cambio.
- `npx eslint` sobre los dos archivos: 0 errores; queda 1 warning preexistente (`getAvailableMoodsForLevel` sin usar).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDbPgiQCFLttntJ2x5NPsr)_