### PR TITLE
Honrar los combos del bloque en drills del módulo de progreso

### DIFF
--- a/src/hooks/modules/DrillFormFilters.js
+++ b/src/hooks/modules/DrillFormFilters.js
@@ -38,12 +38,48 @@ const PEDAGOGICAL_THIRD_PERSON_FAMILIES = new Set(['E_I_IR', 'O_U_GER_IR', 'HIAT
 const STRONG_PRETERITE_IRREGULARITIES = new Set(['PRET_UV', 'PRET_U', 'PRET_I', 'PRET_J', 'PRET_SUPPL'])
 export const FILTER_DISCARD_REASONS = Object.freeze({
   SPECIFIC_PRACTICE: 'specific_practice_constraints',
+  PROGRESS_BLOCK: 'progress_block_filter',
   VERB_TYPE: 'verb_type_filter',
   PEDAGOGICAL_PRETERITE: 'pedagogical_preterite_filter',
   FAMILY: 'family_filter',
   PRONOUN_REGION: 'pronoun_region_filter',
   LEVEL_GATE: 'level_gate_filter'
 })
+
+/**
+ * Restrict forms to the targeting carried by an ad-hoc drill block.
+ *
+ * Progress-module cards (error heatmap, difficult verbs, "Reglas y tips", the
+ * session HUD "practicar lo pendiente", etc.) build blocks shaped like
+ * `{ combos: [{mood, tense}], itemsRemaining }` or, when they target a single
+ * cell, `{ cells: [{mood, tense, person}] }`. Those blocks run in `mixed`
+ * practice mode, so without this gate the mixed pool (which spans every tense
+ * allowed for the level, including participios/gerundios) leaks through and the
+ * user ends up drilling something other than what they tapped.
+ *
+ * Cells are the finest-grained targeting; when present they win over combos.
+ *
+ * @param {Array} forms - Forms to filter
+ * @param {Object} currentBlock - The active drill block
+ * @returns {Array} - Forms matching the block's combos/cells
+ */
+export const filterByProgressBlock = (forms, currentBlock) => {
+  if (!currentBlock) return forms
+
+  const cells = Array.isArray(currentBlock.cells) ? currentBlock.cells : []
+  if (cells.length > 0) {
+    const cellSet = new Set(cells.map(c => `${c.mood}|${c.tense}|${c.person}`))
+    return forms.filter(f => cellSet.has(`${f.mood}|${f.tense}|${f.person}`))
+  }
+
+  const combos = Array.isArray(currentBlock.combos) ? currentBlock.combos : []
+  if (combos.length > 0) {
+    const comboSet = new Set(combos.map(c => `${c.mood}|${c.tense}`))
+    return forms.filter(f => comboSet.has(`${f.mood}|${f.tense}`))
+  }
+
+  return forms
+}
 
 export const getFormsCacheKey = (region = 'la_general', settings = {}) =>
   // Only include fields that can actually change the generated forms.
@@ -579,6 +615,21 @@ const runFilteringPipeline = (forms, settings, specificConstraints = {}, formsIn
     (current) => filterForSpecificPractice(current, specificConstraints, formsIndex, settings?.region || null)
   )) {
     return { filtered, stages, emptyReason: FILTER_DISCARD_REASONS.SPECIFIC_PRACTICE }
+  }
+
+  const block = settings?.currentBlock
+  const hasBlockTargeting = Boolean(
+    block && (
+      (Array.isArray(block.combos) && block.combos.length > 0) ||
+      (Array.isArray(block.cells) && block.cells.length > 0)
+    )
+  )
+  if (applyStage(
+    { id: 'progress_block', reason: FILTER_DISCARD_REASONS.PROGRESS_BLOCK },
+    hasBlockTargeting,
+    (current) => filterByProgressBlock(current, block)
+  )) {
+    return { filtered, stages, emptyReason: FILTER_DISCARD_REASONS.PROGRESS_BLOCK }
   }
 
   if (applyStage(

--- a/src/hooks/modules/DrillFormFilters.test.js
+++ b/src/hooks/modules/DrillFormFilters.test.js
@@ -278,3 +278,67 @@ describe('DrillFormFilters - filtering diagnostics', () => {
     })
   })
 })
