### PR TITLE
fix(search): surface simplified verb groups on partial queries

### DIFF
--- a/src/lib/search/searchTopics.js
+++ b/src/lib/search/searchTopics.js
@@ -1,5 +1,6 @@
 import { foldForSearch, tokenize, editDistanceWithin } from './searchText.js'
 import { TOPIC_KINDS } from './topicSearchIndex.js'
+import { expandSimplifiedGroup } from '../data/simplifiedFamilyGroups.js'
 
 /**
  * Ranking for the menu topic search.
@@ -111,6 +112,44 @@ export function computeHighlightRanges(entry, tokens) {
 }
 
 /**
+ * Lift each matched simplified group to just above the best-scoring technical
+ * family it expands to.
+ *
+ * A learner-facing group ("Verbos que diptongan") and its technical families
+ * ("Diptongación e→ie", …) match the same query, but a short query prefix-matches
+ * the family label harder ("dipt" hits the *start* of "Diptongación" yet only
+ * mid-word in the group). Combined with MAX_FAMILY_RESULTS that buries the group
+ * behind its own children, so a partial query never surfaces the whole-group
+ * option. This makes the group lead its cluster instead.
+ *
+ * The lift is bounded by the children's scores, and every child is a FAMILY
+ * entry, so it can never push a group past a tense or verb-type row the user
+ * actually named ("presente irregulares" still resolves to the verb-type row).
+ */
+function liftSimplifiedGroups(scored) {
+  const familyKey = (payload) =>
+    `${payload.specificMood}:${payload.specificTense}:${payload.selectedFamily}`
+
+  const familyScores = new Map()
+  for (const item of scored) {
+    if (item.entry.kind === TOPIC_KINDS.FAMILY && item.entry.payload) {
+      familyScores.set(familyKey(item.entry.payload), item.score)
+    }
+  }
+
+  for (const item of scored) {
+    if (!item.entry.simplified || !item.entry.payload) continue
+    const { specificMood, specificTense, selectedFamily } = item.entry.payload
+    let bestChild = -Infinity
+    for (const memberId of expandSimplifiedGroup(selectedFamily)) {
+      const childScore = familyScores.get(`${specificMood}:${specificTense}:${memberId}`)
+      if (childScore !== undefined) bestChild = Math.max(bestChild, childScore)
+    }
+    if (bestChild >= item.score) item.score = bestChild + 1
+  }
+}
+
+/**
  * @param {string} query - raw user input
  * @param {Array} index - from getTopicSearchIndex()
  * @param {{limit?: number}} options
@@ -146,6 +185,8 @@ export function searchTopics(query, index, { limit = 8 } = {}) {
 
     scored.push({ entry, score: total, order: i })
   }
+
+  liftSimplifiedGroups(scored)
 
   scored.sort((a, b) => (b.score - a.score) || (a.order - b.order))
 

--- a/src/lib/search/searchTopics.test.js
+++ b/src/lib/search/searchTopics.test.js
@@ -126,6 +126,28 @@ describe('searchTopics', () => {
     expect(ids('irregulares en yo')[0]).toContain('FIRST_PERSON_IRREGULAR')
   })
 
+  it('surfaces the simplified group on a partial query, not just its families', () => {
+    // Typing "dipt"/"diptong" prefix-matches the technical "Diptongación …"
+    // families; the broad "Verbos que diptongan" group must not be crowded out
+    // of the (capped) family results by its own children.
+    for (const q of ['dipt', 'diptong']) {
+      const found = ids(q, { limit: 8 })
+      const stem = found.findIndex(id => id.includes('STEM_CHANGES'))
+      const firstDipht = found.findIndex(id => /DIPHT_/.test(id))
+      expect(stem, q).toBeGreaterThanOrEqual(0)
+      // The group ranks at or above the first technical family it expands to.
+      if (firstDipht !== -1) expect(stem, q).toBeLessThanOrEqual(firstDipht)
+    }
+  })
+
+  it('surfaces simplified groups generally, not just diptongación', () => {
+    expect(ids('pret fuerte', { limit: 8 }).some(id => id.includes('PRETERITE_STRONG_STEM'))).toBe(true)
+  })
+
+  it('still lets a named tense outrank the simplified groups', () => {
+    expect(ids('presente', { limit: 8 })[0]).toBe('tense:indicative:pres')
+  })
+
   it('caps family results so they never crowd out tenses', () => {
     const found = run('irregulares', { limit: 8 })
     const families = found.filter(r => r.entry.kind === 'family')


### PR DESCRIPTION
## Problema

En el buscador del menú (`searchTopics`), al escribir una consulta parcial como `dipt` / `diptong` aparecían las **familias técnicas** ("Diptongación e→ie", "o→ue", "u→ue") pero **no** la opción de grupo completo "Verbos que diptongan · presente". El grupo solo emergía escribiendo la palabra entera `diptongan`.

**Causa:** en `scoreToken()` una familia técnica cuyo nombre *empieza* con lo tecleado gana `LABEL_PREFIX = 70`, mientras que el grupo "Verbos que **Diptongan**" solo consigue `WORD_PREFIX = 50` porque "diptong" cae a mitad de la etiqueta. Con el tope `MAX_FAMILY_RESULTS = 3`, las familias técnicas llenan los cupos y expulsan al grupo. Como aclaró el usuario, no era un caso puntual de diptongación: el mismo patrón escondía a todos los grupos simplificados detrás de las familias que expanden (p. ej. `pret fuerte` → "Muy Irregulares (raíz fuerte)").

## Solución

Elevar cada grupo simplificado que matchea la consulta a **justo por encima de la familia mejor puntuada que ese grupo expande**, para que el grupo lidere su propio clúster. La elevación está **acotada por el puntaje de las familias hijas** (todas de tipo `FAMILY`), así que nunca empuja al grupo por encima de un tiempo o un `verbType` que el usuario nombró — `presente irregulares` sigue resolviendo a la fila de verbo irregular.

La relación grupo→familias se obtiene con `expandSimplifiedGroup()` (`src/lib/data/simplifiedFamilyGroups.js`), emparejando por `mood`/`tense`/`selectedFamily` del payload de cada entrada.

## Cambios

- `src/lib/search/searchTopics.js`: nueva función `liftSimplifiedGroups()` aplicada antes de ordenar en `searchTopics()`.
- `src/lib/search/searchTopics.test.js`: tests de que `dipt`/`diptong` (parciales) surfacean el grupo al frente de sus familias, que otros grupos también aparecen (`pret fuerte`), y que un tiempo nombrado sigue ganando (`presente`).

## Comportamiento verificado

| Consulta | Antes | Ahora |
|---|---|---|
| `dipt` / `diptong` | solo familias técnicas | **grupo "Verbos que diptongan" primero**, luego las familias |
| `diptongan` | grupo (ya funcionaba) | grupo (sin cambios) |
| `pret fuerte` | familias técnicas | **grupo "Muy Irregulares (raíz fuerte)" primero** |
| `presente` | tiempo | tiempo (sin cambios) |
| `presente irregulares` | verbType irregular | verbType irregular (sin cambios) |

## Testing

- `npx vitest run src/lib/search` — 56 tests en verde
- `npx vitest run src/components/onboarding/TopicSearch.test.jsx` — 12 en verde
- `npx eslint` sobre los archivos modificados — limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWzT976RLS3u8EAwE9ht7W)_