### PR TITLE
Arreglar "Practicar esto" con combos por encima del nivel en el módulo de progreso

### DIFF
--- a/src/hooks/modules/DrillFormFilters.js
+++ b/src/hooks/modules/DrillFormFilters.js
@@ -669,7 +669,13 @@ const runFilteringPipeline = (forms, settings, specificConstraints = {}, formsIn
 
   if (applyStage(
     { id: 'level_gate', reason: FILTER_DISCARD_REASONS.LEVEL_GATE },
-    settings.practiceMode !== 'specific' && settings.practiceMode !== 'theme',
+    // A runtime block (progress-module micro-drills, SRS review cells) targets
+    // combos straight from the learner's mistakes, which may sit above the
+    // current level. The progress_block stage above already narrowed the pool to
+    // exactly those combos/cells, so re-applying the level gate here would strip
+    // any above-level target and empty the pool. Skip it whenever a block is
+    // targeting, just like specific/theme practice.
+    settings.practiceMode !== 'specific' && settings.practiceMode !== 'theme' && !hasBlockTargeting,
     (current) => current.filter(form => allowsLevel(form, settings))
   )) {
     return { filtered, stages, emptyReason: FILTER_DISCARD_REASONS.LEVEL_GATE }

--- a/src/hooks/modules/DrillFormFilters.test.js
+++ b/src/hooks/modules/DrillFormFilters.test.js
@@ -341,4 +341,40 @@ describe('DrillFormFilters - progress block targeting', () => {
     expect(filtered.length).toBeGreaterThan(1)
     expect(stages.find(s => s.id === 'progress_block')).toMatchObject({ skipped: true })
   })
+
+  it('honors a block combo that sits ABOVE the current level (level gate skipped)', () => {
+    // The real "Practicar esto" bug: recent-error combos can be above the
+    // learner's level. The level gate must NOT strip them after the block stage
+    // already narrowed the pool, or the drill empties out and falls back.
+    const settings = {
+      ...mixedSettings,
+      level: 'A2',
+      currentBlock: { combos: [{ mood: 'indicative', tense: 'pretIndef' }], itemsRemaining: 8 }
+    }
+
+    const { filtered, stages, emptyReason } = getFilteringDiagnostics(forms, settings)
+
+    expect(emptyReason).toBeNull()
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toMatchObject({ mood: 'indicative', tense: 'pretIndef' })
+    expect(stages.find(s => s.id === 'level_gate')).toMatchObject({ skipped: true })
+  })
+
+  it('honors a block cell that sits ABOVE the current level (level gate skipped)', () => {
+    const subjForms = [
+      { lemma: 'hablar', mood: 'subjunctive', tense: 'subjImpf', person: '1s', value: 'hablara' },
+      { lemma: 'comer', mood: 'indicative', tense: 'pres', person: '1s', value: 'como' }
+    ]
+    const settings = {
+      ...mixedSettings,
+      level: 'A2',
+      currentBlock: { cells: [{ mood: 'subjunctive', tense: 'subjImpf', person: '1s' }] }
+    }
+
+    const { filtered, emptyReason } = getFilteringDiagnostics(subjForms, settings)
+
+    expect(emptyReason).toBeNull()
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toMatchObject({ mood: 'subjunctive', tense: 'subjImpf', person: '1s' })
+  })
 })

--- a/src/lib/core/FormFilterService.js
+++ b/src/lib/core/FormFilterService.js
@@ -55,6 +55,10 @@ export function filterEligibleForms(forms, settings, context = {}) {
           .filter(Boolean)
       )
     : null
+  // `mood|tense` combos a runtime block targets (from combos OR cells). These
+  // come from the learner's mistakes/SRS queue and can sit above the current
+  // level, so the level filter must honor them instead of the level inventory.
+  const blockComboFilter = buildBlockComboSet(currentBlock)
 
   // Step 1: Gate sistemático por curriculum y dialecto
   const preFiltered = gateFormsByCurriculumAndDialect(forms, settings)
@@ -67,7 +71,7 @@ export function filterEligibleForms(forms, settings, context = {}) {
     }
 
     // Level filtering
