### PR TITLE
Fix Render deploy failure: upgrade better-sqlite3 for Node 24

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "bcryptjs": "^2.4.3",
-        "better-sqlite3": "^9.4.3",
+        "better-sqlite3": "^12.2.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "express-rate-limit": "^8.5.2",
@@ -22,7 +22,7 @@
         "zod": "^3.25.76"
       },
       "engines": {
-        "node": ">=18.0.0 <25.0.0",
+        "node": ">=20.0.0 <25.0.0",
         "npm": ">=8.0.0"
       }
     },
@@ -99,14 +99,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bignumber.js": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,12 +9,12 @@
     "postinstall": "npm rebuild better-sqlite3"
   },
   "engines": {
-    "node": ">=18.0.0 <25.0.0",
+    "node": ">=20.0.0 <25.0.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^9.4.3",
+    "better-sqlite3": "^12.2.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-rate-limit": "^8.5.2",


### PR DESCRIPTION
## Problem

Deployments to Render were failing during `npm install` with a generic npm error (`npm error A complete log of this run can be found in: /opt/render/.cache/_logs/…`).

The recent Node 20 → 24 upgrade (PR #212) bumped `server/.nvmrc` and the server `Dockerfile` to Node 24, but `server/package.json` still pinned `better-sqlite3@^9.4.3` (resolved 9.6.0). That version ships **no prebuilt binary for Node 24's ABI** (`NODE_MODULE_VERSION 137`), so `npm install` on Render fell back to compiling the native addon from source and aborted the deploy.

## Fix

- Upgrade `better-sqlite3` to `^12.2.0` (resolves to **12.11.1**), which publishes prebuilt binaries for Node 24 — no source compilation needed at install time.
- Raise the server `engines.node` floor from `>=18.0.0` to `>=20.0.0` to match the new dependency's supported range (`20.x || 22.x || 23.x || 24.x`).
- Regenerate `server/package-lock.json`.

Only the backend server (`server/`, deployed on Render) is affected — it is the sole package with a native dependency. The frontend has no native deps.

## Verification

- `npm ci` in `server/` completes cleanly (exit 0), confirming lockfile sync.
- Native module loads and executes: `new Database(':memory:')` with insert/select round-trips successfully (better-sqlite3 12.11.1).
- Server boots and its health endpoint (`GET /`) returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJwLMhuXpdHvkAoFUErarB)_