### PR TITLE
Fix production deploy: provision JWT_SECRET via Render blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,31 @@
+# Render Blueprint for the Progress Sync backend (conju.onrender.com)
+# Docs: https://render.com/docs/blueprint-spec
+#
+# The server refuses to boot in production without JWT_SECRET
+# (see server/src/auth-service.js). Render generates and persists a
+# secure value automatically via `generateValue: true`, so the deploy
+# no longer fails on a missing secret.
+services:
+  - type: web
+    name: conju-sync
+    runtime: node
+    rootDir: server
+    plan: free
+    buildCommand: npm ci
+    startCommand: npm start
+    healthCheckPath: /
+    autoDeploy: true
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: API_PREFIX
+        value: /api
+      # Auto-generated once and persisted across deploys.
+      - key: JWT_SECRET
+        generateValue: true
+      # Comma-separated allowlist of frontend origins.
+      - key: CORS_ORIGIN
+        value: https://verb-os.vercel.app
+      # Set in the Render dashboard: your Google OAuth client id(s).
+      - key: GOOGLE_CLIENT_IDS
+        sync: false


### PR DESCRIPTION
## Problem

The backend deploy failed with:

> Error: JWT_SECRET must be set in production (see server/.env.example)

This throw in `server/src/auth-service.js` is an **intentional** security guard (added in `bed25d8` — "cerrar bypass de autenticación"), so the fix is not to remove it. The real cause is that the Render backend (`conju.onrender.com`) had no `JWT_SECRET` set and there was no blueprint provisioning one.

## Fix

Add a `render.yaml` blueprint for the sync service that auto-generates and **persists** a secure `JWT_SECRET` via `generateValue: true`, so deploys succeed without manual secret entry. Persisting the value (rather than generating one at boot) also keeps the 30-day auth tokens valid across restarts.

The blueprint also wires:
- `NODE_ENV=production`, `API_PREFIX=/api`
- `CORS_ORIGIN=https://verb-os.vercel.app`
- `GOOGLE_CLIENT_IDS` left as `sync: false` (set once in the dashboard)

`rootDir: server`, `buildCommand: npm ci`, `startCommand: npm start`, and a `/` health check match the existing server setup.

## Important — applying this

`generateValue` only takes effect for a service **created/synced from the blueprint**. If the existing Render service was created manually, either:

1. **Recommended:** create the service from this blueprint (New → Blueprint), or
2. Manually add a `JWT_SECRET` env var in the Render dashboard for the existing service.

Both are one-time platform actions only the account owner can perform; the code side is now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZS577SQepZVcBnvyQ5gLH)_