-    if (!applyLevelFilter(form, {level, practiceMode, currentBlock})) {
+    if (!applyLevelFilter(form, {level, practiceMode, blockComboFilter})) {
       return false
     }
 
@@ -150,18 +154,41 @@ export function filterEligibleForms(forms, settings, context = {}) {
 }
 
 /**
+ * Collect the `mood|tense` combos a runtime block targets, from either its
+ * `combos` (mood/tense pairs) or its `cells` (mood/tense/person triples).
+ * Returns null when the block targets nothing, so callers fall back to the
+ * level inventory.
+ */
+function buildBlockComboSet(currentBlock) {
+  if (!currentBlock) return null
+  const set = new Set()
+  if (Array.isArray(currentBlock.combos)) {
+    for (const c of currentBlock.combos) {
+      if (c && c.mood && c.tense) set.add(`${c.mood}|${c.tense}`)
+    }
+  }
+  if (Array.isArray(currentBlock.cells)) {
+    for (const c of currentBlock.cells) {
+      if (c && c.mood && c.tense) set.add(`${c.mood}|${c.tense}`)
+    }
+  }
+  return set.size > 0 ? set : null
+}
+
+/**
  * Apply level-based filtering for mood/tense combinations
  */
-function applyLevelFilter(form, {level, practiceMode, currentBlock}) {
+function applyLevelFilter(form, {level, practiceMode, blockComboFilter}) {
   const isSpecificTopicPractice = (practiceMode === 'theme') || (practiceMode === 'specific')
 
   if (isSpecificTopicPractice) {
     return true // Skip level filtering for targeted practice
   }
 
-  const allowed = currentBlock && currentBlock.combos && currentBlock.combos.length
-    ? new Set(currentBlock.combos.map(c => `${c.mood}|${c.tense}`))
-    : getAllowedCombosForLevel(level)
+  // A runtime block (progress-module micro-drills, SRS review cells) targets
+  // combos straight from the learner's mistakes, which may sit above the current
+  // level. Honor the block's own combos instead of the level inventory.
+  const allowed = blockComboFilter || getAllowedCombosForLevel(level)
 
   return allowed.has(`${form.mood}|${form.tense}`)
 }

--- a/src/lib/core/curriculumGate.js
+++ b/src/lib/core/curriculumGate.js
@@ -114,8 +114,26 @@ export function getAllowedPersonsForRegion(region, { useVoseo = false, useVosotr
   return ALL;
 }
 
+// Collect the `mood|tense` combos a runtime block targets, from either its
+// `combos` (mood/tense pairs) or its `cells` (mood/tense/person triples).
+function collectBlockCombos(currentBlock) {
+  const combos = new Set();
+  if (!currentBlock) return combos;
+  if (Array.isArray(currentBlock.combos)) {
+    for (const c of currentBlock.combos) {
+      if (c && c.mood && c.tense) combos.add(`${c.mood}|${c.tense}`);
+    }
+  }
+  if (Array.isArray(currentBlock.cells)) {
+    for (const c of currentBlock.cells) {
+      if (c && c.mood && c.tense) combos.add(`${c.mood}|${c.tense}`);
+    }
+  }
+  return combos;
+}
+
 export function gateFormsByCurriculumAndDialect(forms, settings) {
-  const { level, region, useVoseo, useVosotros, practiceMode, cameFromTema, specificMood, specificTense } = settings || {};
+  const { level, region, useVoseo, useVosotros, practiceMode, cameFromTema, specificMood, specificTense, currentBlock } = settings || {};
   const allowedPersons = getAllowedPersonsForRegion(region, { useVoseo, useVosotros });
 
   // Debug logging for regional filtering issues
@@ -130,7 +148,18 @@ export function gateFormsByCurriculumAndDialect(forms, settings) {
   }
 
   const enforceCurriculumLevel = practiceMode !== 'specific' && practiceMode !== 'theme';
-  const allowedCombos = enforceCurriculumLevel ? getAllowedCombosForLevel(level || 'A1') : null;
+  // Progress-module micro-drills ("Practicar esto", error heatmap, difficult verbs)
+  // run in 'mixed' mode but target a specific mood/tense through `currentBlock`.
+  // Those combos come straight from the learner's mistakes, so they can sit ABOVE
+  // the current level. The curriculum gate must not strip them, or the pool empties
+  // out and the drill falls back to the broad mixed pool (presente regular et al.).
+  // `applyLevelFilter` downstream still narrows the pool to exactly the block combos.
+  const blockCombos = collectBlockCombos(currentBlock);
+  let allowedCombos = enforceCurriculumLevel ? getAllowedCombosForLevel(level || 'A1') : null;
+  if (allowedCombos && blockCombos.size > 0) {
+    allowedCombos = new Set(allowedCombos);
+    for (const combo of blockCombos) allowedCombos.add(combo);
+  }
   const enforceSelection = practiceMode === 'specific' && cameFromTema !== true;
   const MIXED_COMBO_MAP = new Map([
     ['imperative|impMixed', new Set(['impAff', 'impNeg'])],

--- a/src/lib/core/generator.progressBlock.test.js
+++ b/src/lib/core/generator.progressBlock.test.js
@@ -64,6 +64,57 @@ describe('Progress micro-drill blocks (combos without id)', () => {
     }
   })
 
+  it('should honor a block combo that sits ABOVE the current level', async () => {
+    // The real-world "Practicar esto" bug: recent-error combos come from the
+    // learner's mistakes and can be above their current level. Before the fix,
+    // gateFormsByCurriculumAndDialect stripped every above-level form up front, so
+    // the pool emptied and the drill fell back to the broad mixed pool (presente
+    // regular, futuro, gerundio, …) instead of the targeted combo.
+    const forms = await buildFormsForRegion('la_general')
+
+    // A2 learner, block targeting subjuntivo imperfecto (a B2 combo).
+    const blockSettings = {
+      ...baseSettings,
+      level: 'A2',
+      currentBlock: {
+        combos: [{ mood: 'subjunctive', tense: 'subjImpf' }],
+        itemsRemaining: 8
+      }
+    }
+
+    for (let i = 0; i < 40; i++) {
+      const r = await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: blockSettings })
+      expect(r, `Iteration ${i + 1}: no form returned`).toBeTruthy()
+      expect(
+        `${r.mood}|${r.tense}`,
+        `Iteration ${i + 1}: expected subjunctive|subjImpf but got ${r.mood}|${r.tense} (${r.lemma})`
+      ).toBe('subjunctive|subjImpf')
+    }
+  })
+
+  it('should honor a block cell that sits ABOVE the current level', async () => {
+    // Heatmap-style cell targeting (mood/tense/person) must survive the gate too.
+    const forms = await buildFormsForRegion('la_general')
+
+    const cellSettings = {
+      ...baseSettings,
+      level: 'A2',
+      currentBlock: {
+        cells: [{ mood: 'subjunctive', tense: 'subjImpf', person: '1s' }],
+        itemsRemaining: 8
+      }
+    }
+
+    for (let i = 0; i < 20; i++) {
+      const r = await chooseNext({ forms, history: {}, currentItem: null, sessionSettings: cellSettings })
+      expect(r, `Iteration ${i + 1}: no form returned`).toBeTruthy()
+      expect(
+        `${r.mood}|${r.tense}|${r.person}`,
+        `Iteration ${i + 1}: expected subjunctive|subjImpf|1s but got ${r.mood}|${r.tense}|${r.person} (${r.lemma})`
+      ).toBe('subjunctive|subjImpf|1s')
+    }
+  })
+
   it('should not cross-contaminate two different combo blocks sharing no id', async () => {
     const forms = await buildFormsForRegion('la_general')
 


### PR DESCRIPTION
## Problema

En el módulo de progreso → **Errores recientes** (mapa de errores, "Verbos que necesitan refuerzo", "Reglas y tips") y las distintas variantes de **"Practicar esto"**, al hacer click el drill **no practicaba el tema propuesto**: mostraba "cualquier otra cosa" (presente regular, futuro, gerundio, etc.).

Ya se había "arreglado" varias veces (clave de caché, `applyLevelFilter`), pero seguía fallando en el caso real que nadie había reproducido.

## Causa raíz

Estos micro-drills corren en modo `mixed` pero apuntan a un `mood/tense` puntual a través de `currentBlock` (`{ combos }` o `{ cells }`). Esos combos salen **directamente de los errores del usuario**, así que pueden estar **por encima de su nivel actual**.

El filtro de currículum por nivel se aplicaba **antes** de honrar el bloque y descartaba todas las formas del combo objetivo cuando estaba por encima del nivel → el pool quedaba vacío → el drill caía al pool mixto amplio.

El detalle clave: las dos rutas de filtrado que existen en el código tenían la misma falla, y **ninguna** la cubría porque los tests previos sólo usaban combos dentro de nivel (o `level: 'ALL'`).

## Solución

Se corrigen **ambas** rutas de filtrado para que el bloque, cuando apunta a combos/cells, tenga prioridad sobre el gate de nivel (el filtrado por persona/dialecto se mantiene intacto):

- **`generator.js` / `FormFilterService`**: `gateFormsByCurriculumAndDialect` y `applyLevelFilter` ahora suman los combos del bloque (derivados de `combos` **o** `cells`) al inventario de combos permitidos.
- **`useDrillMode` / `DrillFormFilters`**: la etapa `level_gate` se saltea cuando el bloque ya acotó el pool, igual que en práctica `specific`/`theme`.

## Tests

Se agregan regresiones que **fallan sin el fix**, en ambas rutas, usando un nivel bajo (`A2`) con combos/cells por encima del nivel (`subjImpf`, `pretIndef`):

- `generator.progressBlock.test.js`: honra un combo y una cell por encima del nivel end-to-end vía `chooseNext`.
- `DrillFormFilters.test.js`: la etapa `level_gate` se saltea y el pool conserva el objetivo por encima del nivel.

Suite completa de `src/lib/core`, `src/hooks` y `src/state` en verde (289 passed / 2 skipped) y lint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8FsjrWwqkWNmYF4YRpEnE)_