### PR TITLE
Fix "Practicar esto" still leaking presente after PR #205

### DIFF
--- a/src/hooks/modules/DrillFormFilters.js
+++ b/src/hooks/modules/DrillFormFilters.js
@@ -374,6 +374,19 @@ export const allowsLevel = (form, settings) => {
   // This includes both Tema practice and Progress module navigation
   if (settings.practiceMode === 'specific') return true
 
+  // Progress-module micro-drills (and other ad-hoc blocks) target a specific set of
+  // mood/tense combos while staying in 'mixed' mode. Honor that targeting here so the
+  // eligible pool is actually narrowed to the block. Otherwise this pre-filter yields
+  // every level-appropriate form, and the SRS "due" shortcut in hierarchicalSelection
+  // serves due items from any combo (typically presente regular) — the exact leak that
+  // made "Practicar esto" feel like it always drilled presente. Mirrors
+  // FormFilterService.applyLevelFilter, which chooseNext already applies downstream.
+  const blockCombos = settings.currentBlock?.combos
+  if (Array.isArray(blockCombos) && blockCombos.length) {
+    const allowed = new Set(blockCombos.map(c => `${c.mood}|${c.tense}`))
+    return allowed.has(`${form.mood}|${form.tense}`)
+  }
+
   const userLevel = settings.level || 'A1'
   if (userLevel === 'ALL') return true
   const allowed = getAllowedCombosForLevelCached(userLevel)

--- a/src/hooks/modules/DrillFormFilters.test.js
+++ b/src/hooks/modules/DrillFormFilters.test.js
@@ -278,3 +278,45 @@ describe('DrillFormFilters - filtering diagnostics', () => {
     })
   })
 })
+
+describe('DrillFormFilters - progress micro-drill blocks (currentBlock.combos)', () => {
+  // Regression for the "Practicar esto always drills presente regular" bug that
+  // PR #205 only half-fixed. #205 taught the generator's own cache (chooseNext) to
+  // honor the ad-hoc block, but this pre-filter — which builds the eligible pool the
+  // SRS "due" shortcut samples directly — still ignored the block, so the shortcut
+  // kept serving due presente items during a targeted micro-drill.
+  const forms = [
+    { lemma: 'hablar', mood: 'indicative', tense: 'pres', person: '1s', value: 'hablo' },
+    { lemma: 'comer', mood: 'indicative', tense: 'pres', person: '3s', value: 'come' },
+    { lemma: 'hablar', mood: 'indicative', tense: 'impf', person: '1s', value: 'hablaba' },
+    { lemma: 'comer', mood: 'subjunctive', tense: 'subjPres', person: '1s', value: 'coma' }
+  ]
+  const baseSettings = {
+    region: 'la_general',
+    verbType: 'all',
+    selectedFamily: null,
+    practiceMode: 'mixed',
+    practicePronoun: 'all',
+    level: 'B1'
+  }
+
+  it('narrows the eligible pool to the block combos in mixed mode', () => {
+    const settings = {
+      ...baseSettings,
+      currentBlock: { combos: [{ mood: 'indicative', tense: 'impf' }], itemsRemaining: 8 }
+    }
+
+    const { filtered } = getFilteringDiagnostics(forms, settings)
+
+    expect(filtered.length).toBeGreaterThan(0)
+    expect(filtered.every(f => f.mood === 'indicative' && f.tense === 'impf')).toBe(true)
+    expect(filtered.some(f => f.tense === 'pres')).toBe(false)
+  })
+
+  it('does not narrow when there is no block (normal mixed practice)', () => {
+    const { filtered } = getFilteringDiagnostics(forms, { ...baseSettings, currentBlock: null })
+
+    // Present indicative is level-appropriate for B1, so it must survive.
+    expect(filtered.some(f => f.mood === 'indicative' && f.tense === 'pres')).toBe(true)
+  })
+})

--- a/src/hooks/modules/drillCacheKey.js
+++ b/src/hooks/modules/drillCacheKey.js
@@ -23,6 +23,25 @@ export function buildReviewFilterFingerprint(reviewSessionType, reviewSessionFil
   return `${reviewSessionType}|${stableStringify(reviewSessionFilter || {})}`
 }
 
+// Progress-module micro-drills carry an ad-hoc `currentBlock` (`{ combos, cells }`,
+// usually with no id) that narrows the eligible pool to a specific mood/tense set.
+// It MUST be part of the cache key: without it, the pool built for one block — or for
+// plain mixed practice — gets reused for a different block, so "Practicar esto" either
+// keeps serving the previous pool (presente regular) or leaks its own tense into the
+// next session.
+export function buildBlockFingerprint(currentBlock) {
+  if (!currentBlock) return 'no_block'
+  const parts = []
+  if (currentBlock.id) parts.push(`id:${currentBlock.id}`)
+  if (Array.isArray(currentBlock.combos) && currentBlock.combos.length) {
+    parts.push('c:' + currentBlock.combos.map(c => `${c.mood}|${c.tense}`).join(','))
+  }
+  if (Array.isArray(currentBlock.cells) && currentBlock.cells.length) {
+    parts.push('x:' + currentBlock.cells.map(c => `${c.mood}|${c.tense}|${c.person}`).join(','))
+  }
+  return parts.length ? parts.join(';') : 'block'
+}
+
 export function buildEligibleFormsKey(signature, targetSettings, specificConstraints, reviewSessionType, reviewSessionFilter) {
   return [
     signature,
@@ -38,6 +57,7 @@ export function buildEligibleFormsKey(signature, targetSettings, specificConstra
     specificConstraints?.specificMood || '',
     specificConstraints?.specificTense || '',
     specificConstraints?.specificPerson || '',
+    buildBlockFingerprint(targetSettings.currentBlock),
     buildReviewFilterFingerprint(reviewSessionType, reviewSessionFilter)
   ].join('|')
 }

--- a/src/hooks/modules/drillCacheKey.test.js
+++ b/src/hooks/modules/drillCacheKey.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildBlockFingerprint,
   buildEligibleFormsKey,
   buildReviewFilterFingerprint,
   shouldCacheEligibleForms
@@ -32,5 +33,45 @@ describe('drillCacheKey', () => {
   it('disables eligible cache only for regular mode', () => {
     expect(shouldCacheEligibleForms({ verbType: 'regular' })).toBe(false)
     expect(shouldCacheEligibleForms({ verbType: 'all' })).toBe(true)
+  })
+
+  // Regression for the progress micro-drill leak: the eligible pool is narrowed by
+  // currentBlock, so the block MUST be part of the cache key or a pool built for one
+  // block (or for plain mixed practice) gets reused for another.
+  it('changes eligible key when the currentBlock combos change', () => {
+    const settings = {
+      practiceMode: 'mixed',
+      level: 'B1',
+      verbType: 'all',
+      selectedFamily: null,
+      practicePronoun: 'all',
+      useVoseo: false,
+      useVosotros: false,
+      irregularityFilterMode: 'tense'
+    }
+    const specific = { isSpecific: false }
+
+    const noBlock = buildEligibleFormsKey('pool-a', settings, specific, 'due', {})
+    const impfBlock = buildEligibleFormsKey(
+      'pool-a',
+      { ...settings, currentBlock: { combos: [{ mood: 'indicative', tense: 'impf' }] } },
+      specific, 'due', {}
+    )
+    const subjBlock = buildEligibleFormsKey(
+      'pool-a',
+      { ...settings, currentBlock: { combos: [{ mood: 'subjunctive', tense: 'subjPres' }] } },
+      specific, 'due', {}
+    )
+
+    expect(noBlock).not.toBe(impfBlock)
+    expect(impfBlock).not.toBe(subjBlock)
+  })
+
+  it('fingerprints blocks by their targeting, not identity', () => {
+    expect(buildBlockFingerprint(null)).toBe('no_block')
+    expect(buildBlockFingerprint({ combos: [{ mood: 'indicative', tense: 'impf' }] }))
+      .toBe('c:indicative|impf')
+    expect(buildBlockFingerprint({ cells: [{ mood: 'subjunctive', tense: 'subjPres', person: '1s' }] }))
+      .toBe('x:subjunctive|subjPres|1s')
   })
 })


### PR DESCRIPTION
## Por qué el PR #205 no arregló nada

El #205 enseñó a la caché interna del generador (`chooseNext`) a respetar el `currentBlock` que arma "Practicar esto". Pero el drill tiene **una segunda ruta de filtrado paralela** que el #205 nunca tocó, así que el bug seguía reproduciéndose.

`useDrillGenerator` construye su propio pool elegible con `getFilteringDiagnostics` → `allowsLevel`, y **`allowsLevel` ignoraba por completo `currentBlock.combos`** — solo filtraba por nivel CEFR. Entonces el pool nunca se restringía al modo/tiempo del bloque. Ese pool alimenta el atajo SRS de "vencidos" en `hierarchicalSelection` (PATH B, ~35% de los ítems), que lo samplea directo, salteándose `chooseNext`. Para justo los usuarios que llegan a "Practicar esto" (tienen historial y ítems vencidos, en su mayoría presente), ese atajo seguía sirviendo presente durante un micro-drill dirigido — el síntoma "siempre presente", todavía presente después del #205.

## Cambios

Dos correcciones, replicando lo que hizo el #205 pero una capa más adentro:

- **`allowsLevel`** (`DrillFormFilters.js`) ahora respeta `currentBlock.combos` en modo `mixed`, igual que `FormFilterService.applyLevelFilter`. El pool elegible se restringe al bloque, así el atajo SRS solo puede elegir ítems vencidos que coincidan con el bloque y, si no, cae a `chooseNext`.
- **`buildEligibleFormsKey`** (`drillCacheKey.js`) ahora firma el bloque (combos + cells) para que el pool restringido no se cachee y se reutilice entre bloques distintos o en práctica mixta normal.

## Tests

- `DrillFormFilters.test.js`: el pre-filtro restringe el pool a los combos del bloque en modo mixed, y no restringe cuando no hay bloque.
- `drillCacheKey.test.js`: la clave de caché cambia por bloque, y `buildBlockFingerprint` firma por targeting (combos/cells), no por identidad.

Suites relacionadas (`src/hooks/modules/`, `src/lib/core/generator*`) pasan, incluido el test de regresión del #205. Lint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRm5UV6NTRG8sA7jE72wej)_