### PR TITLE
Fix progress micro-drills always practicing presente regular

### DIFF
--- a/src/lib/core/generator.js
+++ b/src/lib/core/generator.js
@@ -123,9 +123,27 @@ export async function chooseNext({ forms, history: _history, currentItem, sessio
     }
   })()
 
+  // Progress-module micro-drills build ad-hoc blocks like `{ combos, itemsRemaining }`
+  // with no `id`, so keying only on `currentBlock?.id` collapsed every one of them
+  // (and normal mixed practice) onto the same `none` bucket — the first cached pool
+  // was then served for every combination, which surfaced as "always presente regular".
+  // Sign the block by its actual targeting (combos + cells), falling back to id.
+  const blockSig = (() => {
+    if (!currentBlock) return 'none'
+    const parts = []
+    if (currentBlock.id) parts.push(`id:${currentBlock.id}`)
+    if (Array.isArray(currentBlock.combos) && currentBlock.combos.length) {
+      parts.push('c:' + currentBlock.combos.map(c => `${c.mood}|${c.tense}`).join(','))
+    }
+    if (Array.isArray(currentBlock.cells) && currentBlock.cells.length) {
+      parts.push('x:' + currentBlock.cells.map(c => `${c.mood}|${c.tense}|${c.person}`).join(','))
+    }
+    return parts.length ? parts.join(';') : 'block'
+  })()
+
   // cameFromTema belongs in the key: it still drives applyLemmaRestrictions, so
   // two otherwise identical settings would share a pool they disagree about.
-  const filterKey = `filter|${level}|${region}|${useVoseo}|${useTuteo}|${useVosotros}|${practiceMode}|${specificMood}|${specificTense}|${practicePronoun}|${verbType}|${selectedFamily}|tema:${cameFromTema ? 1 : 0}|${currentBlock?.id || 'none'}|allowed:${allowedSig}|levelMode:${effectiveLevelPracticeMode}|userLevel:${effectiveUserLevel}`
+  const filterKey = `filter|${level}|${region}|${useVoseo}|${useTuteo}|${useVosotros}|${practiceMode}|${specificMood}|${specificTense}|${practicePronoun}|${verbType}|${selectedFamily}|tema:${cameFromTema ? 1 : 0}|${blockSig}|allowed:${allowedSig}|levelMode:${effectiveLevelPracticeMode}|userLevel:${effectiveUserLevel}`
 
   // CACHE CLEARING: Force fresh calculation for specific practice navigation from progress module
   if (practiceMode === 'specific' && specificMood && specificTense) {

--- a/src/lib/core/generator.progressBlock.test.js
+++ b/src/lib/core/generator.progressBlock.test.js
@@ -1,0 +1,94 @@
+// Regression test for the progress-module "Practicar esto" bug.
+//
+// Bug: In the progress dashboard's "Ver más" → "Reglas y tips" (and the error
+// heatmap / difficult-verb cards), clicking "Practicar esto" always drilled
+// presente regular instead of the targeted mood/tense.
+//
+// Root cause: these micro-drills build ad-hoc blocks like
+// `{ combos, itemsRemaining }` with NO `id`. The generator's form-filter cache
+// key used only `currentBlock?.id || 'none'`, so every block (and normal mixed
+// practice) collapsed onto the same `none` bucket. The first pool cached there —
+// typically the broad mixed pool dominated by present-indicative regular verbs —
+// was then served for every subsequent combination.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { chooseNext } from './generator.js'
+import { buildFormsForRegion } from './eligibility.js'
+import { clearAllCaches } from './optimizedCache.js'
+
+const baseSettings = {
+  level: 'B1',
+  region: 'la_general',
+  practiceMode: 'mixed',
+  specificMood: null,
+  specificTense: null,
+  verbType: 'all',
+  useVoseo: true,
+  useTuteo: true,
+  useVosotros: false,
+  cameFromTema: false,
+  currentBlock: null
+}
+
+describe('Progress micro-drill blocks (combos without id)', () => {
+  beforeEach(() => {
+    clearAllCaches()
+  })
+
+  it('should honor currentBlock.combos even after the general mixed pool is cached', async () => {
+    const forms = await buildFormsForRegion('la_general')
+
+    // 1) Warm the cache with a plain mixed-practice call (no block). Before the
+    //    fix this populated the shared `none` bucket with the broad pool.
+    for (let i = 0; i < 5; i++) {
+      await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: { ...baseSettings } })
+    }
+
+    // 2) Now drill an ad-hoc block targeting a NON-present combo, exactly like the
+    //    "Practicar esto" cards do: a block with combos and itemsRemaining, no id.
+    const blockSettings = {
+      ...baseSettings,
+      currentBlock: {
+        combos: [{ mood: 'indicative', tense: 'impf' }],
+        itemsRemaining: 8
+      }
+    }
+
+    for (let i = 0; i < 40; i++) {
+      const result = await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: blockSettings })
+      expect(result, `Iteration ${i + 1}: no form returned`).toBeTruthy()
+      expect(
+        `${result.mood}|${result.tense}`,
+        `Iteration ${i + 1}: expected indicative|impf but got ${result.mood}|${result.tense} (${result.lemma})`
+      ).toBe('indicative|impf')
+    }
+  })
+
+  it('should not cross-contaminate two different combo blocks sharing no id', async () => {
+    const forms = await buildFormsForRegion('la_general')
+
+    const subjBlock = {
+      ...baseSettings,
+      currentBlock: { combos: [{ mood: 'subjunctive', tense: 'subjPres' }], itemsRemaining: 8 }
+    }
+    const condBlock = {
+      ...baseSettings,
+      currentBlock: { combos: [{ mood: 'conditional', tense: 'cond' }], itemsRemaining: 8 }
+    }
+
+    // Prime the subjunctive block, then switch to the conditional block. Before
+    // the fix both shared the `none` cache bucket and the second reused the first.
+    for (let i = 0; i < 5; i++) {
+      const r = await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: subjBlock })
+      expect(`${r.mood}|${r.tense}`).toBe('subjunctive|subjPres')
+    }
+
+    for (let i = 0; i < 20; i++) {
+      const r = await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: condBlock })
+      expect(
+        `${r.mood}|${r.tense}`,
+        `Iteration ${i + 1}: expected conditional|cond but got ${r.mood}|${r.tense} (${r.lemma})`
+      ).toBe('conditional|cond')
+    }
+  })
+})


