### PR TITLE
Fix all ESLint no-unused-vars warnings

### DIFF
--- a/src/components/auth/AuthModal.jsx
+++ b/src/components/auth/AuthModal.jsx
@@ -84,7 +84,7 @@ export default function AuthModal({ isOpen, onClose, onSuccess }) {
         setError('Google OAuth no está disponible. Probá con email y contraseña.')
         setLoading(false)
       }
-    } catch (err) {
+    } catch {
       setError('Error con Google OAuth. Probá con email y contraseña.')
       setLoading(false)
     }

--- a/src/components/drill/PronunciationPanelSafe.test.jsx
+++ b/src/components/drill/PronunciationPanelSafe.test.jsx
@@ -232,7 +232,7 @@ describe('PronunciationPanelSafe', () => {
           configurable: true,
           writable: true
         });
-      } catch (error) {
+      } catch {
         import.meta.env[key] = value;
       }
     };

--- a/src/components/learning/DurationSelectionStep.jsx
+++ b/src/components/learning/DurationSelectionStep.jsx
@@ -7,7 +7,6 @@ function DurationSelectionStep({
   onSelectDuration,
   onStart,
   onBack,
-  onHome,
   durationOptions = getDefaultDurationOptions()
 }) {
   const options = useMemo(() =>

--- a/src/components/learning/LearningDrill.jsx
+++ b/src/components/learning/LearningDrill.jsx
@@ -222,7 +222,6 @@ function LearningDrillContent({ tense, verbType, selectedFamilies, duration, exc
     } else {
       // Old format (backward compatibility) - first arg is isCorrect
       const isCorrect = result;
-      const accuracy = arguments[1];
       const extra = arguments[2] || {};
 
       trackingResult = {

--- a/src/components/learning/NarrativeIntroduction.jsx
+++ b/src/components/learning/NarrativeIntroduction.jsx
@@ -346,8 +346,6 @@ function renderThirdPersonIrregularDeconstruction(exampleVerbs, settings) {
           })
           .map((verbObj, index) => {
             const verb = verbObj.lemma;
-            const group = verb.endsWith('ar') ? '-ar' : verb.endsWith('er') ? '-er' : '-ir';
-            const highlightData = highlightStemVowel(verb);
 
             return (
               <div key={`third-${index}`} className="third-person-verb-item">
@@ -508,7 +506,6 @@ function renderRegularFutureConditionalDeconstruction(exampleVerbs, tense, setti
           })
           .map((verbObj, index) => {
             const verb = verbObj.lemma
-            const group = verb.endsWith('ar') ? '-ar' : verb.endsWith('er') ? '-er' : '-ir'
 
             return (
               <div key={`regular-verb-${index}`} className="future-root-item">
@@ -564,7 +561,7 @@ function renderNonFiniteIrregularDeconstruction(exampleVerbs, tense) {
   )
 }
 
-function renderRegularNonFiniteDeconstruction(exampleVerbs, tense, settings) {
+function renderRegularNonFiniteDeconstruction(exampleVerbs, tense, _settings) {
   if (!tense || !['ger', 'part'].includes(tense.tense)) {
     return null
   }
@@ -600,7 +597,6 @@ function renderRegularNonFiniteDeconstruction(exampleVerbs, tense, settings) {
           })
           .map((verbObj, index) => {
             const verb = verbObj.lemma
-            const group = verb.endsWith('ar') ? '-ar' : verb.endsWith('er') ? '-er' : '-ir'
             const stem = verb.slice(0, -2)
             const ending = getRegularEnding(verb)
 
@@ -753,7 +749,6 @@ function renderIrregularYoDeconstruction(exampleVerbs, tense, settings) {
             const verb = verbObj.lemma;
             const group = verb.endsWith('ar') ? '-ar' : verb.endsWith('er') ? '-er' : '-ir';
             const forms = getDialectForms(verbObj);
-            const highlightData = highlightStemVowel(verb);
 
             // Obtener la forma YO conjugada para destacarla
             const yoForm = forms[0]; // Primera forma es siempre 1s
@@ -833,7 +828,6 @@ function renderStrongPreteriteDeconstruction(exampleVerbs, settings) {
           })
           .map((verbObj, index) => {
             const verb = verbObj.lemma;
-            const group = verb.endsWith('ar') ? '-ar' : verb.endsWith('er') ? '-er' : '-ir';
             const irregularStem = getIrregularStem(verb);
 
             return (

--- a/src/components/learning/TypeSelectionStep.jsx
+++ b/src/components/learning/TypeSelectionStep.jsx
@@ -94,7 +94,7 @@ const buildIrregularCategories = (tenseKey, availableFamilies) => {
   return categories
 }
 
-function TypeSelectionStep({ selectedTense, availableFamilies = [], onSelectType, onBack, onHome }) {
+function TypeSelectionStep({ selectedTense, availableFamilies = [], onSelectType, onBack }) {
   const tenseKey = selectedTense?.tense
 
   const irregularCategories = useMemo(

--- a/src/components/onboarding/OnboardingFlow.jsx
+++ b/src/components/onboarding/OnboardingFlow.jsx
@@ -378,7 +378,7 @@ function buildStep(step, settings, handlers) {
     selectDialect, selectLevel, selectPracticeMode, selectMood, selectTense,
     selectVerbType, selectFamily, goToLevelDetails, onStartPractice,
     onGoToProgress, onStartLearningNewTense, onStartLevelTest,
-    getAvailableMoodsForLevel, getAvailableTensesForLevelAndMood,
+    getAvailableTensesForLevelAndMood,
     themeSubMenu, setThemeSubMenu
   } = handlers
 

--- a/src/features/drill/AdaptiveDifficultyIndicator.jsx
+++ b/src/features/drill/AdaptiveDifficultyIndicator.jsx
@@ -35,7 +35,7 @@ export default function AdaptiveDifficultyIndicator({ compact = false }) {
       const stats = engine.getSessionStats()
       setFlowState(stats.flowState)
       setDifficultyBoost(stats.currentBoost)
-    } catch (error) {
+    } catch {
       // Engine not available, use defaults
     }
 

--- a/src/features/drill/SessionProgressHUD.jsx
+++ b/src/features/drill/SessionProgressHUD.jsx
@@ -69,12 +69,12 @@ export default function SessionProgressHUD() {
     updateProgress()
 
     // Escuchar eventos de progreso de sesión
-    const handleSessionUpdate = (event) => {
+    const handleSessionUpdate = (_event) => {
       updateProgress()
     }
 
     // Escuchar eventos de plan
-    const handlePlanUpdate = (event) => {
+    const handlePlanUpdate = (_event) => {
       updateProgress()
     }
 

--- a/src/features/progress/ExpertModePanel.jsx
+++ b/src/features/progress/ExpertModePanel.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import { toggleExpertMode, setExpertModeSettings } from '../../lib/progress/expertMode.js'
+import { setExpertModeSettings } from '../../lib/progress/expertMode.js'
 import './expert-mode-panel.css'
 import { createLogger } from '../../lib/utils/logger.js'
 

--- a/src/features/progress/ProgressDashboard.smoke.test.jsx
+++ b/src/features/progress/ProgressDashboard.smoke.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 
 const useProgressDashboardDataMock = vi.fn()

--- a/src/hooks/modules/hierarchicalSelection.js
+++ b/src/hooks/modules/hierarchicalSelection.js
@@ -43,7 +43,6 @@ export const selectNextForm = async ({
   // Determine if the user is in an explicit review session vs general practice
   const isExplicitReview = settings.practiceMode === 'review'
   const isSpecificPractice = settings.practiceMode === 'specific' || settings.practiceMode === 'theme'
-  const isGeneralPractice = !isExplicitReview && !isSpecificPractice
 
   // ─── PATH A: Explicit review or specific practice ───
   // Use the traditional hierarchy: SRS → adaptive → chooseNext

--- a/src/lib/core/AutoRecoverySystem.js
+++ b/src/lib/core/AutoRecoverySystem.js
@@ -225,7 +225,7 @@ class AutoRecoverySystem {
   /**
    * Determine appropriate recovery strategy
    */
-  determineRecoveryStrategy(classification, context) {
+  determineRecoveryStrategy(classification, _context) {
     const { category, severity, suggestedStrategy } = classification
 
     // Check if we've tried this strategy recently
@@ -322,7 +322,7 @@ class AutoRecoverySystem {
   /**
    * Execute emergency recovery as last resort
    */
-  async executeEmergencyRecovery(error, context) {
+  async executeEmergencyRecovery(error, _context) {
     logger.error('executeEmergencyRecovery', '🚨 EMERGENCY RECOVERY ACTIVATED', { error: error.message })
 
     this.emergencyModeActive = true
@@ -375,7 +375,7 @@ class AutoRecoverySystem {
    */
   setupErrorClassifiers() {
     // Data corruption classifier
-    this.addErrorClassifier('data_corruption', (error, context) => {
+    this.addErrorClassifier('data_corruption', (error, _context) => {
       const patterns = ['corrupt', 'invalid', 'malformed', 'checksum', 'integrity']
       const isDataError = patterns.some(pattern =>
         error.message.toLowerCase().includes(pattern)
@@ -433,7 +433,7 @@ class AutoRecoverySystem {
     })
 
     // Network failure classifier
-    this.addErrorClassifier('network_failure', (error, context) => {
+    this.addErrorClassifier('network_failure', (error, _context) => {
       const patterns = ['network', 'fetch', 'connection', 'timeout', 'offline']
       const isNetworkError = patterns.some(pattern =>
         error.message.toLowerCase().includes(pattern)
@@ -501,7 +501,7 @@ class AutoRecoverySystem {
     })
 
     // Fallback data strategy
-    this.addRecoveryStrategy(RECOVERY_STRATEGIES.FALLBACK_DATA, async (error, context) => {
+    this.addRecoveryStrategy(RECOVERY_STRATEGIES.FALLBACK_DATA, async (_error, _context) => {
       try {
         logger.info('recovery:fallback_data', 'Activating fallback data sources')
 
@@ -521,7 +521,7 @@ class AutoRecoverySystem {
     })
 
     // Cache rebuild strategy
-    this.addRecoveryStrategy(RECOVERY_STRATEGIES.CACHE_REBUILD, async (error, context) => {
+    this.addRecoveryStrategy(RECOVERY_STRATEGIES.CACHE_REBUILD, async (_error, _context) => {
       try {
         logger.info('recovery:cache_rebuild', 'Rebuilding caches')
 
@@ -540,7 +540,7 @@ class AutoRecoverySystem {
     })
 
     // Memory cleanup strategy
-    this.addRecoveryStrategy(RECOVERY_STRATEGIES.MEMORY_CLEANUP, async (error, context) => {
+    this.addRecoveryStrategy(RECOVERY_STRATEGIES.MEMORY_CLEANUP, async (_error, _context) => {
       try {
         logger.info('recovery:memory_cleanup', 'Performing memory cleanup')
 
@@ -559,7 +559,7 @@ class AutoRecoverySystem {
     })
 
     // Graceful degradation strategy
-    this.addRecoveryStrategy(RECOVERY_STRATEGIES.GRACEFUL_DEGRADATION, async (error, context) => {
+    this.addRecoveryStrategy(RECOVERY_STRATEGIES.GRACEFUL_DEGRADATION, async (_error, _context) => {
       try {
         logger.warn('recovery:graceful_degradation', 'Activating graceful degradation')
 
@@ -576,7 +576,7 @@ class AutoRecoverySystem {
     })
 
     // Emergency mode strategy
-    this.addRecoveryStrategy(RECOVERY_STRATEGIES.EMERGENCY_MODE, async (error, context) => {
+    this.addRecoveryStrategy(RECOVERY_STRATEGIES.EMERGENCY_MODE, async (_error, _context) => {
       try {
         logger.error('recovery:emergency_mode', '🚨 Activating emergency mode')
 
@@ -805,7 +805,7 @@ class AutoRecoverySystem {
     this.metrics.lastError = new Date()
   }
 
-  updateRecoveryMetrics(startTime, success) {
+  updateRecoveryMetrics(startTime, _success) {
     const recoveryTime = performance.now() - startTime
 
     // Update average recovery time
@@ -848,7 +848,7 @@ class AutoRecoverySystem {
     this.recoveryAttempts.set(strategy, count + 1)
   }
 
-  escalateStrategy(currentStrategy, severity) {
+  escalateStrategy(currentStrategy, _severity) {
     const escalationMap = {
       [RECOVERY_STRATEGIES.RESTART_COMPONENT]: RECOVERY_STRATEGIES.CACHE_REBUILD,
       [RECOVERY_STRATEGIES.CACHE_REBUILD]: RECOVERY_STRATEGIES.FALLBACK_DATA,

--- a/src/lib/core/CacheOrchestrator.js
+++ b/src/lib/core/CacheOrchestrator.js
@@ -339,7 +339,7 @@ class CacheOrchestrator {
   /**
    * Trigger intelligent preloading based on patterns
    */
-  async triggerIntelligentPreloading(triggerKey, cacheType) {
+  async triggerIntelligentPreloading(triggerKey, _cacheType) {
     if (this.isPreloading || this.strategy === COORDINATION_STRATEGIES.CONSERVATIVE) {
       return
     }
@@ -528,7 +528,7 @@ class CacheOrchestrator {
   /**
    * Take corrective actions based on health status
    */
-  async takeCorrectiveActions(health, healthReport) {
+  async takeCorrectiveActions(health, _healthReport) {
     logger.info('takeCorrectiveActions', `Taking corrective actions for health: ${health}`)
 
     try {
@@ -556,7 +556,7 @@ class CacheOrchestrator {
           this.isPreloading = false
 
           // Disable all non-essential caches
-          for (const [cacheType, cacheInfo] of this.cacheRegistry) {
+          for (const [, cacheInfo] of this.cacheRegistry) {
             if (cacheInfo.level !== CACHE_LEVELS.L1_MEMORY) {
               cacheInfo.isHealthy = false
             }
@@ -705,7 +705,7 @@ class CacheOrchestrator {
       this.performanceMetrics.averageResponseTime * (1 - alpha) + responseTime * alpha
   }
 
-  recordCacheError(cacheType, error) {
+  recordCacheError(cacheType, _error) {
     const cacheInfo = this.cacheRegistry.get(cacheType)
     if (cacheInfo) {
       cacheInfo.errorCount++

--- a/src/lib/core/EmergencyFallback.js
+++ b/src/lib/core/EmergencyFallback.js
@@ -37,7 +37,7 @@ export class EmergencyFallback {
    * @returns {Object|null} Fallback form or null
    */
   async findFallback(allForms, preferences = {}) {
-    const { specificMood, specificTense, level, verbType, practiceMode } = preferences
+    const { specificMood, specificTense, level } = preferences
 
     logger.info('findFallback', 'Attempting emergency fallback', {
       mood: specificMood,

--- a/src/lib/core/FormFilterService.js
+++ b/src/lib/core/FormFilterService.js
@@ -20,9 +20,7 @@ import {
   isRegularNonfiniteForm
 } from './conjugationRules.js'
 import { gateFormsByCurriculumAndDialect, getAllowedCombosForLevel } from './curriculumGate.js'
-import { createLogger } from '../utils/logger.js'
 
-const logger = createLogger('core:FormFilterService')
 
 /**
  * Filter forms based on comprehensive user settings
@@ -35,7 +33,6 @@ const logger = createLogger('core:FormFilterService')
 export function filterEligibleForms(forms, settings, context = {}) {
   const {
     level,
-    region,
     practiceMode,
     specificMood,
     specificTense,
@@ -300,7 +297,7 @@ function applyLemmaRestrictions(form, options) {
 /**
  * Apply verb type filtering (regular/irregular)
  */
-function applyVerbTypeFilter(form, verb, {verbType, verbLookupMap}) {
+function applyVerbTypeFilter(form, verb, {verbType}) {
   const isMixedPractice = !verbType || verbType === 'mixed' || verbType === 'all'
 
   if (isMixedPractice) {

--- a/src/lib/core/FormSelector.js
+++ b/src/lib/core/FormSelector.js
@@ -220,13 +220,12 @@ export class FormSelector {
       })
 
       // Advance index only one position from the actually used index
-      const nextIdx = (usedIdx + 1) % seq.length
       // Note: This would need to update the global state, which should be handled by the caller
 
       // Select from boosted pool
       const idx = Math.floor(Math.random() * boosted.length)
       return boosted[idx]
-    } catch (error) {
+    } catch {
       // Fallback to simple random
       const idx = Math.floor(Math.random() * forms.length)
       return forms[idx]

--- a/src/lib/core/FormSelectorService.js
+++ b/src/lib/core/FormSelectorService.js
@@ -39,7 +39,7 @@ const dbg = (...args) => { if (isDev && !import.meta?.env?.VITEST) logger.debug(
  * @param {Object} context - Additional context (verbLookupMap, etc.)
  * @returns {Promise<Object>} Selected form with all transformations applied
  */
-export async function selectForm(eligible, settings, context = {}) {
+export async function selectForm(eligible, settings, _context = {}) {
   // Early return for empty eligible pool
   if (!eligible || eligible.length === 0) {
     return null
@@ -133,12 +133,6 @@ export async function selectForm(eligible, settings, context = {}) {
   // ENHANCED: Strong preference for PURE regular lemmas when user selects 'regular'
   if (verbType === 'regular') {
     try {
-      const pureRegularSet = new Set(
-        Array.from(VERB_LOOKUP_MAP.values())
-          .filter(v => v?.type === 'regular')
-          .map(v => v.lemma)
-      )
-
       const isCompound = (t) => (t === 'pretPerf' || t === 'plusc' || t === 'futPerf' || t === 'condPerf' || t === 'subjPerf' || t === 'subjPlusc')
 
       // Keep only pure regular lemmas and forms that are morphologically regular

--- a/src/lib/core/FormSelectorService.test.js
+++ b/src/lib/core/FormSelectorService.test.js
@@ -4,7 +4,7 @@
  * Comprehensive test suite to ensure functional equivalence with the original generator.js selection logic
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { selectForm } from './FormSelectorService.js'
 
 describe('FormSelectorService', () => {

--- a/src/lib/core/VerbDataRedundancyManager.js
+++ b/src/lib/core/VerbDataRedundancyManager.js
@@ -137,7 +137,7 @@ class VerbDataRedundancyManager {
     // Safe logging - avoid TDZ during module initialization
     try {
       logger?.info?.('initialize', 'Starting VerbDataRedundancyManager initialization')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
 
@@ -155,7 +155,7 @@ class VerbDataRedundancyManager {
           healthState: this.healthState,
           verbCount: this.getVerbCount()
         })
-      } catch (e) {
+      } catch {
         // Logger not ready yet
       }
 
@@ -163,7 +163,7 @@ class VerbDataRedundancyManager {
       // Safe logging - avoid TDZ during module initialization
       try {
         logger?.error?.('initialize', 'Failed to initialize VerbDataRedundancyManager', error)
-      } catch (e) {
+      } catch {
         // Logger not ready yet
       }
       await this.handleInitializationFailure(error)
@@ -684,7 +684,7 @@ class VerbDataRedundancyManager {
     try {
       const verbs = this.dataCache.get(this.currentLayer)
       return verbs ? verbs.length : 0
-    } catch (error) {
+    } catch {
       return 0
     }
   }

--- a/src/lib/core/generator.js
+++ b/src/lib/core/generator.js
@@ -86,10 +86,8 @@ export async function chooseNext({ forms, history: _history, currentItem, sessio
   const {
     level: rawLevel, useVoseo, useTuteo, useVosotros,
     practiceMode: rawPracticeMode, specificMood, specificTense, practicePronoun, verbType: rawVerbType,
-    currentBlock, selectedFamily, region: rawRegion, enableFuturoSubjProd, allowedLemmas,
+    currentBlock, selectedFamily, region: rawRegion, allowedLemmas,
     cameFromTema,
-    enableC2Conmutacion, conmutacionSeq, conmutacionIdx, rotateSecondPerson,
-    nextSecondPerson, cliticsPercent, enableProgressIntegration,
     userLevel, levelPracticeMode
   } = allSettings
 
@@ -262,7 +260,6 @@ export function validateMoodTenseAvailability(mood, tense, settings, allForms) {
     const level = settings.level || 'B1'
     const region = settings.region || 'rioplatense'
     const useVoseo = settings.useVoseo !== false
-    const useTuteo = settings.useTuteo !== false
     const useVosotros = settings.useVosotros !== false
 
 

--- a/src/lib/core/optimizedCache.js
+++ b/src/lib/core/optimizedCache.js
@@ -512,7 +512,7 @@ if (typeof window !== 'undefined') {
           if (orchestrator.registerIntelligentCaches) {
             orchestrator.registerIntelligentCaches()
           }
-        } catch (error) {
+        } catch {
           // Ignore if orchestrator isn't available yet
           logger.debug('auto-init', 'CacheOrchestrator not available yet for registration')
         }
@@ -527,7 +527,7 @@ if (typeof window !== 'undefined') {
             try {
               const { getRedundancyStats } = await import('./VerbDataRedundancyManager.js')
               return typeof getRedundancyStats === 'function' ? getRedundancyStats() : { error: 'RedundancyManager not available' }
-            } catch (error) {
+            } catch {
               return { error: 'RedundancyManager not available' }
             }
           },
@@ -535,7 +535,7 @@ if (typeof window !== 'undefined') {
             try {
               const { getIntegrityStats } = await import('./DataIntegrityGuard.js')
               return typeof getIntegrityStats === 'function' ? getIntegrityStats() : { error: 'IntegrityGuard not available' }
-            } catch (error) {
+            } catch {
               return { error: 'IntegrityGuard not available' }
             }
           }

--- a/src/lib/core/prioritizer/index.js
+++ b/src/lib/core/prioritizer/index.js
@@ -11,7 +11,6 @@
  * - ✅ Clean orchestration pattern
  */
 
-import curriculum from '../../../data/curriculum.json'
 import { createLogger } from '../../utils/logger.js'
 import { LEVEL_PRIORITY_WEIGHTS } from './constants.js'
 import { CurriculumProcessor } from './CurriculumProcessor.js'
@@ -159,7 +158,6 @@ export class LevelDrivenPrioritizer {
   getWeightedSelection(forms, level, userProgress = null) {
     if (!forms || forms.length === 0) return []
 
-    const masteryMap = this.assessor.createMasteryMap(userProgress)
     const adjusted = this.calculator.applyAdvancedProgressAdjustments(
       forms.map(form => ({
         ...form,

--- a/src/lib/core/verbDataService.js
+++ b/src/lib/core/verbDataService.js
@@ -9,7 +9,7 @@ import { expandSimplifiedGroup } from '../data/simplifiedFamilyGroups.js'
 import { convertLearningFamilyToOld, LEARNING_IRREGULAR_FAMILIES } from '../data/learningIrregularFamilies.js'
 import { gateFormsByCurriculumAndDialect } from './curriculumGate.js'
 import { getAllVerbsWithRedundancy } from './VerbDataRedundancyManager.js'
-import { validateAndHealVerbs, getIntegrityGuard } from './DataIntegrityGuard.js'
+import { getIntegrityGuard } from './DataIntegrityGuard.js'
 import { handleErrorWithRecovery } from './AutoRecoverySystem.js'
 import { createLogger } from '../utils/logger.js'
 
@@ -221,7 +221,7 @@ export async function getVerbsByLemmas(lemmas) {
     const lemmaSet = new Set(lemmas)
 
     // Filter efficiently
-    const foundVerbs = allVerbs.filter(verb => {
+    allVerbs.filter(verb => {
       if (lemmaSet.has(verb.lemma)) {
         results.push(verb)
         return true
@@ -299,7 +299,7 @@ export async function getVerbsByLemmas(lemmas) {
 }
 
 // Enhanced build forms for a specific region with comprehensive error handling
-export async function getFormsForRegion(region, settings = {}) {
+export async function getFormsForRegion(region, _settings = {}) {
   if (!region || typeof region !== 'string') {
     logger.warn('getFormsForRegion', 'Invalid region parameter', { region })
     return []
@@ -476,7 +476,7 @@ export async function getFormsForRegion(region, settings = {}) {
 }
 
 // Enhanced get example verbs for learning with comprehensive error handling
-export function getExampleVerbs({ verbType = 'all', families = [], tense = null, region = 'la_general' } = {}) {
+export function getExampleVerbs({ verbType = 'all', families = [], tense: _tense = null, region: _region = 'la_general' } = {}) {
   try {
     // Get verbs with fallback protection
     let candidateVerbs = getAllVerbsSync()
@@ -516,7 +516,7 @@ export function getExampleVerbs({ verbType = 'all', families = [], tense = null,
         candidateVerbs = candidateVerbs.filter(verb => {
           try {
             return verb.type === 'regular' || !verb.type
-          } catch (error) {
+          } catch {
             errorCount++
             return false
           }
@@ -525,7 +525,7 @@ export function getExampleVerbs({ verbType = 'all', families = [], tense = null,
         candidateVerbs = candidateVerbs.filter(verb => {
           try {
             return verb.type === 'irregular'
-          } catch (error) {
+          } catch {
             errorCount++
             return false
           }

--- a/src/lib/learning/SpeechRecognitionManager.js
+++ b/src/lib/learning/SpeechRecognitionManager.js
@@ -303,7 +303,7 @@ export class SpeechRecognitionManager {
         result.microphone = true
         // Stop the stream immediately
         stream.getTracks().forEach(track => track.stop())
-      } catch (error) {
+      } catch {
         result.microphone = false
         result.recommendations.push('Permite el acceso al micrófono en la configuración del navegador')
       }

--- a/src/lib/learning/conversationGrader.js
+++ b/src/lib/learning/conversationGrader.js
@@ -1,10 +1,6 @@
 // Conversation Grader - Evaluates user responses in conversations
 // Uses fuzzy matching and linguistic analysis for natural dialog validation
 
-import { createLogger } from '../utils/logger.js'
-
-const logger = createLogger('learning:conversationGrader')
-
 /**
  * Calculate Levenshtein distance between two strings
  */

--- a/src/lib/levels/DynamicLevelEvaluator.js
+++ b/src/lib/levels/DynamicLevelEvaluator.js
@@ -360,7 +360,7 @@ export class DynamicLevelEvaluator {
   /**
    * Genera recomendaciones específicas para el usuario
    */
-  async generateRecommendations(evaluation, currentLevel) {
+  async generateRecommendations(evaluation, _currentLevel) {
     const recommendations = []
     const { accuracy, coverage, consistency, responseTime } = evaluation.evaluation
 

--- a/src/lib/levels/LevelRecommendationEngine.js
+++ b/src/lib/levels/LevelRecommendationEngine.js
@@ -177,7 +177,7 @@ export class LevelRecommendationEngine {
   /**
    * Genera recomendaciones para cerrar brechas en competencias
    */
-  async generateCompetencyGapRecommendations(progress, evaluation) {
+  async generateCompetencyGapRecommendations(progress, _evaluation) {
     const recommendations = []
 
     if (!progress || !progress.details) return recommendations
@@ -212,7 +212,7 @@ export class LevelRecommendationEngine {
     })
 
     // Recomendaciones para áreas más débiles
-    weakestAreas.slice(0, 2).forEach((area, index) => {
+    weakestAreas.slice(0, 2).forEach((area, _index) => {
       if (area.needsWork) {
         recommendations.push({
           id: `weak-area-${area.mood}-${area.tense}`,
@@ -321,7 +321,7 @@ export class LevelRecommendationEngine {
   /**
    * Genera recomendaciones motivacionales
    */
-  async generateMotivationalRecommendations(profile, progress, evaluation) {
+  async generateMotivationalRecommendations(profile, progress, _evaluation) {
     const recommendations = []
 
     // Celebrar fortalezas

--- a/src/lib/levels/levelAssessment.js
+++ b/src/lib/levels/levelAssessment.js
@@ -2,7 +2,6 @@
 // Implements a "Binary Search" style adaptive algorithm for efficient placement
 // CEFR Levels: A1, A2, B1, B2, C1, C2
 
-import { getCurrentUserProfile, setGlobalPlacementTestBaseline } from './userLevelProfile.js'
 import { createLogger } from '../utils/logger.js'
 
 const logger = createLogger('levelAssessment')

--- a/src/lib/progress/AdaptiveDifficultyEngine.js
+++ b/src/lib/progress/AdaptiveDifficultyEngine.js
@@ -210,7 +210,7 @@ export class AdaptiveDifficultyEngine {
    * Genera recomendaciones para el generator
    * @returns {Object} Configuración para generator.js
    */
-  generateRecommendations(flowAnalysis) {
+  generateRecommendations(_flowAnalysis) {
     const boost = this.currentDifficultyBoost
 
     const recommendations = {

--- a/src/lib/progress/SyncMutex.test.js
+++ b/src/lib/progress/SyncMutex.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { SyncMutex, withMutex, globalMutex } from './SyncMutex.js'
 
 describe('SyncMutex', () => {

--- a/src/lib/progress/abTesting.js
+++ b/src/lib/progress/abTesting.js
@@ -49,7 +49,7 @@ export class ABTestingManager {
     // Safe logging - avoid TDZ during module initialization
     try {
       logger?.systemInit?.('A/B Testing Manager initialized')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
   }
@@ -581,7 +581,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('A/B Testing Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/progress/analytics.js
+++ b/src/lib/progress/analytics.js
@@ -399,7 +399,7 @@ export async function getPronunciationStats(userId, signal) {
     const recentAttempts = attemptsWithMetadata
       .sort((a, b) => (b.createdAtMs || 0) - (a.createdAtMs || 0))
       .slice(0, 8)
-      .map(({ createdAtMs, ...rest }) => rest)
+      .map(({ createdAtMs: _createdAtMs, ...rest }) => rest)
 
     const toAverage = (sum, count) => (count > 0 ? Math.round((sum / count) * 10) / 10 : 0)
     const successRate = Math.round((correctCount / pronunciationAttempts.length) * 100)
@@ -789,7 +789,6 @@ export async function getAdvancedAnalytics(userId, signal) {
   const config = PROGRESS_CONFIG.ADVANCED_ANALYTICS_CONFIG || {}
   const retentionWindow = config.RETENTION_WINDOW_DAYS || 30
   const engagementWindow = config.ENGAGEMENT_WINDOW_DAYS || 14
-  const dayMs = 24 * 60 * 60 * 1000
 
   try {
     ensureNotCancelled(signal)

--- a/src/lib/progress/confidenceEngine.js
+++ b/src/lib/progress/confidenceEngine.js
@@ -744,7 +744,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Confidence Engine Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/progress/database.range.test.js
+++ b/src/lib/progress/database.range.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getByIndexRange, getAttemptsByUser, saveAttempt } from './database.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getByIndexRange, saveAttempt } from './database.js';
 
 // Mock dependencies
 const mockOpenDB = vi.fn();

--- a/src/lib/progress/database.schedules.test.js
+++ b/src/lib/progress/database.schedules.test.js
@@ -18,7 +18,7 @@ describe('schedules index and queries', () => {
   beforeEach(async () => {
     try {
       await deleteDB()
-    } catch (error) {
+    } catch {
       // Ignorar errores cuando la DB aún no existe
     }
     await initDB()

--- a/src/lib/progress/dynamicGoals.js
+++ b/src/lib/progress/dynamicGoals.js
@@ -1028,7 +1028,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Dynamic Goals Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/progress/dynamicRecommendations.js
+++ b/src/lib/progress/dynamicRecommendations.js
@@ -131,10 +131,8 @@ function getDayOfWeek() {
 function buildRecommendation(context) {
   const {
     stats,
-    timePattern,
     weekPattern,
     flowMetrics,
-    flowRecommendations,
     dueItems,
     masteryData,
     currentTime
@@ -281,7 +279,7 @@ function generateActivities(mode, duration, masteryData, dueItems) {
           .sort((a, b) => a.score - b.score)
           .slice(0, 3)
 
-        weakAreas.forEach((area, index) => {
+        weakAreas.forEach((area, _index) => {
           activities.push({
             type: 'focused_practice',
             title: `Refuerza ${area.tense}`,

--- a/src/lib/progress/flowStateDetection.js
+++ b/src/lib/progress/flowStateDetection.js
@@ -622,7 +622,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Flow Detector Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/progress/fsrs.js
+++ b/src/lib/progress/fsrs.js
@@ -43,7 +43,7 @@ export class IntelligentFSRS {
     // Safe logging - avoid TDZ during module initialization
     try {
       logger?.systemInit?.('Intelligent FSRS initialized')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
   }

--- a/src/lib/progress/learningPathPredictor.js
+++ b/src/lib/progress/learningPathPredictor.js
@@ -40,7 +40,7 @@ export class LearningPathPredictor {
     // Safe logging - avoid TDZ during module initialization
     try {
       logger?.systemInit?.('Predictor de Ruta de Aprendizaje inicializado')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
   }

--- a/src/lib/progress/memoryManager.js
+++ b/src/lib/progress/memoryManager.js
@@ -36,7 +36,7 @@ class MemoryManager {
     // Safe logging - avoid TDZ errors during module initialization
     try {
       logger?.debug?.(`Interval registrado: ${systemName}`, { intervalMs, description })
-    } catch (e) {
+    } catch {
       // Logger not ready yet - silent fail
     }
     return intervalId
@@ -71,7 +71,7 @@ class MemoryManager {
     // Safe logging - avoid TDZ errors during module initialization
     try {
       logger?.debug?.(`Sistema registrado: ${systemName}`)
-    } catch (e) {
+    } catch {
       // Logger not ready yet - silent fail
     }
   }
@@ -140,7 +140,7 @@ class MemoryManager {
     // Safe logging - avoid TDZ errors
     try {
       logger?.info?.('Iniciando cleanup completo de memoria')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
 
@@ -163,14 +163,14 @@ class MemoryManager {
         // Safe logging - avoid TDZ errors
         try {
           logger?.cleanup?.(systemName, 'Sistema limpiado')
-        } catch (e) {
+        } catch {
           // Logger not ready yet
         }
       } catch (error) {
         // Safe logging - avoid TDZ errors
         try {
           logger?.error?.(`Error en cleanup de ${systemName}:`, error)
-        } catch (e) {
+        } catch {
           // Logger not ready yet
         }
       }
@@ -179,7 +179,7 @@ class MemoryManager {
     // Safe logging - avoid TDZ errors
     try {
       logger?.info?.('Cleanup completo de memoria finalizado')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
     this.isCleaningUp = false

--- a/src/lib/progress/mlRecommendations.js
+++ b/src/lib/progress/mlRecommendations.js
@@ -37,7 +37,7 @@ export class MLRecommendationEngine {
     // Safe logging - avoid TDZ during module initialization
     try {
       logger?.systemInit?.('ML Recommendation Engine initialized')
-    } catch (e) {
+    } catch {
       // Logger not ready yet
     }
   }

--- a/src/lib/progress/momentumTracker.js
+++ b/src/lib/progress/momentumTracker.js
@@ -780,7 +780,7 @@ export function initializeMomentumTracking() {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Momentum Tracker')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
   return momentumTracker
@@ -816,7 +816,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Momentum Tracker Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/progress/partialSyncFailure.test.js
+++ b/src/lib/progress/partialSyncFailure.test.js
@@ -52,7 +52,6 @@ describe('Partial Sync Failure Scenarios', () => {
         getCurrentUserId: () => 'user-123'
       }))
 
-	      let attemptsSaved = false
 	      let masterySaved = false
 
 	      vi.doMock('./database.js', () => ({
@@ -86,7 +85,6 @@ describe('Partial Sync Failure Scenarios', () => {
 	          postJSON: vi.fn(async () => ({ data: {} })),
 	          tryBulk: vi.fn(async (collection) => {
 	            if (collection === 'attempts') {
-	              attemptsSaved = true
 	              throw new Error('Network error')
 	            }
 	            if (collection === 'mastery') {

--- a/src/lib/progress/socialSharing.js
+++ b/src/lib/progress/socialSharing.js
@@ -158,7 +158,6 @@ export async function generateShareableImage(stats) {
 
     // Stats display
     const statsY = 380
-    const statsSpacing = 120
     const statsToShow = [
       { icon: '⚡', label: 'XP', value: stats.xp || 0 },
       { icon: '🔥', label: 'Racha', value: stats.streak || 0 },

--- a/src/lib/progress/studyPlans.js
+++ b/src/lib/progress/studyPlans.js
@@ -185,7 +185,6 @@ function convertRecommendationsToExecutableSessions(recommendations, predictedSe
     const remaining = Math.min(3 - sessions.length, predictedSequence.length)
 
     predictedSequence.slice(0, remaining).forEach((combo, index) => {
-      const sessionIndex = sessions.length
       const formattedMoodTense = formatMoodTense(combo.mood, combo.tense)
       sessions.push({
         id: `session-predicted-${Date.now()}-${index}`,

--- a/src/lib/progress/syncConcurrency.test.js
+++ b/src/lib/progress/syncConcurrency.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { syncWithCloud, getSyncStatus, cancelScheduledSync } from './cloudSync.js'
 import { globalMutex } from './SyncMutex.js'
 
@@ -58,7 +58,6 @@ describe('Sync Concurrency Tests', () => {
 
     it('should release mutex after sync error', async () => {
       // Force sync to fail and verify mutex is released
-      const statusBefore = getSyncStatus()
 
       try {
         await syncWithCloud({ include: ['invalid_collection'] })
@@ -178,7 +177,6 @@ describe('Sync Concurrency Tests', () => {
     })
 
     it('should maintain lastSyncTime accuracy across concurrent syncs', async () => {
-      const beforeSync = new Date()
 
       await syncWithCloud({ include: ['attempts'] })
 
@@ -234,7 +232,7 @@ describe('Sync Concurrency Tests', () => {
 
   describe('Performance Under Load', () => {
     it('should handle 10 concurrent sync attempts without crashing', async () => {
-      const attempts = Array.from({ length: 10 }, (_, i) =>
+      const attempts = Array.from({ length: 10 }, (_, _i) =>
         syncWithCloud({ include: ['attempts'] })
       )
 

--- a/src/lib/progress/syncCoordinator.js
+++ b/src/lib/progress/syncCoordinator.js
@@ -1,10 +1,7 @@
 import {
-  getAttemptsByUser,
   getMasteryByUser,
-  getFromDB,
   getAllFromDB,
   initDB,
-  getLearningSessionsByUser,
   getUnsyncedItems
 } from './database.js'
 import { STORAGE_CONFIG } from './config.js'
@@ -73,7 +70,7 @@ async function markSynced(storeName, items) {
 
         const updated = { ...existing, syncedAt: new Date() }
         await store.put(updated)
-      } catch (err) {
+      } catch {
         // Ignore individual errors
       }
     }

--- a/src/lib/progress/temporalIntelligence.js
+++ b/src/lib/progress/temporalIntelligence.js
@@ -842,7 +842,7 @@ if (typeof window !== 'undefined') {
   // Safe logging - avoid TDZ during module initialization
   try {
     logger?.systemInit?.('Temporal Intelligence Debug Interface')
-  } catch (e) {
+  } catch {
     // Logger not ready yet
   }
 }

--- a/src/lib/pronunciation/pronunciationAnalyzer.js
+++ b/src/lib/pronunciation/pronunciationAnalyzer.js
@@ -798,7 +798,7 @@ class PronunciationAnalyzer {
   /**
    * Determine if two vowels form a diphthong in Spanish based on phonological rules
    */
-  _isSpanishDiphthong(vowel1, vowel2, word, _vowelIndex) {
+  _isSpanishDiphthong(vowel1, vowel2, _word, _vowelIndex) {
     // Spanish vowel classification
     const weakVowels = ['i', 'u', 'í', 'ú'];
     const strongVowels = ['a', 'e', 'o', 'á', 'é', 'ó'];
@@ -821,7 +821,6 @@ class PronunciationAnalyzer {
     // Rule 3: Weak + Strong or Strong + Weak = diphthong (unless accent on weak)
     if ((isWeak1 && isStrong2) || (isStrong1 && isWeak2)) {
       // Special exceptions based on Spanish phonology
-      const pair = vowel1 + vowel2;
 
       // These combinations are always diphthongs in Spanish
       const alwaysDiphthongs = [

--- a/src/lib/utils/logger.js
+++ b/src/lib/utils/logger.js
@@ -220,7 +220,7 @@ export function createLogger(context) {
   const safeCall = (fn, ...args) => {
     try {
       return fn(...args)
-    } catch (e) {
+    } catch {
       // Logger not ready yet - silent fail
       return undefined
     }


### PR DESCRIPTION
## Summary

`npm run lint` reported **123 problems — 0 errors, all `no-unused-vars` warnings**. This PR clears all of them, bringing the lint run to a clean 0/0. Every change is mechanical and behavior-neutral.

## Changes by pattern

- **Unused `catch` bindings** → optional catch binding (`} catch (e) {` → `} catch {`), an already-used idiom in this codebase. ~34 sites across `memoryManager.js`, `syncCoordinator.js`, `optimizedCache.js`, `VerbDataRedundancyManager.js`, `fsrs.js`, `momentumTracker.js`, and others.
- **Unused function parameters** → prefixed with `_` (e.g. `context` → `_context`, `event` → `_event`, `index` → `_index`). Heaviest in `AutoRecoverySystem.js` error-handler signatures. Call sites untouched (positional args unaffected).
- **Unused imports** → removed from their `import { … }` lists (e.g. `getAttemptsByUser`/`getFromDB`/`getLearningSessionsByUser` in `syncCoordinator.js`, `vi`/`afterEach`/`fireEvent` in test files, `validateAndHealVerbs`, `getCurrentUserProfile`, `curriculum`).
- **Unused local assignments / destructured names** → removed (e.g. dead `const group`/`highlightData` in `NarrativeIntroduction.jsx`, unused session-flag destructures in `generator.js`, `dayMs`, `statsSpacing`, `sessionIndex`).

## Care taken to preserve behavior

- In `verbDataService.js`, the flagged `.filter()` callback performs `results.push(verb)`; kept the call and only dropped the unused `const foundVerbs =` binding.
- In `analytics.js`, a property-omit destructure (`{ createdAtMs, ...rest }`) kept the key and renamed the binding to `_createdAtMs` so the omit still works.
- In `CacheOrchestrator.js`, an unused for-of loop binding became an array elision (`[, cacheInfo]`).

## Verification

- `npm run lint` → **0 warnings, 0 errors** (was 123).
- Ran the edited test suites (`partialSyncFailure`, `syncConcurrency`, `database.range`, `database.schedules`, `FormSelectorService`) → **46 passing**.
- `npm run build` → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc47R1xJXcyeTHzYs8JEpW)_