### PR TITLE
Regenerar el primer ítem al lanzar "Practicar esto"

### DIFF
--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -52,6 +52,7 @@ import { useOnboardingFlow } from '../hooks/useOnboardingFlow.js'
 import router from '../lib/routing/Router.js'
 import { ROUTES } from '../lib/routing/routeContract.js'
 import { useSessionStore } from '../state/session.js'
+import { snapshotDrillTargeting, drillTargetingChanged } from '../features/progress/drillNavigationConfig.js'
 import { createLogger } from '../lib/utils/logger.js'
 
 const logger = createLogger('AppRouter')
@@ -87,14 +88,12 @@ function AppRouter() {
   const drillMode = useDrillMode()
   const onboardingFlow = useOnboardingFlow()
 
-  // Track previous settings to detect changes from progress navigation
-  const prevSettingsRef = useRef({
-    practiceMode: settings.practiceMode,
-    specificMood: settings.specificMood,
-    specificTense: settings.specificTense,
-    verbType: settings.verbType,
-    selectedFamily: settings.selectedFamily
-  })
+  // Track previous drill targeting to detect changes from progress navigation.
+  // Includes the runtime block/review fingerprints from the session store, which
+  // change while practiceMode stays 'mixed'/'review' — see snapshotDrillTargeting.
+  const prevSettingsRef = useRef(
+    snapshotDrillTargeting(settings, useSessionStore.getState())
+  )
 
 
   // Note: Progress system initialization is handled by autoInit.js imported in main.jsx
@@ -201,14 +200,14 @@ function AppRouter() {
 
       // CRITICAL: Always read fresh settings from store to avoid stale closures
       const LATEST_SETTINGS = useSettings.getState();
+      const LATEST_TARGETING = snapshotDrillTargeting(
+        LATEST_SETTINGS,
+        useSessionStore.getState()
+      );
 
-      // Detect if specific practice settings changed
-      const settingsChanged =
-        prevSettingsRef.current.practiceMode !== LATEST_SETTINGS.practiceMode ||
-        prevSettingsRef.current.specificMood !== LATEST_SETTINGS.specificMood ||
-        prevSettingsRef.current.specificTense !== LATEST_SETTINGS.specificTense ||
-        prevSettingsRef.current.verbType !== LATEST_SETTINGS.verbType ||
-        prevSettingsRef.current.selectedFamily !== LATEST_SETTINGS.selectedFamily;
+      // Detect if drill targeting changed (practice mode/mood/tense/family/verbType
+      // OR the runtime block/review filter set by progress-module drills).
+      const settingsChanged = drillTargetingChanged(prevSettingsRef.current, LATEST_TARGETING);
 
       // If settings changed and we have a current item, clear it first
       if (settingsChanged && drillMode.currentItem && drillMode.clearCurrentItem) {
@@ -236,14 +235,8 @@ function AppRouter() {
         clearDrillGenerationTimeout();
       }
 
-      // Update previous settings reference with LATEST settings
-      prevSettingsRef.current = {
-        practiceMode: LATEST_SETTINGS.practiceMode,
-        specificMood: LATEST_SETTINGS.specificMood,
-        specificTense: LATEST_SETTINGS.specificTense,
-        verbType: LATEST_SETTINGS.verbType,
-        selectedFamily: LATEST_SETTINGS.selectedFamily
-      };
+      // Update previous targeting reference with the latest snapshot
+      prevSettingsRef.current = LATEST_TARGETING;
     }
   }, [
     currentMode,

--- a/src/features/progress/drillNavigationConfig.js
+++ b/src/features/progress/drillNavigationConfig.js
@@ -1,3 +1,5 @@
+import { buildBlockFingerprint, buildReviewFilterFingerprint } from '../../hooks/modules/drillCacheKey.js'
+
 const DEFAULT_DRILL_SETTINGS = {
   practiceMode: 'mixed',
   specificMood: null,
@@ -32,4 +34,48 @@ export function buildDrillSettingsUpdate(drillConfig = {}, overrides = {}) {
   }
 
   return next
+}
+
+/**
+ * Snapshot the settings + runtime-session values that define which forms a drill
+ * should target. Progress-module drills ("Practicar esto", SRS review filters)
+ * keep `practiceMode` as 'mixed'/'review' and only change the runtime block or
+ * review filter in the session store, so those must be fingerprinted explicitly
+ * — otherwise the drill-entry effect can't tell the targeting changed and reuses
+ * a stale `currentItem` from the previous session as the first exercise.
+ *
+ * @param {object} settings - Durable settings (or a subset with the same keys).
+ * @param {object} session - Session store state (runtimeCurrentBlock, review context).
+ * @returns {object} A comparable targeting snapshot.
+ */
+export function snapshotDrillTargeting(settings = {}, session = {}) {
+  return {
+    practiceMode: settings.practiceMode ?? null,
+    specificMood: settings.specificMood ?? null,
+    specificTense: settings.specificTense ?? null,
+    verbType: settings.verbType ?? null,
+    selectedFamily: settings.selectedFamily ?? null,
+    blockFingerprint: buildBlockFingerprint(session.runtimeCurrentBlock),
+    reviewFingerprint: buildReviewFilterFingerprint(
+      session.runtimeReviewSessionType,
+      session.runtimeReviewSessionFilter
+    )
+  }
+}
+
+/**
+ * Compare two targeting snapshots produced by {@link snapshotDrillTargeting}.
+ * @returns {boolean} true when the drill should discard its current item and regenerate.
+ */
+export function drillTargetingChanged(prev, next) {
+  if (!prev || !next) return true
+  return (
+    prev.practiceMode !== next.practiceMode ||
+    prev.specificMood !== next.specificMood ||
+    prev.specificTense !== next.specificTense ||
+    prev.verbType !== next.verbType ||
+    prev.selectedFamily !== next.selectedFamily ||
+    prev.blockFingerprint !== next.blockFingerprint ||
+    prev.reviewFingerprint !== next.reviewFingerprint
+  )
 }

--- a/src/features/progress/drillNavigationConfig.test.js
+++ b/src/features/progress/drillNavigationConfig.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildDrillSettingsUpdate } from './drillNavigationConfig.js'
+import {
+  buildDrillSettingsUpdate,
+  snapshotDrillTargeting,
+  drillTargetingChanged
+} from './drillNavigationConfig.js'
 
 describe('drillNavigationConfig', () => {
   it('normalizes specific mode configuration', () => {
@@ -53,5 +57,79 @@ describe('drillNavigationConfig', () => {
     expect(result.currentBlock).toEqual(currentBlock)
     expect(result.specificMood).toBeNull()
     expect(result.specificTense).toBeNull()
+  })
+})
+
+describe('drill targeting change detection', () => {
+  const mixedSettings = {
+    practiceMode: 'mixed',
+    specificMood: null,
+    specificTense: null,
+    verbType: 'all',
+    selectedFamily: null
+  }
+
+  it('detects a new "Practicar esto" block even when practiceMode stays mixed', () => {
+    // Regression: the first exercise after clicking "Practicar esto" showed the
+    // stale item from the previous mixed session because change detection ignored
+    // the runtime block. Two mixed sessions with different blocks must differ.
+    const prevSession = { runtimeCurrentBlock: null }
+    const nextSession = {
+      runtimeCurrentBlock: { combos: [{ mood: 'indicative', tense: 'pretIndef' }] }
+    }
+
+    const prev = snapshotDrillTargeting(mixedSettings, prevSession)
+    const next = snapshotDrillTargeting(mixedSettings, nextSession)
+
+    expect(drillTargetingChanged(prev, next)).toBe(true)
+  })
+
+  it('distinguishes two different targeted blocks under the same mixed mode', () => {
+    const prev = snapshotDrillTargeting(mixedSettings, {
+      runtimeCurrentBlock: { combos: [{ mood: 'indicative', tense: 'pres' }] }
+    })
+    const next = snapshotDrillTargeting(mixedSettings, {
+      runtimeCurrentBlock: { combos: [{ mood: 'subjunctive', tense: 'subjPres' }] }
+    })
+
+    expect(drillTargetingChanged(prev, next)).toBe(true)
+  })
+
+  it('reports no change when settings and runtime block are identical', () => {
+    const session = {
+      runtimeCurrentBlock: { combos: [{ mood: 'indicative', tense: 'pres' }] }
+    }
+    const prev = snapshotDrillTargeting(mixedSettings, session)
+    const next = snapshotDrillTargeting(mixedSettings, session)
+
+    expect(drillTargetingChanged(prev, next)).toBe(false)
+  })
+
+  it('detects a changed SRS review filter while practiceMode stays review', () => {
+    const reviewSettings = { ...mixedSettings, practiceMode: 'review' }
+    const prev = snapshotDrillTargeting(reviewSettings, {
+      runtimeReviewSessionType: 'due',
+      runtimeReviewSessionFilter: { mood: 'indicative' }
+    })
+    const next = snapshotDrillTargeting(reviewSettings, {
+      runtimeReviewSessionType: 'due',
+      runtimeReviewSessionFilter: { mood: 'subjunctive' }
+    })
+
+    expect(drillTargetingChanged(prev, next)).toBe(true)
+  })
+
+  it('still detects classic specific-practice changes', () => {
+    const prev = snapshotDrillTargeting(mixedSettings, {})
+    const next = snapshotDrillTargeting(
+      { ...mixedSettings, practiceMode: 'specific', specificMood: 'subjunctive', specificTense: 'subjPres' },
+      {}
+    )
+
+    expect(drillTargetingChanged(prev, next)).toBe(true)
+  })
+
+  it('treats a missing snapshot as a change (forces regeneration)', () => {
+    expect(drillTargetingChanged(null, snapshotDrillTargeting(mixedSettings, {}))).toBe(true)
   })
 })


### PR DESCRIPTION
## Problema

Al tocar **"Practicar esto"** (y otros drills dirigidos del módulo de progreso: *Errores recientes*, mapa de errores, colas de SRS, "Reglas y tips"), el **primer** verbo aparecía en la forma de la sesión anterior, no en la forma pedida. Recién el **segundo** ítem y los siguientes salían correctos.

## Causa raíz

`useDrillMode` guarda `currentItem` en el estado de React de `AppRouter`, que **no se desmonta** al cambiar de ruta. Así, el ítem de la sesión previa sobrevive a la navegación progreso → drill.

La detección de cambios del efecto de entrada al drill (`settingsChanged`) sólo comparaba `practiceMode / specificMood / specificTense / verbType / selectedFamily`. Pero los drills del módulo de progreso mantienen `practiceMode` en `'mixed'`/`'review'` y sólo cambian el **bloque objetivo** (o el filtro de review) en el *session store* (`runtimeCurrentBlock`), que la detección nunca miraba.

Resultado: `settingsChanged` daba `false`, el `currentItem` viejo no se limpiaba, y se mostraba como primer ejercicio. Como `handleContinue` sí regenera con el bloque nuevo, los ítems siguientes salían bien — de ahí que "el primero muestra las formas de antes, los siguientes ya funcionan".

## Solución

Incorporar la huella del bloque/review runtime a la detección de cambios:

- **Nuevos helpers puros** en `drillNavigationConfig.js`:
  - `snapshotDrillTargeting(settings, session)` — fingerprintea settings + bloque + filtro de review, reutilizando `buildBlockFingerprint` / `buildReviewFilterFingerprint` de `drillCacheKey.js`.
  - `drillTargetingChanged(prev, next)` — compara dos snapshots.
- **`AppRouter.jsx`** usa esos helpers en el efecto de entrada al drill. Ahora un bloque nuevo (aunque `practiceMode` siga `'mixed'`) limpia el ítem stale y regenera **antes** de mostrarlo, siguiendo el mismo camino ya probado para los cambios de práctica específica.

## Tests

- Regresiones en `drillNavigationConfig.test.js`: bloque nuevo bajo `mixed`, dos bloques distintos, filtro de review cambiado bajo `review`, práctica specific clásica, y snapshot ausente.
- Verificado que siguen pasando `DrillFormFilters.test.js`, `generator.progressBlock.test.js`, `drillCacheKey.test.js` y `useDrillMode.generation-smoke.test.js`.
- Lint limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012jqPhCY4Y9QbQkdvmPFMA5)_