### PR DESCRIPTION
## Problema

En el módulo de progreso, al hacer clic en **Ver más** aparecen las tarjetas de **Reglas y tips** (y también el mapa de errores y los verbos que necesitan refuerzo), cada una con un botón **Practicar esto** apuntando a un modo/tiempo distinto. Sin embargo, al clickear, no se practicaba ese modo/tiempo sino **presente regular**.

## Causa raíz

Estas tarjetas del módulo de progreso construyen bloques de práctica ad-hoc con la forma `{ combos, itemsRemaining }`, **sin `id`** (ver `ErrorIntelligence.jsx`, `EnhancedErrorAnalysis.jsx`, `ErrorInsights.jsx`, `ErrorRadar.jsx`).

La cache key del filtro de formas en `generator.js` usaba únicamente `currentBlock?.id || 'none'`:

```js
`...|${currentBlock?.id || 'none'}|...`
```

Como ninguno de esos bloques tiene `id`, todos colapsaban en el mismo bucket `'none'` — el mismo que usa la práctica mixta normal (`currentBlock === null`). El primer pool cacheado ahí (el pool amplio de práctica mixta, dominado por presente de indicativo regular) se servía luego para **cualquier** combinación posterior. De ahí que "Practicar esto" siempre cayera en presente regular.

El filtrado en `FormFilterService.applyLevelFilter` ya respetaba `currentBlock.combos` correctamente; el problema era puramente la colisión de cache.

## Solución

Firmar la cache key por el targeting real del bloque (`combos` + `cells`, con fallback a `id`) en lugar de solo `id`, de modo que bloques distintos ya no compartan el pool cacheado.

## Tests

- Nuevo `src/lib/core/generator.progressBlock.test.js`:
  - Verifica que `currentBlock.combos` se respeta incluso después de que el pool mixto general fue cacheado.
  - Verifica que dos bloques distintos sin `id` no se contaminan entre sí.
- Ambos tests **fallan sin el arreglo** y **pasan con él**.
- Los tests existentes de generador/filtro siguen pasando (`generator.bug.test.js`, `FormFilterService.test.js`, `generator.smoke.test.js`, `curriculumGate.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dsz5Xtvme5u6s6CJZZySBR)_