### PR TITLE
Unificar "bloque" como "tema" en toda la UI

### DIFF
--- a/src/components/learning/DurationSelectionStep.jsx
+++ b/src/components/learning/DurationSelectionStep.jsx
@@ -32,7 +32,7 @@ function DurationSelectionStep({
     n: '03',
     kicker: 'DURACIÓN',
     prompt: 'La sesión dura...',
-    aux: 'Ajustá el bloque antes de entrar al recorrido guiado.',
+    aux: 'Ajustá la duración antes de entrar al recorrido guiado.',
     options,
   }
 

--- a/src/components/onboarding/MoodTenseSelection.jsx
+++ b/src/components/onboarding/MoodTenseSelection.jsx
@@ -50,7 +50,7 @@ function MoodTenseSelection({
               badge="MODO"
               title={getMoodLabel(mood)}
               subtitle="Modo verbal"
-              description="Activa solo este bloque para filtrar tiempos y ejemplos relevantes."
+              description="Activa solo este tema para filtrar tiempos y ejemplos relevantes."
               detail="yo hablo, tú hablas, él/ella habla"
               onClick={() => onSelectMood(mood)}
               cardTitle={`Seleccionar ${getMoodLabel(mood)}`}
@@ -98,7 +98,7 @@ function MoodTenseSelection({
         badge="01"
         title="INDICATIVO"
         subtitle="Hechos, hábitos y relato"
-        description="El bloque más amplio para tiempos de uso central."
+        description="El tema más amplio para tiempos de uso central."
         detail="yo hablo, tú hablas, él/ella habla"
         onClick={() => onSelectMood('indicative')}
         cardTitle="Seleccionar modo indicativo"
@@ -173,7 +173,7 @@ function MoodTenseSelection({
               badge="TEMA"
               title={getTenseLabel(tense)}
               subtitle="Tiempo verbal"
-              description="Entrada temática directa para practicar un bloque concreto."
+              description="Entrada directa para practicar un tema concreto."
               detail={getConjugationExample(settings.specificMood, tense)}
               onClick={() => onSelectTense(tense)}
               cardTitle={`Seleccionar ${getTenseLabel(tense)}`}

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -462,11 +462,11 @@ function buildStep(step, settings, handlers) {
       }
       return {
         n: '05',
-        kicker: themeSubMenu ? (kickerMapLevel[themeSubMenu] || themeSubMenu.toUpperCase()) : 'BLOQUE',
+        kicker: themeSubMenu ? (kickerMapLevel[themeSubMenu] || themeSubMenu.toUpperCase()) : 'TEMA',
         prompt: 'Trabajás...',
         aux: themeSubMenu
           ? 'Elegí un tiempo para seguir con el tipo de verbos.'
-          : 'Elegí un bloque para practicar.',
+          : 'Elegí un tema para practicar.',
         options: buildLevelTopicOptions({
           level: settings.level,
           selectMood, selectTense,

--- a/src/components/onboarding/PracticeModeSelection.jsx
+++ b/src/components/onboarding/PracticeModeSelection.jsx
@@ -20,7 +20,7 @@ function PracticeModeSelection({ onSelectPracticeMode, onBack }) {
           eyebrow="PRECISA"
           badge="FOCUS"
           title="ESPECÍFICA"
-          subtitle="Un bloque a la vez"
+          subtitle="Un tema a la vez"
           description="Aísla un modo y un tiempo para practicar con intención y repetición útil."
           detail="Ideal para dominar formas particulares"
           onClick={() => onSelectPracticeMode('specific')}

--- a/src/components/onboarding/menuMetadata.js
+++ b/src/components/onboarding/menuMetadata.js
@@ -90,7 +90,7 @@ export function getStepMeta(step, settings = {}) {
           step: '05',
           kicker: 'FOCO',
           title: 'Elegí el modo o tiempo que querés atacar',
-          description: 'Segmentá la práctica para trabajar un bloque verbal bien definido sin tocar la lógica de conjugación.'
+          description: 'Segmentá la práctica para trabajar un tema verbal bien definido sin tocar la lógica de conjugación.'
         },
     6: settings.practiceMode === 'mixed'
       ? {

--- a/src/features/progress/focusTracks.js
+++ b/src/features/progress/focusTracks.js
@@ -66,7 +66,7 @@ export function buildFocusTracks({ heatMapData = null, userStats = {} } = {}) {
     title: mastery < 50 ? 'Base guiada' : 'Mixto de consolidación',
     level: mastery < 50 ? 'Baja' : 'Media',
     description: mastery < 50
-      ? 'Bloque corto para recuperar precisión general.'
+      ? 'Práctica corta para recuperar precisión general.'
       : 'Práctica variada para mantener velocidad y retención.',
     drillConfig: {
       practiceMode: mastery < 50 ? 'review' : 'mixed',


### PR DESCRIPTION
Continúa el cambio de #199, que reemplazó "un bloque puntual" por "un tema puntual" en el menú 04. Acá se unifican los usos restantes de "bloque" en textos visibles.

## Cambios

**"bloque" → "tema"** (mismo concepto que el menú 04):
- `PracticeModeSelection.jsx`: subtítulo de la tarjeta ESPECÍFICA → "Un tema a la vez"
- `MoodTenseSelection.jsx`: tres descripciones de tarjetas (modo por nivel, INDICATIVO, y entrada temática por tiempo)
- `menuMetadata.js`: descripción del paso 05 en flujo específico
- `OnboardingFlow.jsx`: kicker del paso 05 por nivel (`BLOQUE` → `TEMA`) y su texto auxiliar ("Elegí un tema para practicar.")

**Casos donde "bloque" no significaba tema verbal** — se usó el término correcto en lugar de "tema":
- `DurationSelectionStep.jsx`: se refería a la duración de la sesión → "Ajustá la duración antes de entrar al recorrido guiado."
- `focusTracks.js`: se refería a una sesión corta → "Práctica corta para recuperar precisión general."

No quedan usos de "bloque" en cadenas visibles al usuario. Se dejó sin tocar el comentario interno `// Bloques de práctica` sobre la key de estado `currentBlock` en `settings.js`, porque es nomenclatura de código y no texto de UI.

## Verificación

- `npm run lint`: 0 errores (153 warnings preexistentes)
- `npm run validate-integrity`: pasa
- Tests de `DurationSelectionStep` y `focusTracks`: pasan
- `navigationBack.test.jsx` tiene 1 fallo, pero es **preexistente**: verificado que falla igual en `main` (a4e10b4), sin relación con este diff

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbhzq85NcBJGLLcRPR8uRb)_