+
+describe('DrillFormFilters - progress block targeting', () => {
+  const forms = [
+    { lemma: 'hablar', mood: 'indicative', tense: 'pretIndef', person: '1s', value: 'hablé' },
+    { lemma: 'comer', mood: 'indicative', tense: 'pres', person: '1s', value: 'como' },
+    { lemma: 'vivir', mood: 'nonfinite', tense: 'part', person: '', value: 'vivido' },
+    { lemma: 'hablar', mood: 'nonfinite', tense: 'ger', person: '', value: 'hablando' }
+  ]
+
+  const mixedSettings = {
+    region: 'la_general',
+    verbType: 'all',
+    selectedFamily: null,
+    practiceMode: 'mixed',
+    practicePronoun: 'all',
+    level: 'ALL'
+  }
+
+  it('restricts a mixed-mode drill to the block combos (no participios leaking in)', () => {
+    const settings = {
+      ...mixedSettings,
+      currentBlock: { combos: [{ mood: 'indicative', tense: 'pretIndef' }], itemsRemaining: 8 }
+    }
+
+    const { filtered, stages } = getFilteringDiagnostics(forms, settings)
+
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toMatchObject({ mood: 'indicative', tense: 'pretIndef' })
+    expect(stages.find(s => s.id === 'progress_block')).toMatchObject({ skipped: false })
+  })
+
+  it('restricts to the block cells when a single cell is targeted', () => {
+    const settings = {
+      ...mixedSettings,
+      currentBlock: { cells: [{ mood: 'indicative', tense: 'pres', person: '1s' }] }
+    }
+
+    const { filtered } = getFilteringDiagnostics(forms, settings)
+
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toMatchObject({ mood: 'indicative', tense: 'pres', person: '1s' })
+  })
+
+  it('reports the standardized empty reason when the block matches nothing', () => {
+    const settings = {
+      ...mixedSettings,
+      currentBlock: { combos: [{ mood: 'subjunctive', tense: 'subjImpf' }] }
+    }
+
+    const { filtered, emptyReason } = getFilteringDiagnostics(forms, settings)
+
+    expect(filtered).toHaveLength(0)
+    expect(emptyReason).toBe(FILTER_DISCARD_REASONS.PROGRESS_BLOCK)
+  })
+
+  it('skips block filtering when the block carries no combos or cells', () => {
+    const settings = { ...mixedSettings, currentBlock: { id: 'lvl-A1', itemsRemaining: 8 } }
+
+    const { filtered, stages } = getFilteringDiagnostics(forms, settings)
+
+    expect(filtered.length).toBeGreaterThan(1)
+    expect(stages.find(s => s.id === 'progress_block')).toMatchObject({ skipped: true })
+  })
+})

--- a/src/hooks/modules/drillCacheKey.js
+++ b/src/hooks/modules/drillCacheKey.js
@@ -23,6 +23,24 @@ export function buildReviewFilterFingerprint(reviewSessionType, reviewSessionFil
   return `${reviewSessionType}|${stableStringify(reviewSessionFilter || {})}`
 }
 
