### PR TITLE
Agregar efectos de sonido de acierto/error en los drills

### DIFF
--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useSettings } from '../../state/settings.js'
 import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
-import { ConfigSvg, AccentsSvg, MicSvg, DiceSvg, ChartSvg } from '../shared/DrillIcons.jsx'
+import { ConfigSvg, AccentsSvg, MicSvg, DiceSvg, ChartSvg, SoundOnSvg, SoundOffSvg } from '../shared/DrillIcons.jsx'
 import router from '../../lib/routing/Router.js'
 
 const DIALECT_LABEL = {
@@ -56,6 +56,7 @@ function DrillHeader({
   const settings = useSettings()
   const isReviewMode = settings.practiceMode === 'review'
   const breadcrumb = buildBreadcrumb(settings)
+  const soundEnabled = settings.soundEnabled !== false
 
   return (
     <header className="header">
@@ -143,6 +144,17 @@ function DrillHeader({
           aria-pressed={showGames}
         >
           <DiceSvg />
+        </button>
+
+        <button
+          type="button"
+          onClick={() => settings.toggleSound()}
+          className={`icon-btn${soundEnabled ? ' active' : ''}`}
+          title={soundEnabled ? 'Silenciar sonidos' : 'Activar sonidos'}
+          aria-label={soundEnabled ? 'Silenciar sonidos' : 'Activar sonidos'}
+          aria-pressed={soundEnabled}
+        >
+          {soundEnabled ? <SoundOnSvg /> : <SoundOffSvg />}
         </button>
 
         <button

--- a/src/components/shared/DrillIcons.jsx
+++ b/src/components/shared/DrillIcons.jsx
@@ -75,3 +75,20 @@ export const SpeakerSvg = ({ size = 18 }) => (
     <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/>
   </svg>
 )
+
+export const SoundOnSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M3 9v6h4l5 5V4L7 9H3z"/>
+    <path d="M16 7.5c1.48.74 2.5 2.26 2.5 4.03s-1.02 3.29-2.5 4.02V7.5z"/>
+    <path d="M16 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/>
+  </svg>
+)
+
+export const SoundOffSvg = ({ size = SIZE }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 9v6h4l5 5V4L7 9H3z" fill="currentColor" stroke="none"/>
+    <line x1="16" y1="9" x2="22" y2="15"/>
+    <line x1="22" y1="9" x2="16" y2="15"/>
+  </svg>
+)

--- a/src/features/drill/useProgressTracking.js
+++ b/src/features/drill/useProgressTracking.js
@@ -20,6 +20,7 @@ import { useSessionStore } from '../../state/session.js'
 import { initProgressSystem as initProgressSystemCore } from '../../lib/progress/index.js'
 import { getAdaptiveEngine } from '../../lib/progress/AdaptiveDifficultyEngine.js'
 import { useShallow } from 'zustand/react/shallow'
+import { playFeedbackSound } from '../../lib/audio/soundEffects.js'
 
 const logger = createLogger('useProgressTracking')
 
@@ -128,6 +129,9 @@ export function useProgressTracking(currentItem, onResult) {
     if (onResult) {
       onResult(result)
     }
+
+    // Feedback de sonido de acierto/error (no-op si el sonido está desactivado)
+    playFeedbackSound(result?.correct ? 'correct' : 'incorrect')
 
     // Latencia del intento (una sola medición reutilizada por los consumidores)
     const latencyMs = itemStartTimeRef.current ? Date.now() - itemStartTimeRef.current : 0

--- a/src/lib/audio/soundEffects.js
+++ b/src/lib/audio/soundEffects.js
@@ -1,0 +1,83 @@
+// Efectos de sonido sintetizados con la Web Audio API (osciladores, sin archivos
+// de audio): la app se mantiene 100% offline y sin assets que descargar. Todo va
+// envuelto en guards para no romper en entornos sin la API (SSR, jsdom).
+// Portado de los repos hermanos Gener-os e Impacto-in-directo.
+
+import { useSettings } from '../../state/settings.js'
+import { createLogger } from '../utils/logger.js'
+
+const logger = createLogger('soundEffects')
+
+const hasApi = () =>
+  typeof window !== 'undefined' &&
+  (typeof window.AudioContext !== 'undefined' ||
+    typeof window.webkitAudioContext !== 'undefined')
+
+// Un único AudioContext reutilizado entre llamadas (crear uno por sonido agota el
+// límite de contextos concurrentes de algunos navegadores).
+let cachedContext = null
+
+function getContext() {
+  if (!hasApi()) return null
+  if (cachedContext) return cachedContext
+  try {
+    const Ctor = window.AudioContext || window.webkitAudioContext
+    cachedContext = new Ctor()
+  } catch {
+    return null
+  }
+  return cachedContext
+}
+
+/**
+ * Reproduce un efecto de sonido de feedback. No hace nada si el sonido está
+ * desactivado en los ajustes o si la Web Audio API no está disponible.
+ *
+ * @param {'correct'|'incorrect'} kind - Tipo de feedback.
+ */
+export function playFeedbackSound(kind) {
+  // Respeta la preferencia global persistida.
+  try {
+    if (!useSettings.getState().soundEnabled) return
+  } catch {
+    // Si el store todavía no está listo, seguimos con el default (sonar).
+  }
+
+  const ctx = getContext()
+  if (!ctx) return
+
+  try {
+    // Algunos navegadores arrancan el contexto suspendido hasta el primer gesto.
+    if (ctx.state === 'suspended' && typeof ctx.resume === 'function') {
+      ctx.resume().catch(() => {})
+    }
+
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    const now = ctx.currentTime
+
+    if (kind === 'correct') {
+      // Tono ascendente D5 -> A5 (sine).
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(587.33, now)
+      osc.frequency.setValueAtTime(880, now + 0.08)
+      gain.gain.setValueAtTime(0.12, now)
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.25)
+      osc.start(now)
+      osc.stop(now + 0.25)
+    } else {
+      // Zumbido descendente 120 -> 90 Hz (sawtooth).
+      osc.type = 'sawtooth'
+      osc.frequency.setValueAtTime(120, now)
+      osc.frequency.setValueAtTime(90, now + 0.1)
+      gain.gain.setValueAtTime(0.12, now)
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.35)
+      osc.start(now)
+      osc.stop(now + 0.35)
+    }
+  } catch (error) {
+    logger.debug('No se pudo reproducir el efecto de sonido', error)
+  }
+}

--- a/src/lib/audio/soundEffects.test.js
+++ b/src/lib/audio/soundEffects.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// El módulo cachea un único AudioContext a nivel de módulo, así que reseteamos
+// los módulos antes de cada test para garantizar aislamiento.
+
+const originalAudioContext = window.AudioContext
+const originalWebkit = window.webkitAudioContext
+
+// Mock mínimo de la Web Audio API para verificar el grafo de nodos.
+function createMockAudioContext() {
+  const oscillator = {
+    type: '',
+    frequency: { setValueAtTime: vi.fn() },
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn()
+  }
+  const gain = {
+    gain: {
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn()
+    },
+    connect: vi.fn()
+  }
+  const ctx = {
+    state: 'running',
+    currentTime: 0,
+    destination: {},
+    resume: vi.fn(() => Promise.resolve()),
+    createOscillator: vi.fn(() => oscillator),
+    createGain: vi.fn(() => gain)
+  }
+  return { ctx, oscillator, gain }
+}
+
+// Carga fresca del módulo (caché de AudioContext reiniciado) + ajuste de sonido.
+async function loadModule(soundEnabled = true) {
+  vi.resetModules()
+  const { useSettings } = await import('../../state/settings.js')
+  useSettings.setState({ soundEnabled })
+  const { playFeedbackSound } = await import('./soundEffects.js')
+  return { playFeedbackSound }
+}
+
+describe('playFeedbackSound', () => {
+  beforeEach(() => {
+    window.AudioContext = undefined
+    window.webkitAudioContext = undefined
+  })
+
+  afterEach(() => {
+    window.AudioContext = originalAudioContext
+    window.webkitAudioContext = originalWebkit
+    vi.restoreAllMocks()
+  })
+
+  it('crea un oscilador y un gain al reproducir un acierto', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playFeedbackSound } = await loadModule(true)
+
+    playFeedbackSound('correct')
+
+    expect(ctx.createOscillator).toHaveBeenCalled()
+    expect(ctx.createGain).toHaveBeenCalled()
+    expect(oscillator.type).toBe('sine')
+    expect(oscillator.start).toHaveBeenCalled()
+    expect(oscillator.stop).toHaveBeenCalled()
+  })
+
+  it('usa una onda sawtooth para el error', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playFeedbackSound } = await loadModule(true)
+
+    playFeedbackSound('incorrect')
+
+    expect(oscillator.type).toBe('sawtooth')
+  })
+
+  it('es no-op cuando el sonido está desactivado', async () => {
+    const { ctx } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playFeedbackSound } = await loadModule(false)
+
+    playFeedbackSound('correct')
+
+    expect(ctx.createOscillator).not.toHaveBeenCalled()
+  })
+
+  it('no lanza cuando la Web Audio API no está disponible', async () => {
+    const { playFeedbackSound } = await loadModule(true)
+
+    expect(() => playFeedbackSound('correct')).not.toThrow()
+  })
+})

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -96,6 +96,9 @@ const createDefaultSettings = () => ({
   // Sistema de progreso - toggle para la integración con mastery data
   enableProgressIntegration: true,
 
+  // Efectos de sonido - feedback de acierto/error en los drills
+  soundEnabled: true,
+
   // Metas diarias
   dailyGoalType: 'attempts',
   dailyGoalValue: 20,
@@ -183,7 +186,8 @@ const PERSISTED_SETTINGS_KEYS = [
   'dailyGoalValue',
   'practiceReminderEnabled',
   'practiceReminderTime',
-  'practiceReminderDays'
+  'practiceReminderDays',
+  'soundEnabled'
 ]
 
 const pickPersistedSettings = (state) => {
@@ -242,7 +246,8 @@ const persistedSettingsSchema = z.object({
   dailyGoalValue: z.number().optional(),
   practiceReminderEnabled: z.boolean().optional(),
   practiceReminderTime: z.string().optional(),
-  practiceReminderDays: z.array(z.number()).optional()
+  practiceReminderDays: z.array(z.number()).optional(),
+  soundEnabled: z.boolean().optional()
 })
 
 const sanitizePersistedSettings = (persistedState) => {
@@ -390,6 +395,7 @@ const useSettings = create(
         setCliticsPercent: (percent) => set({ cliticsPercent: percent }),
         setC2RareBoost: (lemmas) => set({ c2RareBoostLemmas: lemmas }),
         toggleChunks: () => set((state) => ({ enableChunks: !state.enableChunks })),
+        toggleSound: () => set((state) => ({ soundEnabled: !state.soundEnabled })),
         toggleProgressIntegration: () => set((state) => ({ enableProgressIntegration: !state.enableProgressIntegration })),
 
         setDailyGoalType: (goalType) =>


### PR DESCRIPTION
## Qué

Agrega efectos de sonido de feedback en los drills/ejercicios, replicando el comportamiento de los repos hermanos [Gener-os](https://github.com/ravacholin/Gener-os) e [Impacto-in-directo](https://github.com/ravacholin/Impacto-in-directo).

- **Acierto**: tono ascendente D5 → A5 (onda `sine`).
- **Error**: zumbido descendente 120 → 90 Hz (onda `sawtooth`).

## Cómo

Igual que las referencias, los sonidos se **sintetizan con la Web Audio API** (osciladores, sin archivos `.mp3`/`.wav`), así la app se mantiene 100% offline y no crece el bundle.

- **`src/lib/audio/soundEffects.js`** (nuevo): `playFeedbackSound('correct' | 'incorrect')`. Reutiliza un único `AudioContext` cacheado y está envuelto en guards para no romper en entornos sin la API (SSR/jsdom). Lee la preferencia `soundEnabled` internamente, así que es no-op cuando el sonido está desactivado.
- **`src/features/drill/useProgressTracking.js`**: dispara el sonido en `handleResult`, el único punto por el que pasan los tres modos de envío (normal, doble y reverse).
- **`src/state/settings.js`**: nueva preferencia persistida `soundEnabled` (default `true`) con setter `toggleSound` (añadida al default, a `PERSISTED_SETTINGS_KEYS` y al schema zod de sanitización).
- **`src/components/drill/DrillHeader.jsx`** + **`src/components/shared/DrillIcons.jsx`**: botón de altavoz para silenciar/activar en la barra del drill, con íconos `SoundOnSvg`/`SoundOffSvg`.

No se toca el sistema de TTS existente (`useSpeech.ts`) ni el panel de pronunciación.

## Verificación

- ✅ Test unitario nuevo `src/lib/audio/soundEffects.test.js` (4 tests): crea oscilador/gain, usa la onda correcta por tipo, es no-op cuando está desactivado y no lanza sin Web Audio API.
- ✅ `npm run lint` — 0 errores (sin nuevos warnings en los archivos modificados).
- ✅ `npm run validate-integrity` — passed (239 verbos).
- ✅ Tests de `src/state` — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwNqxqEcT4Bd2huLbirW9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwNqxqEcT4Bd2huLbirW9K)_