### PR TITLE
Ampliar los efectos de sonido a onboarding, menús y modo Supervivencia

### DIFF
--- a/src/components/drill/DrillHeader.jsx
+++ b/src/components/drill/DrillHeader.jsx
@@ -3,6 +3,7 @@ import { useSettings } from '../../state/settings.js'
 import { getSafeMoodTenseLabels } from '../../lib/utils/moodTenseValidator.js'
 import { ConfigSvg, AccentsSvg, MicSvg, DiceSvg, ChartSvg, SoundOnSvg, SoundOffSvg } from '../shared/DrillIcons.jsx'
 import router from '../../lib/routing/Router.js'
+import { playUiSound } from '../../lib/audio/soundEffects.js'
 
 const DIALECT_LABEL = {
   rioplatense: 'vos',
@@ -65,7 +66,7 @@ function DrillHeader({
         <button
           type="button"
           className="vd-back-btn"
-          onClick={() => router.back()}
+          onClick={() => { playUiSound('back'); router.back() }}
           title="Volver"
           aria-label="Volver"
         >
@@ -105,7 +106,7 @@ function DrillHeader({
       <div className="icon-row">
         <button
           type="button"
-          onClick={() => onToggleQuickSwitch(showQuickSwitch ? false : true)}
+          onClick={() => { playUiSound('select'); onToggleQuickSwitch(showQuickSwitch ? false : true) }}
           className={`icon-btn${showQuickSwitch ? ' active' : ''}`}
           title="Configuración rápida"
           aria-label="Configuración rápida"
@@ -116,7 +117,7 @@ function DrillHeader({
 
         <button
           type="button"
-          onClick={() => onToggleAccentKeys()}
+          onClick={() => { playUiSound('select'); onToggleAccentKeys() }}
           className="icon-btn"
           title="Tildes especiales"
           aria-label="Tildes especiales"
@@ -126,7 +127,7 @@ function DrillHeader({
 
         <button
           type="button"
-          onClick={() => onTogglePronunciation()}
+          onClick={() => { playUiSound('select'); onTogglePronunciation() }}
           className={`icon-btn${showPronunciation ? ' active' : ''}${isRecording ? ' recording' : ''}`}
           title="Pronunciación"
           aria-label="Pronunciación"
@@ -137,7 +138,7 @@ function DrillHeader({
 
         <button
           type="button"
-          onClick={() => onToggleGames(showGames ? false : true)}
+          onClick={() => { playUiSound('select'); onToggleGames(showGames ? false : true) }}
           className={`icon-btn${showGames ? ' active' : ''}`}
           title="Modos de juego"
           aria-label="Modos de juego"
@@ -148,7 +149,7 @@ function DrillHeader({
 
         <button
           type="button"
-          onClick={() => settings.toggleSound()}
+          onClick={() => { settings.toggleSound(); if (!soundEnabled) playUiSound('select') }}
           className={`icon-btn${soundEnabled ? ' active' : ''}`}
           title={soundEnabled ? 'Silenciar sonidos' : 'Activar sonidos'}
           aria-label={soundEnabled ? 'Silenciar sonidos' : 'Activar sonidos'}
@@ -159,7 +160,7 @@ function DrillHeader({
 
         <button
           type="button"
-          onClick={() => onNavigateToProgress()}
+          onClick={() => { playUiSound('select'); onNavigateToProgress() }}
           className="icon-btn"
           title="Progreso"
           aria-label="Progreso"

--- a/src/components/drill/GamesPanel.jsx
+++ b/src/components/drill/GamesPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useSessionStore } from '../../state/session.js'
+import { playUiSound } from '../../lib/audio/soundEffects.js'
 
 const RESISTANCE_BASE_MS_BY_LEVEL = {
   C2: 15000,
@@ -76,13 +77,16 @@ function GamesPanel({ settings, onClose, onRegenerateItem }) {
             <button
               key={mode.id}
               className={`vd-game-btn${active ? ' vd-game-btn--active' : ''}`}
-              onClick={() => mode.toggle({
-                game,
-                setGameMode,
-                settings,
-                onClose,
-                onRegen: onRegenerateItem
-              })}
+              onClick={() => {
+                playUiSound('select')
+                mode.toggle({
+                  game,
+                  setGameMode,
+                  settings,
+                  onClose,
+                  onRegen: onRegenerateItem
+                })
+              }}
               aria-pressed={active}
             >
               <img src={mode.icon} alt="" className="vd-game-img" aria-hidden="true" />
@@ -96,7 +100,7 @@ function GamesPanel({ settings, onClose, onRegenerateItem }) {
         })}
       </div>
       <div className="vd-qs-actions">
-        <button className="btn btn-secondary" onClick={onClose}>Cerrar</button>
+        <button className="btn btn-secondary" onClick={() => { playUiSound('back'); onClose() }}>Cerrar</button>
       </div>
     </div>
   )

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -7,6 +7,7 @@ import { getTopicSearchIndex } from '../../lib/search/topicSearchIndex.js'
 import { searchTopics } from '../../lib/search/searchTopics.js'
 import { getTensesForMood, getTenseLabel, getMoodLabel } from '../../lib/utils/verbLabels.js'
 import { getFamilyChoices } from '../../lib/data/familyChoices.js'
+import { playUiSound } from '../../lib/audio/soundEffects.js'
 
 /* ── Design tokens ── */
 const ACCENT = 'var(--accent-primary)'
@@ -708,6 +709,7 @@ function OnboardingFlow({
   }, [lastPlacementResult, settings])
 
   const handleBack = useCallback(() => {
+    playUiSound('back')
     if (onboardingStep === 5 && themeSubMenu) {
       setThemeSubMenu(null)
       setAnimKey(k => k + 1)
@@ -717,6 +719,7 @@ function OnboardingFlow({
   }, [onboardingStep, themeSubMenu])
 
   const handleLogoClick = useCallback(() => {
+    playUiSound('back')
     handleHome(setCurrentMode)
   }, [handleHome, setCurrentMode])
 
@@ -828,6 +831,7 @@ function OnboardingFlow({
   }), [searchQuery, searchResults, searchOptions, handleBack])
 
   const handleOptionSelect = useCallback((opt) => {
+    playUiSound('select')
     opt.onSelect()
   }, [])
 

--- a/src/components/shared/ClickableCard.jsx
+++ b/src/components/shared/ClickableCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react'
+import { playUiSound } from '../../lib/audio/soundEffects.js'
 
 /**
  * Componente accesible para elementos interactivos
@@ -51,6 +52,7 @@ function ClickableCard({ className = '', onClick, children, title, role = "butto
   }
 
   const handleActivate = (e) => {
+    playUiSound('select')
     triggerClickAnim()
     onClick && onClick(e)
   }

--- a/src/features/drill/useResistanceTimer.ts
+++ b/src/features/drill/useResistanceTimer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSettings, RESISTANCE_MAX_MS } from '../../state/settings.js'
 import { useSessionStore } from '../../state/session.js'
+import { playGameSound } from '../../lib/audio/soundEffects.js'
 
 /**
  * useResistanceTimer.ts
@@ -27,6 +28,9 @@ export function useResistanceTimer() {
   const [clockClickFeedback, setClockClickFeedback] = useState(false)
   const intervalRef = useRef<number | null>(null)
   const msLeftRef = useRef(0)
+  // Último segundo entero al que ya le sonó el tick, para disparar el pip de
+  // cuenta regresiva una sola vez por segundo (el interval corre cada 100ms).
+  const lastTickSecondRef = useRef<number | null>(null)
   const urgentTickTimeoutRef = useRef<number | null>(null)
   const explosionTimeoutRef = useRef<number | null>(null)
   const clockClickTimeoutRef = useRef<number | null>(null)
@@ -60,6 +64,7 @@ export function useResistanceTimer() {
     const initialMs = useSessionStore.getState().resistanceMsLeft || 0
     msLeftRef.current = initialMs
     setMsLeft(initialMs)
+    lastTickSecondRef.current = null
 
     if (initialMs <= 0 || typeof window === 'undefined') {
       return
@@ -79,10 +84,18 @@ export function useResistanceTimer() {
           urgentTickTimeoutRef.current = null
           setUrgentTick(false)
         }, 150)
+
+        // Pip de cuenta regresiva: una vez por segundo entero (no cada 100ms).
+        const second = Math.ceil(left / 1000)
+        if (lastTickSecondRef.current !== second) {
+          lastTickSecondRef.current = second
+          playGameSound('tick')
+        }
       }
 
       if (left === 0) {
         clearTimer()
+        playGameSound('gameOver')
         setShowExplosion(true)
         explosionTimeoutRef.current = window.setTimeout(() => {
           explosionTimeoutRef.current = null
@@ -122,6 +135,7 @@ export function useResistanceTimer() {
     if (!resistanceActive || msLeftRef.current <= 0) return
     msLeftRef.current = Math.min(msLeftRef.current + 5000, RESISTANCE_MAX_MS)
     setMsLeft(msLeftRef.current)
+    playGameSound('bonus')
     setClockClickFeedback(true)
     if (clockClickTimeoutRef.current !== null) {
       clearTimeout(clockClickTimeoutRef.current)

--- a/src/lib/audio/soundEffects.js
+++ b/src/lib/audio/soundEffects.js
@@ -30,12 +30,18 @@ function getContext() {
 }
 
 /**
- * Reproduce un efecto de sonido de feedback. No hace nada si el sonido está
- * desactivado en los ajustes o si la Web Audio API no está disponible.
+ * Motor común de todos los efectos: un oscilador con envolvente exponencial de
+ * gain. Respeta la preferencia global `soundEnabled` (un mismo toggle silencia
+ * TODOS los sonidos) y es no-op cuando la Web Audio API no está disponible.
  *
- * @param {'correct'|'incorrect'} kind - Tipo de feedback.
+ * @param {Object} spec
+ * @param {OscillatorType} spec.type - Forma de onda ('sine', 'sawtooth', ...).
+ * @param {Array<[number, number]>} spec.points - Pares [offsetSegundos, frecuenciaHz]
+ *   que se programan sobre el oscilador (permite barridos y arpegios simples).
+ * @param {number} spec.peakGain - Ganancia inicial (pico) del sonido.
+ * @param {number} spec.duration - Duración total en segundos.
  */
-export function playFeedbackSound(kind) {
+function playTone({ type, points, peakGain, duration }) {
   // Respeta la preferencia global persistida.
   try {
     if (!useSettings.getState().soundEnabled) return
@@ -58,26 +64,101 @@ export function playFeedbackSound(kind) {
     gain.connect(ctx.destination)
     const now = ctx.currentTime
 
-    if (kind === 'correct') {
-      // Tono ascendente D5 -> A5 (sine).
-      osc.type = 'sine'
-      osc.frequency.setValueAtTime(587.33, now)
-      osc.frequency.setValueAtTime(880, now + 0.08)
-      gain.gain.setValueAtTime(0.12, now)
-      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.25)
-      osc.start(now)
-      osc.stop(now + 0.25)
-    } else {
-      // Zumbido descendente 120 -> 90 Hz (sawtooth).
-      osc.type = 'sawtooth'
-      osc.frequency.setValueAtTime(120, now)
-      osc.frequency.setValueAtTime(90, now + 0.1)
-      gain.gain.setValueAtTime(0.12, now)
-      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.35)
-      osc.start(now)
-      osc.stop(now + 0.35)
+    osc.type = type
+    for (const [offset, freq] of points) {
+      osc.frequency.setValueAtTime(freq, now + offset)
     }
+
+    gain.gain.setValueAtTime(peakGain, now)
+    gain.gain.exponentialRampToValueAtTime(0.001, now + duration)
+
+    osc.start(now)
+    osc.stop(now + duration)
   } catch (error) {
     logger.debug('No se pudo reproducir el efecto de sonido', error)
+  }
+}
+
+/**
+ * Reproduce un efecto de sonido de feedback de acierto/error.
+ *
+ * @param {'correct'|'incorrect'} kind - Tipo de feedback.
+ */
+export function playFeedbackSound(kind) {
+  if (kind === 'correct') {
+    // Tono ascendente D5 -> A5 (sine).
+    playTone({
+      type: 'sine',
+      points: [[0, 587.33], [0.08, 880]],
+      peakGain: 0.12,
+      duration: 0.25
+    })
+  } else {
+    // Zumbido descendente 120 -> 90 Hz (sawtooth).
+    playTone({
+      type: 'sawtooth',
+      points: [[0, 120], [0.1, 90]],
+      peakGain: 0.12,
+      duration: 0.35
+    })
+  }
+}
+
+/**
+ * Reproduce un efecto de sonido de interfaz (navegación de menús/onboarding).
+ * Son deliberadamente cortos y de bajo volumen porque se disparan seguido.
+ *
+ * @param {'select'|'back'} kind - 'select' al elegir/avanzar, 'back' al retroceder.
+ */
+export function playUiSound(kind) {
+  if (kind === 'back') {
+    // Blip corto descendente (triangle).
+    playTone({
+      type: 'triangle',
+      points: [[0, 440], [0.04, 330]],
+      peakGain: 0.045,
+      duration: 0.09
+    })
+  } else {
+    // 'select': blip corto ascendente (triangle).
+    playTone({
+      type: 'triangle',
+      points: [[0, 520], [0.03, 660]],
+      peakGain: 0.05,
+      duration: 0.07
+    })
+  }
+}
+
+/**
+ * Reproduce un efecto de sonido de los mini-juegos del drill (modo Supervivencia).
+ *
+ * @param {'tick'|'bonus'|'gameOver'} kind - Momento del juego.
+ */
+export function playGameSound(kind) {
+  if (kind === 'tick') {
+    // Pip corto y agudo de cuenta regresiva.
+    playTone({
+      type: 'square',
+      points: [[0, 880]],
+      peakGain: 0.06,
+      duration: 0.04
+    })
+  } else if (kind === 'bonus') {
+    // Arpegio ascendente tipo power-up (A5 -> C#6 -> E6), distinto del acierto.
+    playTone({
+      type: 'sine',
+      points: [[0, 880], [0.06, 1108.73], [0.12, 1318.51]],
+      peakGain: 0.1,
+      duration: 0.22
+    })
+  } else {
+    // 'gameOver': zumbido descendente en dos escalones, más grave/largo que el error.
+    playTone({
+      type: 'sawtooth',
+      points: [[0, 160], [0.18, 90], [0.36, 55]],
+      peakGain: 0.14,
+      duration: 0.6
+    })
   }
 }

--- a/src/lib/audio/soundEffects.test.js
+++ b/src/lib/audio/soundEffects.test.js
@@ -38,8 +38,8 @@ async function loadModule(soundEnabled = true) {
   vi.resetModules()
   const { useSettings } = await import('../../state/settings.js')
   useSettings.setState({ soundEnabled })
-  const { playFeedbackSound } = await import('./soundEffects.js')
-  return { playFeedbackSound }
+  const { playFeedbackSound, playUiSound, playGameSound } = await import('./soundEffects.js')
+  return { playFeedbackSound, playUiSound, playGameSound }
 }
 
 describe('playFeedbackSound', () => {
@@ -92,5 +92,122 @@ describe('playFeedbackSound', () => {
     const { playFeedbackSound } = await loadModule(true)
 
     expect(() => playFeedbackSound('correct')).not.toThrow()
+  })
+})
+
+describe('playUiSound', () => {
+  beforeEach(() => {
+    window.AudioContext = undefined
+    window.webkitAudioContext = undefined
+  })
+
+  afterEach(() => {
+    window.AudioContext = originalAudioContext
+    window.webkitAudioContext = originalWebkit
+    vi.restoreAllMocks()
+  })
+
+  it('crea un oscilador y un gain al reproducir una selección', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playUiSound } = await loadModule(true)
+
+    playUiSound('select')
+
+    expect(ctx.createOscillator).toHaveBeenCalled()
+    expect(ctx.createGain).toHaveBeenCalled()
+    expect(oscillator.type).toBe('triangle')
+    expect(oscillator.start).toHaveBeenCalled()
+    expect(oscillator.stop).toHaveBeenCalled()
+  })
+
+  it('también suena para "back"', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playUiSound } = await loadModule(true)
+
+    playUiSound('back')
+
+    expect(oscillator.type).toBe('triangle')
+    expect(oscillator.start).toHaveBeenCalled()
+  })
+
+  it('es no-op cuando el sonido está desactivado', async () => {
+    const { ctx } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playUiSound } = await loadModule(false)
+
+    playUiSound('select')
+
+    expect(ctx.createOscillator).not.toHaveBeenCalled()
+  })
+
+  it('no lanza cuando la Web Audio API no está disponible', async () => {
+    const { playUiSound } = await loadModule(true)
+
+    expect(() => playUiSound('select')).not.toThrow()
+  })
+})
+
+describe('playGameSound', () => {
+  beforeEach(() => {
+    window.AudioContext = undefined
+    window.webkitAudioContext = undefined
+  })
+
+  afterEach(() => {
+    window.AudioContext = originalAudioContext
+    window.webkitAudioContext = originalWebkit
+    vi.restoreAllMocks()
+  })
+
+  it('reproduce el pip de cuenta regresiva (tick)', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playGameSound } = await loadModule(true)
+
+    playGameSound('tick')
+
+    expect(ctx.createOscillator).toHaveBeenCalled()
+    expect(oscillator.type).toBe('square')
+    expect(oscillator.start).toHaveBeenCalled()
+  })
+
+  it('reproduce el arpegio de bonus con varias frecuencias', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playGameSound } = await loadModule(true)
+
+    playGameSound('bonus')
+
+    expect(oscillator.type).toBe('sine')
+    // El arpegio programa más de una frecuencia sobre el oscilador.
+    expect(oscillator.frequency.setValueAtTime.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('usa una onda sawtooth para el game over', async () => {
+    const { ctx, oscillator } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playGameSound } = await loadModule(true)
+
+    playGameSound('gameOver')
+
+    expect(oscillator.type).toBe('sawtooth')
+  })
+
+  it('es no-op cuando el sonido está desactivado', async () => {
+    const { ctx } = createMockAudioContext()
+    window.AudioContext = vi.fn(() => ctx)
+    const { playGameSound } = await loadModule(false)
+
+    playGameSound('tick')
+
+    expect(ctx.createOscillator).not.toHaveBeenCalled()
+  })
+
+  it('no lanza cuando la Web Audio API no está disponible', async () => {
+    const { playGameSound } = await loadModule(true)
+
+    expect(() => playGameSound('gameOver')).not.toThrow()
   })
 })


### PR DESCRIPTION
## Contexto

En el commit `9ca0a6d` se agregaron efectos de sonido de acierto/error en los drills, sintetizados con la Web Audio API (osciladores, **sin archivos de audio** → la app sigue 100% offline y sin peso extra en el bundle). Este PR **extiende ese mismo estilo/estética** a más lugares, siempre respetando el mismo toggle de silencio existente (`soundEnabled`).

Se dejó **fuera** el subsistema de gamificación (XP/insignias/rachas), por pedido explícito, ya que no está implementado de cara al usuario. Los "juegos dentro del drill" (modo Supervivencia) **sí** reciben sonidos.

## Cambios

**Motor de audio — `src/lib/audio/soundEffects.js`**
- Se generaliza el patrón inline en un helper `playTone({ type, points, peakGain, duration })` que centraliza el gate de `soundEnabled` (un mismo toggle silencia **todo**), el `AudioContext` cacheado y la envolvente exponencial.
- `playFeedbackSound` mantiene su comportamiento observable (mismas ondas y frecuencias).
- Nuevos dispatchers:
  - `playUiSound('select'|'back')`: blips cortos y de bajo volumen para navegación.
  - `playGameSound('tick'|'bonus'|'gameOver')`: sonidos del modo Supervivencia.

**Puntos de disparo (chokepoints existentes, sin tocar markup ni lógica)**
- **Onboarding** (`OnboardingFlow.jsx`): `select` en `handleOptionSelect` (único punto de mouse + teclado); `back` en `handleBack` y en el logo/home.
- **Tarjetas de menú** (`shared/ClickableCard.jsx`): `select` en `handleActivate` (cubre menús, niveles y aprendizaje; click y Enter/Espacio).
- **Barra del drill** (`drill/DrillHeader.jsx`): `select` en los íconos, `back` en Volver, y `select` al **encender** el sonido desde el botón de silencio.
- **Panel de juegos** (`drill/GamesPanel.jsx`): `select` al alternar un modo, `back` al cerrar.
- **Modo Supervivencia** (`drill/useResistanceTimer.ts`): pip de cuenta regresiva **una vez por segundo** en los últimos 5s, `gameOver` al llegar a 0, y `bonus` al sumar +5s con el reloj. El bonus por acierto se deja sin sonido extra para no solaparse con el `correct` que ya suena en ese instante.

## Pruebas

- `soundEffects.test.js` ampliado con casos para `playUiSound` y `playGameSound` (creación del grafo de nodos, forma de onda esperada, no-op con sonido desactivado, sin excepción cuando no hay Web Audio API). **13/13 verdes.**
- `npm run lint` sin errores nuevos (los warnings existentes son ajenos a este cambio).
- Nota: un test preexistente en `navigationBack.test.jsx` ya fallaba en `main` antes de este PR; no está relacionado con estos cambios.

## Verificación manual

- Onboarding con mouse y teclado → `select` al elegir, `back` al volver.
- Tarjetas de menú/niveles/aprender → `select`.
- Íconos del drill → `select`; back → `back`; toggle de sonido al encender → `select`, al apagar → silencio total.
- Supervivencia: tick por segundo en los últimos 5s, `gameOver` a los 0, `bonus` al +5s.
- Silenciar con el botón de altavoz → **todos** los sonidos dejan de sonar.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013TNKLEVC76YTqfwBmmdfU8)_