+export function buildBlockFingerprint(currentBlock) {
+  if (!currentBlock) {
+    return 'no_block'
+  }
+
+  const parts = []
+  if (currentBlock.id) {
+    parts.push(`id:${currentBlock.id}`)
+  }
+  if (Array.isArray(currentBlock.combos) && currentBlock.combos.length) {
+    parts.push('c:' + currentBlock.combos.map((c) => `${c.mood}|${c.tense}`).join(','))
+  }
+  if (Array.isArray(currentBlock.cells) && currentBlock.cells.length) {
+    parts.push('x:' + currentBlock.cells.map((c) => `${c.mood}|${c.tense}|${c.person}`).join(','))
+  }
+  return parts.length ? parts.join(';') : 'block'
+}
+
 export function buildEligibleFormsKey(signature, targetSettings, specificConstraints, reviewSessionType, reviewSessionFilter) {
   return [
     signature,
@@ -38,7 +56,8 @@ export function buildEligibleFormsKey(signature, targetSettings, specificConstra
     specificConstraints?.specificMood || '',
     specificConstraints?.specificTense || '',
     specificConstraints?.specificPerson || '',
-    buildReviewFilterFingerprint(reviewSessionType, reviewSessionFilter)
+    buildReviewFilterFingerprint(reviewSessionType, reviewSessionFilter),
+    buildBlockFingerprint(targetSettings.currentBlock)
   ].join('|')
 }
 

--- a/src/hooks/modules/drillCacheKey.test.js
+++ b/src/hooks/modules/drillCacheKey.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildBlockFingerprint,
   buildEligibleFormsKey,
   buildReviewFilterFingerprint,
   shouldCacheEligibleForms
@@ -32,5 +33,36 @@ describe('drillCacheKey', () => {
   it('disables eligible cache only for regular mode', () => {
     expect(shouldCacheEligibleForms({ verbType: 'regular' })).toBe(false)
     expect(shouldCacheEligibleForms({ verbType: 'all' })).toBe(true)
+  })
+
+  it('separates a targeted progress block from a plain mixed session', () => {
+    const settings = {
+      practiceMode: 'mixed',
+      level: 'B1',
+      verbType: 'all',
+      selectedFamily: null,
+      practicePronoun: 'all',
+      useVoseo: false,
+      useVosotros: false,
+      irregularityFilterMode: 'tense'
+    }
+    const specific = { isSpecific: false }
+    const mixed = buildEligibleFormsKey('pool-a', settings, specific, 'due', {})
+    const blocked = buildEligibleFormsKey(
+      'pool-a',
+      { ...settings, currentBlock: { combos: [{ mood: 'indicative', tense: 'pretIndef' }] } },
+      specific,
+      'due',
+      {}
+    )
+    expect(mixed).not.toBe(blocked)
+  })
+
+  it('fingerprints combos and cells distinctly', () => {
+    expect(buildBlockFingerprint(null)).toBe('no_block')
+    const combos = buildBlockFingerprint({ combos: [{ mood: 'indicative', tense: 'pres' }] })
+    const cells = buildBlockFingerprint({ cells: [{ mood: 'indicative', tense: 'pres', person: '1s' }] })
+    expect(combos).not.toBe(cells)
+    expect(combos).toContain('indicative|pres')
   })
 })


### PR DESCRIPTION
## Problema

En el módulo de progreso, dentro de **Ver más → "Errores recientes"**, las tarjetas que proponen prácticas dirigidas (mapa de errores, "Verbos que necesitan refuerzo", "Reglas y tips") no funcionaban: al tocar **indefinido** o **presente**, el drill terminaba practicando **participios**.

## Causa raíz

Esas tarjetas (y otros paneles: `ErrorRadar`, `ErrorInsights`, `EnhancedErrorAnalysis`, `SessionHUD`) lanzan la práctica guardando el modo/tiempo elegido en `currentBlock.combos` (o `currentBlock.cells`) y dejando `practiceMode: 'mixed'`.

Pero el pipeline de filtrado que realmente usa el generador de drills —`runFilteringPipeline` en `DrillFormFilters.js`, vía `useDrillGenerator.generateNextItem`— **nunca miraba `currentBlock`**. Por eso `eligibleForms` quedaba con todo el pool mixto del nivel (incluidos participios y gerundios). Solo el fallback profundo dentro de `chooseNext` respetaba los combos; los caminos de selección por SRS-due y por recomendación adaptativa elegían libremente del pool amplio, dejando escapar tiempos no pedidos.

De forma complementaria, `buildEligibleFormsKey` no incluía el bloque, así que una práctica dirigida y una sesión mixta normal compartían la misma entrada de caché de formas elegibles.

Este PR es el complemento de #205 (que arregló la colisión de caché en `chooseNext` por `blockSig`); ahora la restricción del bloque se aplica también en el camino principal de generación.

## Cambios

- **`DrillFormFilters.js`**: nuevo stage `progress_block` en el pipeline que restringe las formas a los combos/cells del bloque activo (las `cells`, más finas, ganan sobre los `combos`), reflejando lo que ya hace `FormFilterService`. Se agrega `FILTER_DISCARD_REASONS.PROGRESS_BLOCK` y el helper exportable `filterByProgressBlock`. El stage se salta cuando el bloque no trae combos ni cells (p. ej. bloques por nivel con solo `id`), sin cambiar el comportamiento existente.
- **`drillCacheKey.js`**: `buildEligibleFormsKey` incluye ahora la huella del bloque (`buildBlockFingerprint`), evitando que la práctica dirigida reuse el pool amplio cacheado (y viceversa).
- **Tests**: cobertura del filtrado por combos/cells del bloque, el motivo de vacío estandarizado, el salto cuando no hay targeting, y la separación de caché.

## Verificación

- `npx vitest run src/hooks/ src/lib/core/generator.progressBlock.test.js src/lib/core/FormFilterService.test.js` → 122 passed / 1 skipped
- ESLint limpio en los archivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZNN5SkrVBFSrKNJVuFsna)_